### PR TITLE
feat(Algebra/LocalIso): prove of_bijective and comp for RingHom.IsLocalIso

### DIFF
--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -132,8 +132,6 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
     · exact hg₁q
   · have hmul : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
       .mul Tg _ _ _
-    let e : Localization.Away (t * g₁) ≃ₐ[T] (Localization.Away (algebraMap T Tg t)) :=
-      Localization.algEquiv _ _
     have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
       rw [← ht]
       have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
@@ -146,32 +144,36 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
         apply IsLocalization.away_of_isUnit_of_bijective
         · exact IsUnit.map _ hunit
         · exact Function.bijective_id
-      let e' : Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n) ≃ₐ[Tg]
-          Localization.Away (algebraMap S Tg r₁) :=
-        Localization.algEquiv _ _
-      set Sr := Localization.Away r₁
-      set Tgr := Localization.Away (algebraMap S Tg r₁)
+      let Sr := Localization.Away r₁
+      let Tgr := Localization.Away (algebraMap S Tg r₁)
       letI : Algebra Sr Tgr := (IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁).toAlgebra
-      haveI : IsScalarTower R Sr Tgr :=
+      have : IsScalarTower R Sr Tgr :=
         IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
         ext x
         simp only [RingHom.comp_apply]
         rw [IsScalarTower.algebraMap_apply R S Sr, RingHom.algebraMap_toAlgebra,
             IsLocalization.Away.map, IsLocalization.map_eq,
             IsScalarTower.algebraMap_apply R Tg Tgr, IsScalarTower.algebraMap_apply R S Tg])
-      haveI : IsScalarTower S Sr Tgr :=
+      have : IsScalarTower S Sr Tgr :=
         IsScalarTower.of_algebraMap_eq' (R := S) (S := Sr) (A := Tgr) (by
         ext a
         simp only [RingHom.comp_apply]
         rw [RingHom.algebraMap_toAlgebra, IsLocalization.Away.map, IsLocalization.map_eq,
             IsScalarTower.algebraMap_apply S Tg Tgr])
-      haveI : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
+      have : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
         IsLocalization.Away.commutes Sr Tg Tgr r₁ s₁
-      haveI : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
-      haveI : Algebra.IsStandardOpenImmersion R Tgr :=
+      have : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
+      have : Algebra.IsStandardOpenImmersion R Tgr :=
         Algebra.IsStandardOpenImmersion.trans R Sr Tgr
-      apply Algebra.IsStandardOpenImmersion.of_algEquiv _ _ _ (e'.symm.restrictScalars R)
-    exact .of_algEquiv _ _ _ (e.symm.restrictScalars R)
+      exact .of_algEquiv _ _ _
+        ((IsLocalization.algEquiv
+          (Submonoid.powers ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n))
+          (Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n))
+          (Localization.Away (algebraMap S Tg r₁))).symm.restrictScalars R)
+    exact .of_algEquiv _ _ _
+      ((IsLocalization.algEquiv (Submonoid.powers (t * g₁))
+        (Localization.Away (t * g₁))
+        (Localization.Away (algebraMap T Tg t))).symm.restrictScalars R)
 
 end Algebra.IsLocalIso
 

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -102,6 +102,95 @@ lemma pi_of_finite {ι : Type*} (R : Type*) (S : ι → Type*)
 instance refl : IsLocalIso R R :=
   instOfIsStandardOpenImmersion R R
 
