### PR TITLE
feat(ProAffineEtale): prove RespectsIso and IsStableUnderComposition

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
+++ b/Proetale/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
@@ -14,4 +14,8 @@ lemma ofObjectProperty_top_left_iff {C : Type*} [Category* C] {X Y : C} {f : X �
     ofObjectProperty ⊤ P f ↔ P Y :=
   ⟨fun h ↦ h.right, fun h ↦ ⟨trivial, h⟩⟩
 
+instance {C : Type*} [Category* C] (P Q : ObjectProperty C) :
+    (ofObjectProperty P Q).IsStableUnderComposition where
+  comp_mem _ _ hf hg := ⟨hf.left, hg.right⟩
+
 end CategoryTheory.MorphismProperty

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.Ind
+import Proetale.Mathlib.CategoryTheory.MorphismProperty.IndSpreads
 import Mathlib.AlgebraicGeometry.Morphisms.WeaklyEtale
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
 
@@ -30,18 +31,36 @@ lemma proAffineEtale.of_isAffine {X Y : Scheme.{u}} [IsAffine X] (f : X ⟶ Y) [
     proAffineEtale f :=
   MorphismProperty.le_pro _ _ ⟨‹_›, ⟨‹_›, trivial⟩⟩
 
+/-- `IsAffine` is preserved under isomorphisms. -/
+instance : ObjectProperty.IsClosedUnderIsomorphisms (C := Scheme.{u}) (IsAffine ·) where
+  of_iso e h := (IsAffine.iff_of_isIso e.hom).mp h
+
 /-- Every pro-affine étale morphism is weakly-étale. -/
 lemma proAffineEtale_le_weaklyEtale : proAffineEtale ≤ @WeaklyEtale :=
   sorry
 
-instance : proAffineEtale.RespectsIso :=
-  sorry
+instance : proAffineEtale.RespectsIso := by
+  rw [proAffineEtale, pro_eq_unop_ind_op]
+  infer_instance
 
 instance : proAffineEtale.HasOfPostcompProperty proAffineEtale :=
   sorry
 
-instance : proAffineEtale.IsStableUnderComposition :=
+/-- `ofObjectProperty (IsAffine ·) ⊤` is stable under composition, since it only depends on the
+source object. -/
+instance : (ofObjectProperty (IsAffine ·) (⊤ : ObjectProperty Scheme.{u})).IsStableUnderComposition
+    where
+  comp_mem {_X _Y _Z} _f _g hf _hg := hf
+
+/-- The property `Etale ⊓ ofObjectProperty (IsAffine ·) ⊤` pre-pro-spreads.
+This is needed to show that `proAffineEtale` is stable under composition. -/
+instance : MorphismProperty.PreProSpreads.{u}
+    (@Etale ⊓ .ofObjectProperty (IsAffine ·) (⊤ : ObjectProperty Scheme.{u})) :=
   sorry
+
+instance : proAffineEtale.IsStableUnderComposition := by
+  rw [proAffineEtale]
+  infer_instance
 
 instance {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffineHom f] :
     proAffineEtale.IsStableUnderBaseChangeAlong f := by

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -46,12 +46,6 @@ instance : proAffineEtale.RespectsIso := by
 instance : proAffineEtale.HasOfPostcompProperty proAffineEtale :=
   sorry
 
-/-- `ofObjectProperty (IsAffine ·) ⊤` is stable under composition, since it only depends on the
-source object. -/
-instance : (ofObjectProperty (IsAffine ·) (⊤ : ObjectProperty Scheme.{u})).IsStableUnderComposition
-    where
-  comp_mem {_X _Y _Z} _f _g hf _hg := hf
-
 /-- The property `Etale ⊓ ofObjectProperty (IsAffine ·) ⊤` pre-pro-spreads.
 This is needed to show that `proAffineEtale` is stable under composition. -/
 instance : MorphismProperty.PreProSpreads.{u}


### PR DESCRIPTION
## Summary

Addresses the sorries in `Proetale/Morphisms/ProAffineEtale.lean` from PR #34.

### Proved (no sorry)

- `instance : ObjectProperty.IsClosedUnderIsomorphisms (C := Scheme.{u}) (IsAffine ·)` — new helper, using `IsAffine.iff_of_isIso`
- `instance : (ofObjectProperty (IsAffine ·) ⊤).IsStableUnderComposition` — trivial, since the property only depends on the source object
- `instance : proAffineEtale.RespectsIso` — proved via `rw [proAffineEtale, pro_eq_unop_ind_op]; infer_instance`, using Mathlib's chain of `RespectsIso` instances for `ind`, `op`, `unop`, and `⊓`
- `instance : proAffineEtale.IsStableUnderComposition` — proved via `rw [proAffineEtale]; infer_instance`, relying on the sorry'd `PreProSpreads` instance and the sorry'd `IsStableUnderComposition (pro P)` instance in `IndSpreads.lean`

### Still sorry'd

- `proAffineEtale_le_weaklyEtale` — requires showing that cofiltered limits of affine étale schemes are weakly étale (the limit projections need to be shown weakly étale, which requires ring-level flatness results for pro-systems not yet in Mathlib)
- `instance : proAffineEtale.HasOfPostcompProperty proAffineEtale` — the standard approach via `hasOfPostcompProperty_iff_le_diagonal` requires `proAffineEtale.IsStableUnderBaseChange` which only holds along affine morphisms
- `instance : MorphismProperty.PreProSpreads (Etale ⊓ ofObjectProperty (IsAffine ·) ⊤)` — helper needed for `IsStableUnderComposition`; requires that étale affine morphisms descend along cofiltered limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)