+/-- The composition of two local isomorphisms is a local isomorphism. -/
+lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
+    [IsLocalIso R S] [IsLocalIso S T] : IsLocalIso R T := by
+  constructor
+  intro q hq
+  obtain ⟨g₁, hg₁q, hstd_g⟩ :=
+    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := S) q
+  obtain ⟨s₁, hs₁⟩ := Algebra.IsStandardOpenImmersion.exists_away S (Localization.Away g₁)
+  set Tg := Localization.Away g₁
+  have hq_disj : Disjoint (Submonoid.powers g₁ : Set T) (↑q : Set T) :=
+    (Ideal.disjoint_powers_iff_notMem g₁ hq.isRadical).mpr hg₁q
+  set q_g := Ideal.map (algebraMap T Tg) q
+  haveI : q_g.IsPrime :=
+    IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq hq_disj
+  have hcomap_qg : q_g.comap (algebraMap T Tg) = q :=
+    IsLocalization.comap_map_of_isPrime_disjoint (Submonoid.powers g₁) Tg hq hq_disj
+  set p := q_g.comap (algebraMap S Tg)
+  haveI : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
+  obtain ⟨r₁, hr₁p, hstd_f⟩ :=
+    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := R) p
+  obtain ⟨n, t, ht⟩ := IsLocalization.Away.surj g₁ (algebraMap S Tg r₁)
+  use t * g₁
+  constructor
+  · apply Ideal.IsPrime.mul_notMem hq
+    · intro htq
+      apply hr₁p
+      rw [Ideal.mem_comap]
+      have ht_mem : algebraMap T Tg t ∈ q_g := Ideal.mem_map_of_mem _ htq
+      rw [← ht] at ht_mem
+      rwa [Ideal.mul_unit_mem_iff_mem] at ht_mem
+      exact IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
+    · exact hg₁q
+  · have hmul : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
+      .mul Tg _ _ _
+    let e : Localization.Away (t * g₁) ≃ₐ[T] (Localization.Away (algebraMap T Tg t)) :=
+      Localization.algEquiv _ _
+    letI instAlg : Algebra (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      RingHom.toAlgebra (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
+    haveI : IsScalarTower R (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      IsScalarTower.of_algebraMap_eq' (A := Localization.Away (t * g₁))
+        (S := Localization.Away (algebraMap T Tg t)) (R := R) (by
+      rw [RingHom.algebraMap_toAlgebra]
+      ext (x : R)
+      simp only [RingHom.coe_comp, Function.comp_apply]
+      rw [IsScalarTower.algebraMap_apply R T (Localization.Away (t * g₁)), ← e.symm.commutes,
+          IsScalarTower.algebraMap_apply R T (Localization.Away (algebraMap T Tg t))]
+      rfl)
+    have : Algebra.IsStandardOpenImmersion
+        (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      .of_bijective _ _ e.symm.bijective
+    have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
+      rw [← ht]
+      have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
+        IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
+      have : IsLocalization.Away
+          ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)
+          (Localization.Away (algebraMap S Tg r₁)) := by
+        apply (config := { allowSynthFailures := true }) IsLocalization.Away.mul'
+          (Localization.Away (algebraMap S Tg r₁))
+        apply IsLocalization.away_of_isUnit_of_bijective
+        · exact IsUnit.map _ hunit
+        · exact Function.bijective_id
+      let e' : Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n) ≃ₐ[Tg]
+          Localization.Away (algebraMap S Tg r₁) :=
+        Localization.algEquiv _ _
+      set Sr := Localization.Away r₁
+      set Tgr := Localization.Away (algebraMap S Tg r₁)
+      letI : Algebra Sr Tgr := (IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁).toAlgebra
+      have hST_R : IsScalarTower R Sr Tgr :=
+        IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
+        ext x
+        simp only [RingHom.comp_apply]
+        rw [IsScalarTower.algebraMap_apply R S Sr, RingHom.algebraMap_toAlgebra,
+            IsLocalization.Away.map, IsLocalization.map_eq,
+            IsScalarTower.algebraMap_apply R Tg Tgr, IsScalarTower.algebraMap_apply R S Tg])
+      haveI : IsScalarTower S Sr Tgr :=
+        IsScalarTower.of_algebraMap_eq' (R := S) (S := Sr) (A := Tgr) (by
+        ext a
+        simp only [RingHom.comp_apply]
+        rw [RingHom.algebraMap_toAlgebra, IsLocalization.Away.map, IsLocalization.map_eq,
+            IsScalarTower.algebraMap_apply S Tg Tgr])
+      haveI : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
+        IsLocalization.Away.commutes Sr Tg Tgr r₁ s₁
+      haveI : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
+      haveI : Algebra.IsStandardOpenImmersion R Tgr :=
+        Algebra.IsStandardOpenImmersion.trans R Sr Tgr
+      apply Algebra.IsStandardOpenImmersion.of_algEquiv _ _ _ (e'.symm.restrictScalars R)
+    exact Algebra.IsStandardOpenImmersion.trans _ (Localization.Away (algebraMap T Tg t)) _
+
 end Algebra.IsLocalIso
 
 /-- A ring homomorphism is a local isomorphism if source locally (in the geometric sense),
@@ -131,156 +220,17 @@ lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
 /-- The composition of two local isomorphisms is a local isomorphism. -/
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
     (g.comp f).IsLocalIso := by
-  letI := f.toAlgebra
-  letI := g.toAlgebra
-  letI := (g.comp f).toAlgebra
+  letI : Algebra R S := f.toAlgebra
+  letI : Algebra S T := g.toAlgebra
+  letI : Algebra R T := (g.comp f).toAlgebra
   haveI : IsScalarTower R S T := .of_algebraMap_eq fun _ ↦ rfl
   haveI : Algebra.IsLocalIso R S := hf
   haveI : Algebra.IsLocalIso S T := hg
-  show Algebra.IsLocalIso R T
-  constructor
-  intro q hq
-  -- Step 1: By IsLocalIso S T, get g₁ ∉ q with IsStandardOpenImmersion S (Localization.Away g₁)
-  obtain ⟨g₁, hg₁q, hstd_g⟩ :=
-    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := S) q
-  obtain ⟨s₁, hs₁⟩ := Algebra.IsStandardOpenImmersion.exists_away S (Localization.Away g₁)
-  set Tg := Localization.Away g₁
-  have hq_disj : Disjoint (Submonoid.powers g₁ : Set T) (↑q : Set T) :=
-    (Ideal.disjoint_powers_iff_notMem g₁ hq.isRadical).mpr hg₁q
-  set q_g := Ideal.map (algebraMap T Tg) q
-  haveI : q_g.IsPrime :=
-    IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq hq_disj
-  have hcomap_qg : q_g.comap (algebraMap T Tg) = q :=
-    IsLocalization.comap_map_of_isPrime_disjoint (Submonoid.powers g₁) Tg hq hq_disj
-  -- p is the prime of S corresponding to q_g via S → Tg
-  set p := q_g.comap (algebraMap S Tg)
-  haveI : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
-  -- Step 2: By IsLocalIso R S, get r₁ ∉ p with IsStandardOpenImmersion R (Localization.Away r₁)
-  obtain ⟨r₁, hr₁p, hstd_f⟩ :=
-    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := R) p
-  -- Step 3: Use surj for T → Tg to lift algebraMap S Tg r₁ to T
-  obtain ⟨n, t, ht⟩ := IsLocalization.Away.surj g₁ (algebraMap S Tg r₁)
-  -- ht : (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n = algebraMap T Tg t
-  -- Step 4: The element t * g₁ : T is not in q
-  use t * g₁
-  constructor
-  · -- Need t * g₁ ∉ q. Since q is prime, suffices t ∉ q and g₁ ∉ q.
-    -- g₁ ∉ q is given. For t ∉ q: if t ∈ q then algebraMap T Tg t ∈ q_g,
-    -- so (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n ∈ q_g, but g₁^n maps to a unit
-    -- in Tg (so its image is not in any prime), contradiction unless algebraMap S Tg r₁ ∈ q_g,
-    -- which would mean r₁ ∈ p, contradicting hr₁p.
-    apply Ideal.IsPrime.mul_notMem hq
-    · -- t ∉ q
-      intro htq
-      apply hr₁p
-      show r₁ ∈ q_g.comap (algebraMap S Tg)
-      rw [Ideal.mem_comap]
-      -- algebraMap S Tg r₁ ∈ q_g
-      -- From ht: (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n = algebraMap T Tg t
-      -- algebraMap T Tg t ∈ q_g since t ∈ q
-      have ht_mem : algebraMap T Tg t ∈ q_g := Ideal.mem_map_of_mem _ htq
-      rw [← ht] at ht_mem
-      -- (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n ∈ q_g
-      -- (algebraMap T Tg g₁)^n is a unit in Tg
-      rwa [Ideal.mul_unit_mem_iff_mem] at ht_mem
-      exact IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
-    · exact hg₁q
-  · -- Step 5: Algebra.IsStandardOpenImmersion R (Localization.Away (t * g₁))
-    -- Following of_span_eq_top pattern lines 59-87
-    -- Localization.Away (t * g₁) ≅ Localization.Away (algebraMap T Tg t) as T-algebras
-    -- via IsLocalization.Away.mul
-    have hmul : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
-      .mul Tg _ _ _
-    let e : Localization.Away (t * g₁) ≃ₐ[T] (Localization.Away (algebraMap T Tg t)) :=
-      Localization.algEquiv _ _
-    letI instAlg : Algebra (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      RingHom.toAlgebra (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
-    haveI : IsScalarTower R (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      IsScalarTower.of_algebraMap_eq' (A := Localization.Away (t * g₁))
-        (S := Localization.Away (algebraMap T Tg t)) (R := R) (by
-      rw [show (algebraMap (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)))
-        = (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
-        from RingHom.algebraMap_toAlgebra _]
-      ext (x : R)
-      -- target: algebraMap R (Loc(t*g₁)) x = e.symm (algebraMap R (Loc(algMap T Tg t)) x)
-      change algebraMap R (Localization.Away (t * g₁)) x =
-        e.symm (algebraMap R (Localization.Away (algebraMap T Tg t)) x)
-      rw [IsScalarTower.algebraMap_apply R T (Localization.Away (algebraMap T Tg t)),
-        AlgEquiv.commutes, IsScalarTower.algebraMap_apply R T (Localization.Away (t * g₁))])
-    have : Algebra.IsStandardOpenImmersion
-        (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      .of_bijective _ _ e.symm.bijective
-    -- Now show Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t))
-    have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
-      rw [← ht]
-      have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
-        IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
-      have : IsLocalization.Away
-          ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)
-          (Localization.Away (algebraMap S Tg r₁)) := by
-        apply (config := { allowSynthFailures := true }) IsLocalization.Away.mul'
-          (Localization.Away (algebraMap S Tg r₁))
-        apply IsLocalization.away_of_isUnit_of_bijective
-        · exact IsUnit.map _ hunit
-        · exact Function.bijective_id
-      let e' : Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n) ≃ₐ[Tg]
-          Localization.Away (algebraMap S Tg r₁) :=
-        Localization.algEquiv _ _
-      -- First establish IsStdOpenImm R (Loc.Away(algebraMap S Tg r₁))
-      -- via trans: R → Loc.Away r₁ → Loc.Away(algebraMap S Tg r₁)
-      -- Step A: Build Algebra (Loc.Away r₁) (Loc.Away(algebraMap S Tg r₁))
-      -- using IsLocalization.Away.map
-      set Sr := Localization.Away r₁  -- S-localization at r₁
-      set Tgr := Localization.Away (algebraMap S Tg r₁)  -- Tg-localization
-      let φ : Sr →+* Tgr := IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁
-      letI : Algebra Sr Tgr := φ.toAlgebra
-      -- Step B: Build IsScalarTower R Sr Tgr
-      have hST_R : IsScalarTower R Sr Tgr :=
-        IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
-        ext x
-        simp only [RingHom.comp_apply]
-        -- Need: algebraMap R Tgr x = φ (algebraMap R Sr x)
-        -- algebraMap R Sr x = algebraMap S Sr (algebraMap R S x) by IsScalarTower
-        -- φ (algebraMap S Sr (algebraMap R S x)) = algebraMap S Tgr (algebraMap R S x)
-        --   by definition of φ = IsLocalization.map
-        -- algebraMap S Tgr (algebraMap R S x) = algebraMap R Tgr x
-        --   by IsScalarTower R S Tg → Tgr
-        change algebraMap R Tgr x = φ (algebraMap R Sr x)
-        rw [IsScalarTower.algebraMap_apply R S Sr]
-        show algebraMap R Tgr x =
-          IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁
-            (algebraMap S Sr (algebraMap R S x))
-        rw [IsLocalization.Away.map, IsLocalization.map_eq]
-        -- Goal: algebraMap R Tgr x = algebraMap Tg Tgr (algebraMap S Tg (algebraMap R S x))
-        rw [← IsScalarTower.algebraMap_apply R S Tg]
-        -- Goal: algebraMap R Tgr x = algebraMap Tg Tgr (algebraMap R Tg x)
-        rw [← IsScalarTower.algebraMap_apply R Tg Tgr])
-      -- Step C: IsStdOpenImm (Loc.Away r₁) (Loc.Away(algebraMap S Tg r₁))
-      -- Use IsLocalization.Away.commutes:
-      -- S₁ = Sr, S₂ = Tg, T = Tgr, x = r₁, y = s₁
-      -- Need IsScalarTower S Sr Tgr
-      haveI : IsScalarTower S Sr Tgr :=
-        IsScalarTower.of_algebraMap_eq' (R := S) (S := Sr) (A := Tgr) (by
-        ext a
-        simp only [RingHom.comp_apply]
-        change algebraMap S Tgr a = φ (algebraMap S Sr a)
-        show algebraMap S Tgr a =
-          IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁ (algebraMap S Sr a)
-        rw [IsLocalization.Away.map, IsLocalization.map_eq,
-          IsScalarTower.algebraMap_apply S Tg Tgr])
-      haveI : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
-        IsLocalization.Away.commutes Sr Tg Tgr r₁ s₁
-      haveI : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
-      haveI : Algebra.IsStandardOpenImmersion R Tgr :=
-        Algebra.IsStandardOpenImmersion.trans R Sr Tgr
-      apply Algebra.IsStandardOpenImmersion.of_algEquiv _ _ _ (e'.symm.restrictScalars R)
-    exact Algebra.IsStandardOpenImmersion.trans _ (Localization.Away (algebraMap T Tg t)) _
+  exact Algebra.IsLocalIso.trans R S
 
-/-- `RingHom.IsLocalIso` is stable under composition. -/
 lemma stableUnderComposition : StableUnderComposition IsLocalIso :=
   fun _ _ _ _ _ _ _ _ hf hg ↦ hg.comp hf
 
-/-- `RingHom.IsLocalIso` respects isomorphisms. -/
 lemma respectsIso : RespectsIso IsLocalIso :=
   stableUnderComposition.respectsIso fun e ↦ .of_bijective e.bijective
 

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -109,20 +109,18 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
   intro q hq
   obtain ⟨g₁, hg₁q, hstd_g⟩ :=
     Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := S) q
-  obtain ⟨s₁, hs₁⟩ := Algebra.IsStandardOpenImmersion.exists_away S (Localization.Away g₁)
-  set Tg := Localization.Away g₁
-  have hq_disj : Disjoint (Submonoid.powers g₁ : Set T) (↑q : Set T) :=
-    (Ideal.disjoint_powers_iff_notMem g₁ hq.isRadical).mpr hg₁q
+  let Tg := Localization.Away g₁
+  obtain ⟨s₁, hs₁⟩ := Algebra.IsStandardOpenImmersion.exists_away S Tg
   set q_g := Ideal.map (algebraMap T Tg) q
-  haveI : q_g.IsPrime :=
-    IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq hq_disj
+  have : q_g.IsPrime :=
+    IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq
+      ((Ideal.disjoint_powers_iff_notMem g₁ hq.isRadical).mpr hg₁q)
   set p := q_g.comap (algebraMap S Tg)
-  haveI : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
+  have : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
   obtain ⟨r₁, hr₁p, hstd_f⟩ :=
     Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := R) p
   obtain ⟨n, t, ht⟩ := IsLocalization.Away.surj g₁ (algebraMap S Tg r₁)
-  use t * g₁
-  constructor
+  refine ⟨t * g₁, ?_, ?_⟩
   · apply Ideal.IsPrime.mul_notMem hq
     · intro htq
       apply hr₁p
@@ -193,12 +191,13 @@ lemma RingHom.isLocalIso_algebraMap [Algebra R S] :
 namespace RingHom.IsLocalIso
 
 lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
-  letI : Algebra R S := f.toAlgebra
+  algebraize [f]
   have hbij : Function.Bijective (algebraMap R S) := hf
   haveI : Algebra.IsStandardOpenImmersion R S := by
     rw [Algebra.isStandardOpenImmersion_iff]
     exact ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hbij⟩
-  exact (inferInstance : Algebra.IsLocalIso R S)
+  show Algebra.IsLocalIso R S
+  infer_instance
 
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
     (g.comp f).IsLocalIso := by

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -119,16 +119,168 @@ lemma RingHom.isLocalIso_algebraMap [Algebra R S] :
 
 namespace RingHom.IsLocalIso
 
-lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso :=
-  sorry
+/-- A bijective ring homomorphism is a local isomorphism. -/
+lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
+  letI : Algebra R S := f.toAlgebra
+  have hbij : Function.Bijective (algebraMap R S) := hf
+  have : Algebra.IsStandardOpenImmersion R S := by
+    rw [Algebra.isStandardOpenImmersion_iff]
+    exact ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hbij⟩
+  exact Algebra.IsLocalIso.instOfIsStandardOpenImmersion R S
 
+/-- The composition of two local isomorphisms is a local isomorphism. -/
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
-    (g.comp f).IsLocalIso :=
-  sorry
+    (g.comp f).IsLocalIso := by
+  letI := f.toAlgebra
+  letI := g.toAlgebra
+  letI := (g.comp f).toAlgebra
+  haveI : IsScalarTower R S T := .of_algebraMap_eq fun _ ↦ rfl
+  haveI : Algebra.IsLocalIso R S := hf
+  haveI : Algebra.IsLocalIso S T := hg
+  show Algebra.IsLocalIso R T
+  constructor
+  intro q hq
+  -- Step 1: By IsLocalIso S T, get g₁ ∉ q with IsStandardOpenImmersion S (Localization.Away g₁)
+  obtain ⟨g₁, hg₁q, hstd_g⟩ :=
+    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := S) q
+  obtain ⟨s₁, hs₁⟩ := Algebra.IsStandardOpenImmersion.exists_away S (Localization.Away g₁)
+  set Tg := Localization.Away g₁
+  have hq_disj : Disjoint (Submonoid.powers g₁ : Set T) (↑q : Set T) :=
+    (Ideal.disjoint_powers_iff_notMem g₁ hq.isRadical).mpr hg₁q
+  set q_g := Ideal.map (algebraMap T Tg) q
+  haveI : q_g.IsPrime :=
+    IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq hq_disj
+  have hcomap_qg : q_g.comap (algebraMap T Tg) = q :=
+    IsLocalization.comap_map_of_isPrime_disjoint (Submonoid.powers g₁) Tg hq hq_disj
+  -- p is the prime of S corresponding to q_g via S → Tg
+  set p := q_g.comap (algebraMap S Tg)
+  haveI : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
+  -- Step 2: By IsLocalIso R S, get r₁ ∉ p with IsStandardOpenImmersion R (Localization.Away r₁)
+  obtain ⟨r₁, hr₁p, hstd_f⟩ :=
+    Algebra.IsLocalIso.exists_notMem_isStandardOpenImmersion (R := R) p
+  -- Step 3: Use surj for T → Tg to lift algebraMap S Tg r₁ to T
+  obtain ⟨n, t, ht⟩ := IsLocalization.Away.surj g₁ (algebraMap S Tg r₁)
+  -- ht : (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n = algebraMap T Tg t
+  -- Step 4: The element t * g₁ : T is not in q
+  use t * g₁
+  constructor
+  · -- Need t * g₁ ∉ q. Since q is prime, suffices t ∉ q and g₁ ∉ q.
+    -- g₁ ∉ q is given. For t ∉ q: if t ∈ q then algebraMap T Tg t ∈ q_g,
+    -- so (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n ∈ q_g, but g₁^n maps to a unit
+    -- in Tg (so its image is not in any prime), contradiction unless algebraMap S Tg r₁ ∈ q_g,
+    -- which would mean r₁ ∈ p, contradicting hr₁p.
+    apply Ideal.IsPrime.mul_notMem hq
+    · -- t ∉ q
+      intro htq
+      apply hr₁p
+      show r₁ ∈ q_g.comap (algebraMap S Tg)
+      rw [Ideal.mem_comap]
+      -- algebraMap S Tg r₁ ∈ q_g
+      -- From ht: (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n = algebraMap T Tg t
+      -- algebraMap T Tg t ∈ q_g since t ∈ q
+      have ht_mem : algebraMap T Tg t ∈ q_g := Ideal.mem_map_of_mem _ htq
+      rw [← ht] at ht_mem
+      -- (algebraMap S Tg r₁) * (algebraMap T Tg g₁)^n ∈ q_g
+      -- (algebraMap T Tg g₁)^n is a unit in Tg
+      rwa [Ideal.mul_unit_mem_iff_mem] at ht_mem
+      exact IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
+    · exact hg₁q
+  · -- Step 5: Algebra.IsStandardOpenImmersion R (Localization.Away (t * g₁))
+    -- Following of_span_eq_top pattern lines 59-87
+    -- Localization.Away (t * g₁) ≅ Localization.Away (algebraMap T Tg t) as T-algebras
+    -- via IsLocalization.Away.mul
+    have hmul : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
+      .mul Tg _ _ _
+    let e : Localization.Away (t * g₁) ≃ₐ[T] (Localization.Away (algebraMap T Tg t)) :=
+      Localization.algEquiv _ _
+    letI instAlg : Algebra (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      RingHom.toAlgebra (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
+    haveI : IsScalarTower R (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      IsScalarTower.of_algebraMap_eq' (A := Localization.Away (t * g₁))
+        (S := Localization.Away (algebraMap T Tg t)) (R := R) (by
+      rw [show (algebraMap (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)))
+        = (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
+        from RingHom.algebraMap_toAlgebra _]
+      ext (x : R)
+      -- target: algebraMap R (Loc(t*g₁)) x = e.symm (algebraMap R (Loc(algMap T Tg t)) x)
+      change algebraMap R (Localization.Away (t * g₁)) x =
+        e.symm (algebraMap R (Localization.Away (algebraMap T Tg t)) x)
+      rw [IsScalarTower.algebraMap_apply R T (Localization.Away (algebraMap T Tg t)),
+        AlgEquiv.commutes, IsScalarTower.algebraMap_apply R T (Localization.Away (t * g₁))])
+    have : Algebra.IsStandardOpenImmersion
+        (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
+      .of_bijective _ _ e.symm.bijective
+    -- Now show Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t))
+    have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
+      rw [← ht]
+      have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
+        IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
+      have : IsLocalization.Away
+          ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)
+          (Localization.Away (algebraMap S Tg r₁)) := by
+        apply (config := { allowSynthFailures := true }) IsLocalization.Away.mul'
+          (Localization.Away (algebraMap S Tg r₁))
+        apply IsLocalization.away_of_isUnit_of_bijective
+        · exact IsUnit.map _ hunit
+        · exact Function.bijective_id
+      let e' : Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n) ≃ₐ[Tg]
+          Localization.Away (algebraMap S Tg r₁) :=
+        Localization.algEquiv _ _
+      -- First establish IsStdOpenImm R (Loc.Away(algebraMap S Tg r₁))
+      -- via trans: R → Loc.Away r₁ → Loc.Away(algebraMap S Tg r₁)
+      -- Step A: Build Algebra (Loc.Away r₁) (Loc.Away(algebraMap S Tg r₁))
+      -- using IsLocalization.Away.map
+      set Sr := Localization.Away r₁  -- S-localization at r₁
+      set Tgr := Localization.Away (algebraMap S Tg r₁)  -- Tg-localization
+      let φ : Sr →+* Tgr := IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁
+      letI : Algebra Sr Tgr := φ.toAlgebra
+      -- Step B: Build IsScalarTower R Sr Tgr
+      have hST_R : IsScalarTower R Sr Tgr :=
+        IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
+        ext x
+        simp only [RingHom.comp_apply]
+        -- Need: algebraMap R Tgr x = φ (algebraMap R Sr x)
+        -- algebraMap R Sr x = algebraMap S Sr (algebraMap R S x) by IsScalarTower
+        -- φ (algebraMap S Sr (algebraMap R S x)) = algebraMap S Tgr (algebraMap R S x)
+        --   by definition of φ = IsLocalization.map
+        -- algebraMap S Tgr (algebraMap R S x) = algebraMap R Tgr x
+        --   by IsScalarTower R S Tg → Tgr
+        change algebraMap R Tgr x = φ (algebraMap R Sr x)
+        rw [IsScalarTower.algebraMap_apply R S Sr]
+        show algebraMap R Tgr x =
+          IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁
+            (algebraMap S Sr (algebraMap R S x))
+        rw [IsLocalization.Away.map, IsLocalization.map_eq]
+        -- Goal: algebraMap R Tgr x = algebraMap Tg Tgr (algebraMap S Tg (algebraMap R S x))
+        rw [← IsScalarTower.algebraMap_apply R S Tg]
+        -- Goal: algebraMap R Tgr x = algebraMap Tg Tgr (algebraMap R Tg x)
+        rw [← IsScalarTower.algebraMap_apply R Tg Tgr])
+      -- Step C: IsStdOpenImm (Loc.Away r₁) (Loc.Away(algebraMap S Tg r₁))
+      -- Use IsLocalization.Away.commutes:
+      -- S₁ = Sr, S₂ = Tg, T = Tgr, x = r₁, y = s₁
+      -- Need IsScalarTower S Sr Tgr
+      haveI : IsScalarTower S Sr Tgr :=
+        IsScalarTower.of_algebraMap_eq' (R := S) (S := Sr) (A := Tgr) (by
+        ext a
+        simp only [RingHom.comp_apply]
+        change algebraMap S Tgr a = φ (algebraMap S Sr a)
+        show algebraMap S Tgr a =
+          IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁ (algebraMap S Sr a)
+        rw [IsLocalization.Away.map, IsLocalization.map_eq,
+          IsScalarTower.algebraMap_apply S Tg Tgr])
+      haveI : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
+        IsLocalization.Away.commutes Sr Tg Tgr r₁ s₁
+      haveI : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
+      haveI : Algebra.IsStandardOpenImmersion R Tgr :=
+        Algebra.IsStandardOpenImmersion.trans R Sr Tgr
+      apply Algebra.IsStandardOpenImmersion.of_algEquiv _ _ _ (e'.symm.restrictScalars R)
+    exact Algebra.IsStandardOpenImmersion.trans _ (Localization.Away (algebraMap T Tg t)) _
 
+/-- `RingHom.IsLocalIso` is stable under composition. -/
 lemma stableUnderComposition : StableUnderComposition IsLocalIso :=
   fun _ _ _ _ _ _ _ _ hf hg ↦ hg.comp hf
 
+/-- `RingHom.IsLocalIso` respects isomorphisms. -/
 lemma respectsIso : RespectsIso IsLocalIso :=
   stableUnderComposition.respectsIso fun e ↦ .of_bijective e.bijective
 

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -103,6 +103,7 @@ lemma pi_of_finite {ι : Type*} (R : Type*) (S : ι → Type*)
 instance refl : IsLocalIso R R :=
   instOfIsStandardOpenImmersion R R
 
+/-- Local isomorphisms are closed under composition of algebra maps. -/
 lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
     [IsLocalIso R S] [IsLocalIso S T] : IsLocalIso R T := by
   constructor
@@ -130,19 +131,17 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       rwa [Ideal.mul_unit_mem_iff_mem] at ht_mem
       exact IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
     · exact hg₁q
-  · have hmul : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
+  · have : IsLocalization.Away (t * g₁) (Localization.Away (algebraMap T Tg t)) :=
       .mul Tg _ _ _
     have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
       rw [← ht]
-      have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
-        IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _)
       have : IsLocalization.Away
           ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)
           (Localization.Away (algebraMap S Tg r₁)) := by
         apply +allowSynthFailures IsLocalization.Away.mul'
           (Localization.Away (algebraMap S Tg r₁))
         apply IsLocalization.away_of_isUnit_of_bijective
-        · exact IsUnit.map _ hunit
+        · exact IsUnit.map _ (IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _))
         · exact Function.bijective_id
       let Sr := Localization.Away r₁
       let Tgr := Localization.Away (algebraMap S Tg r₁)
@@ -188,12 +187,14 @@ lemma RingHom.isLocalIso_algebraMap [Algebra R S] :
 
 namespace RingHom.IsLocalIso
 
+/-- A bijective ring homomorphism is a local isomorphism. -/
 lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
   algebraize [f]
   haveI := Algebra.IsStandardOpenImmersion.of_bijective R S hf
   show Algebra.IsLocalIso R S
   infer_instance
 
+/-- The composition of local isomorphisms is a local isomorphism. -/
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
     (g.comp f).IsLocalIso := by
   algebraize [f, g, g.comp f]

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -78,7 +78,7 @@ lemma of_span_eq_top {ι : Type*} (f : ι → S) (h : Ideal.span (Set.range f) =
     have : IsStandardOpenImmersion R (Localization.Away ((algebraMap S (T i)) g)) := by
       rw [← hg]
       have : IsLocalization.Away (g' * (algebraMap S (T i)) (f i) ^ n) (Localization.Away g') := by
-        apply (config := { allowSynthFailures := true }) IsLocalization.Away.mul' (Localization.Away g')
+        apply +allowSynthFailures IsLocalization.Away.mul' (Localization.Away g')
         apply IsLocalization.away_of_isUnit_of_bijective
         · exact IsUnit.map _ (IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit _))
         · exact Function.bijective_id
@@ -139,7 +139,7 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       have : IsLocalization.Away
           ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)
           (Localization.Away (algebraMap S Tg r₁)) := by
-        apply (config := { allowSynthFailures := true }) IsLocalization.Away.mul'
+        apply +allowSynthFailures IsLocalization.Away.mul'
           (Localization.Away (algebraMap S Tg r₁))
         apply IsLocalization.away_of_isUnit_of_bijective
         · exact IsUnit.map _ hunit
@@ -150,16 +150,14 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       have : IsScalarTower R Sr Tgr :=
         IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
         ext x
-        simp only [RingHom.comp_apply]
-        rw [IsScalarTower.algebraMap_apply R S Sr, RingHom.algebraMap_toAlgebra,
-            IsLocalization.Away.map, IsLocalization.map_eq,
-            IsScalarTower.algebraMap_apply R Tg Tgr, IsScalarTower.algebraMap_apply R S Tg])
+        rw [RingHom.comp_apply, IsScalarTower.algebraMap_apply R S Sr,
+            RingHom.algebraMap_toAlgebra, IsLocalization.Away.map, IsLocalization.map_eq,
+            ← IsScalarTower.algebraMap_apply R S Tg, ← IsScalarTower.algebraMap_apply R Tg Tgr])
       have : IsScalarTower S Sr Tgr :=
         IsScalarTower.of_algebraMap_eq' (R := S) (S := Sr) (A := Tgr) (by
         ext a
-        simp only [RingHom.comp_apply]
-        rw [RingHom.algebraMap_toAlgebra, IsLocalization.Away.map, IsLocalization.map_eq,
-            IsScalarTower.algebraMap_apply S Tg Tgr])
+        rw [RingHom.comp_apply, RingHom.algebraMap_toAlgebra, IsLocalization.Away.map,
+            IsLocalization.map_eq, ← IsScalarTower.algebraMap_apply S Tg Tgr])
       have : IsLocalization.Away (algebraMap S Sr s₁) Tgr :=
         IsLocalization.Away.commutes Sr Tg Tgr r₁ s₁
       have : Algebra.IsStandardOpenImmersion Sr Tgr := ⟨algebraMap S Sr s₁, inferInstance⟩
@@ -167,12 +165,10 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
         Algebra.IsStandardOpenImmersion.trans R Sr Tgr
       exact .of_algEquiv _ _ _
         ((IsLocalization.algEquiv
-          (Submonoid.powers ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n))
-          (Localization.Away ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n))
+          (Submonoid.powers ((algebraMap S Tg r₁) * (algebraMap T Tg g₁) ^ n)) _
           (Localization.Away (algebraMap S Tg r₁))).symm.restrictScalars R)
     exact .of_algEquiv _ _ _
-      ((IsLocalization.algEquiv (Submonoid.powers (t * g₁))
-        (Localization.Away (t * g₁))
+      ((IsLocalization.algEquiv (Submonoid.powers (t * g₁)) _
         (Localization.Away (algebraMap T Tg t))).symm.restrictScalars R)
 
 end Algebra.IsLocalIso
@@ -194,10 +190,7 @@ namespace RingHom.IsLocalIso
 
 lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
   algebraize [f]
-  have hbij : Function.Bijective (algebraMap R S) := hf
-  haveI : Algebra.IsStandardOpenImmersion R S := by
-    rw [Algebra.isStandardOpenImmersion_iff]
-    exact ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hbij⟩
+  haveI := Algebra.IsStandardOpenImmersion.of_bijective R S hf
   show Algebra.IsLocalIso R S
   infer_instance
 

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -5,6 +5,7 @@ Authors: Christian Merten
 -/
 import Mathlib.RingTheory.RingHom.OpenImmersion
 import Mathlib.RingTheory.Spectrum.Prime.Topology
+import Mathlib.Tactic.Algebraize
 import Mathlib.Tactic.DepRewrite
 import Proetale.Mathlib.RingTheory.RingHom.OpenImmersion
 
@@ -195,7 +196,7 @@ end Algebra.IsLocalIso
 
 /-- A ring homomorphism is a local isomorphism if source locally (in the geometric sense),
 it is a standard open immersion. -/
-@[stacks 096E "(1)"]
+@[stacks 096E "(1)", algebraize]
 def RingHom.IsLocalIso {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+* S) : Prop :=
   letI := f.toAlgebra
   Algebra.IsLocalIso R S
@@ -212,20 +213,15 @@ namespace RingHom.IsLocalIso
 lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
   letI : Algebra R S := f.toAlgebra
   have hbij : Function.Bijective (algebraMap R S) := hf
-  have : Algebra.IsStandardOpenImmersion R S := by
+  haveI : Algebra.IsStandardOpenImmersion R S := by
     rw [Algebra.isStandardOpenImmersion_iff]
     exact ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hbij⟩
-  exact Algebra.IsLocalIso.instOfIsStandardOpenImmersion R S
+  exact (inferInstance : Algebra.IsLocalIso R S)
 
 /-- The composition of two local isomorphisms is a local isomorphism. -/
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
     (g.comp f).IsLocalIso := by
-  letI : Algebra R S := f.toAlgebra
-  letI : Algebra S T := g.toAlgebra
-  letI : Algebra R T := (g.comp f).toAlgebra
-  haveI : IsScalarTower R S T := .of_algebraMap_eq fun _ ↦ rfl
-  haveI : Algebra.IsLocalIso R S := hf
-  haveI : Algebra.IsLocalIso S T := hg
+  algebraize [f, g, g.comp f]
   exact Algebra.IsLocalIso.trans R S
 
 lemma stableUnderComposition : StableUnderComposition IsLocalIso :=

--- a/Proetale/Algebra/LocalIso.lean
+++ b/Proetale/Algebra/LocalIso.lean
@@ -103,7 +103,6 @@ lemma pi_of_finite {ι : Type*} (R : Type*) (S : ι → Type*)
 instance refl : IsLocalIso R R :=
   instOfIsStandardOpenImmersion R R
 
-/-- The composition of two local isomorphisms is a local isomorphism. -/
 lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
     [IsLocalIso R S] [IsLocalIso S T] : IsLocalIso R T := by
   constructor
@@ -117,8 +116,6 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
   set q_g := Ideal.map (algebraMap T Tg) q
   haveI : q_g.IsPrime :=
     IsLocalization.isPrime_of_isPrime_disjoint (Submonoid.powers g₁) Tg q hq hq_disj
-  have hcomap_qg : q_g.comap (algebraMap T Tg) = q :=
-    IsLocalization.comap_map_of_isPrime_disjoint (Submonoid.powers g₁) Tg hq hq_disj
   set p := q_g.comap (algebraMap S Tg)
   haveI : p.IsPrime := Ideal.IsPrime.comap (algebraMap S Tg)
   obtain ⟨r₁, hr₁p, hstd_f⟩ :=
@@ -139,20 +136,6 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       .mul Tg _ _ _
     let e : Localization.Away (t * g₁) ≃ₐ[T] (Localization.Away (algebraMap T Tg t)) :=
       Localization.algEquiv _ _
-    letI instAlg : Algebra (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      RingHom.toAlgebra (e.symm : Localization.Away (algebraMap T Tg t) →+* Localization.Away (t * g₁))
-    haveI : IsScalarTower R (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      IsScalarTower.of_algebraMap_eq' (A := Localization.Away (t * g₁))
-        (S := Localization.Away (algebraMap T Tg t)) (R := R) (by
-      rw [RingHom.algebraMap_toAlgebra]
-      ext (x : R)
-      simp only [RingHom.coe_comp, Function.comp_apply]
-      rw [IsScalarTower.algebraMap_apply R T (Localization.Away (t * g₁)), ← e.symm.commutes,
-          IsScalarTower.algebraMap_apply R T (Localization.Away (algebraMap T Tg t))]
-      rfl)
-    have : Algebra.IsStandardOpenImmersion
-        (Localization.Away (algebraMap T Tg t)) (Localization.Away (t * g₁)) :=
-      .of_bijective _ _ e.symm.bijective
     have : Algebra.IsStandardOpenImmersion R (Localization.Away (algebraMap T Tg t)) := by
       rw [← ht]
       have hunit : IsUnit ((algebraMap T Tg g₁) ^ n) :=
@@ -171,7 +154,7 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       set Sr := Localization.Away r₁
       set Tgr := Localization.Away (algebraMap S Tg r₁)
       letI : Algebra Sr Tgr := (IsLocalization.Away.map Sr Tgr (algebraMap S Tg) r₁).toAlgebra
-      have hST_R : IsScalarTower R Sr Tgr :=
+      haveI : IsScalarTower R Sr Tgr :=
         IsScalarTower.of_algebraMap_eq' (R := R) (S := Sr) (A := Tgr) (by
         ext x
         simp only [RingHom.comp_apply]
@@ -190,7 +173,7 @@ lemma trans {T : Type*} [CommSemiring T] [Algebra S T] [Algebra R T] [IsScalarTo
       haveI : Algebra.IsStandardOpenImmersion R Tgr :=
         Algebra.IsStandardOpenImmersion.trans R Sr Tgr
       apply Algebra.IsStandardOpenImmersion.of_algEquiv _ _ _ (e'.symm.restrictScalars R)
-    exact Algebra.IsStandardOpenImmersion.trans _ (Localization.Away (algebraMap T Tg t)) _
+    exact .of_algEquiv _ _ _ (e.symm.restrictScalars R)
 
 end Algebra.IsLocalIso
 
@@ -209,7 +192,6 @@ lemma RingHom.isLocalIso_algebraMap [Algebra R S] :
 
 namespace RingHom.IsLocalIso
 
-/-- A bijective ring homomorphism is a local isomorphism. -/
 lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
   letI : Algebra R S := f.toAlgebra
   have hbij : Function.Bijective (algebraMap R S) := hf
@@ -218,7 +200,6 @@ lemma of_bijective (hf : Function.Bijective f) : f.IsLocalIso := by
     exact ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hbij⟩
   exact (inferInstance : Algebra.IsLocalIso R S)
 
-/-- The composition of two local isomorphisms is a local isomorphism. -/
 lemma comp {T : Type*} [CommSemiring T] {g : S →+* T} (hg : g.IsLocalIso) (hf : f.IsLocalIso) :
     (g.comp f).IsLocalIso := by
   algebraize [f, g, g.comp f]


### PR DESCRIPTION
Prove `RingHom.IsLocalIso.of_bijective`: a bijective ring homomorphism is a local isomorphism.

Prove `RingHom.IsLocalIso.comp`: the composition of two local isomorphisms is a local isomorphism. The proof localizes at primes of the target, lifts elements via `IsLocalization.Away.surj`, and builds the required `IsStandardOpenImmersion` instances by composing localization equivalences.