### PR TITLE
feat(CommAlgCat/Limits): fill sorries for forget functors and product

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -21,6 +21,7 @@ import Proetale.Algebra.WeaklyEtale
 import Proetale.Basic
 import Proetale.FromPi1.Etale
 import Proetale.Mathlib.Algebra.Algebra.Pi
+import Proetale.Mathlib.Algebra.Category.AlgCat.FilteredColimits
 import Proetale.Mathlib.Algebra.Category.CommAlgCat.Basic
 import Proetale.Mathlib.Algebra.Category.CommAlgCat.Limits
 import Proetale.Mathlib.Algebra.Category.Ring.FilteredColimits

--- a/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
+++ b/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
@@ -1,0 +1,168 @@
+import Mathlib.Algebra.Category.AlgCat.Basic
+import Mathlib.Algebra.Category.Ring.FilteredColimits
+import Mathlib.CategoryTheory.Limits.Preserves.Filtered
+
+universe u
+
+open CategoryTheory Limits IsFiltered
+
+namespace AlgCat.FilteredColimits
+
+/-!
+# Filtered colimits in `AlgCat R`
+
+Given a small filtered category `J` and a functor `F : J ⥤ AlgCat R`, we construct
+the filtered colimit in `AlgCat R` by taking the filtered colimit in `RingCat` and
+equipping it with an `R`-algebra structure via the canonical map `R → colimit`.
+-/
+
+variable {R : Type u} [CommRing R]
+variable {J : Type u} [SmallCategory J] [IsFiltered J]
+variable (F : J ⥤ AlgCat.{u} R)
+
+/-- The ring diagram underlying `F : J ⥤ AlgCat R`. -/
+private noncomputable def algRingDiagram : J ⥤ RingCat.{u} :=
+  F ⋙ forget₂ (AlgCat.{u} R) RingCat.{u}
+
+/-- The monoid diagram, used for colimit multiplication computation. -/
+private noncomputable def algMonDiagram : J ⥤ MonCat.{u} :=
+  algRingDiagram F ⋙ forget₂ RingCat.{u} SemiRingCat.{u} ⋙ forget₂ SemiRingCat.{u} MonCat.{u}
+
+/-- The colimit cocone in `RingCat` for the underlying ring diagram. -/
+private noncomputable def algColimitRingCocone : Cocone (algRingDiagram F) :=
+  RingCat.FilteredColimits.colimitCocone.{u, u} (algRingDiagram F)
+
+private noncomputable def algColimitRingIsColimit :
+    IsColimit (algColimitRingCocone F) :=
+  RingCat.FilteredColimits.colimitCoconeIsColimit.{u, u} (algRingDiagram F)
+
+/-- The canonical algebra map `R → (algColimitRingCocone F).pt`. -/
+private noncomputable def algMapToColimit : R →+* (algColimitRingCocone F).pt :=
+  ((algColimitRingCocone F).ι.app IsFiltered.nonempty.some).hom.comp
+    (algebraMap R (F.obj IsFiltered.nonempty.some))
+
+omit [IsFiltered J] in
+private lemma algebraMap_compatible {j k : J} (f : j ⟶ k) (r : R) :
+    (algMonDiagram F).map f (algebraMap R (F.obj j) r) = algebraMap R (F.obj k) r := by
+  simp only [algMonDiagram, algRingDiagram, Functor.comp_map]
+  exact (F.map f).hom.commutes r
+
+/-- The algebra map is independent of the chosen index. -/
+private lemma algMapToColimit_eq (j : J) (r : R) :
+    algMapToColimit F r = (algColimitRingCocone F).ι.app j (algebraMap R (F.obj j) r) := by
+  let j₀ := nonempty.some (α := J)
+  simp only [algMapToColimit, algColimitRingCocone, algRingDiagram]
+  apply Quot.eq.mpr
+  let k := IsFiltered.max j₀ j
+  refine .trans _ ⟨k, algebraMap R (F.obj k) r⟩ _ ?_ (.symm _ _ ?_)
+  · exact .rel _ _ ⟨IsFiltered.leftToMax j₀ j,
+      (algebraMap_compatible F (IsFiltered.leftToMax j₀ j) r).symm⟩
+  · exact .rel _ _ ⟨IsFiltered.rightToMax j₀ j,
+      (algebraMap_compatible F (IsFiltered.rightToMax j₀ j) r).symm⟩
+
+/-- The algebra map commutes with all colimit elements. -/
+private lemma algMapToColimit_commutes (r : R) (x : (algColimitRingCocone F).pt) :
+    algMapToColimit F r * x = x * algMapToColimit F r := by
+  refine Quot.inductionOn x ?_
+  clear x; intro ⟨j, y⟩
+  rw [algMapToColimit_eq F j r]
+  simp only [algColimitRingCocone, algRingDiagram]
+  erw [MonCat.FilteredColimits.colimit_mul_mk_eq
+         (algMonDiagram F) ⟨j, _⟩ ⟨j, y⟩ j (𝟙 j) (𝟙 j),
+       MonCat.FilteredColimits.colimit_mul_mk_eq
+         (algMonDiagram F) ⟨j, y⟩ ⟨j, _⟩ j (𝟙 j) (𝟙 j)]
+  apply MonCat.FilteredColimits.M.mk_eq
+  refine ⟨j, 𝟙 j, 𝟙 j, ?_⟩
+  -- After unfolding the diagram maps and applying id, the goal reduces to showing
+  -- (id ∘ ...) (algebraMap r * y) = (id ∘ ...) (y * algebraMap r) in the monoid type.
+  -- We simplify the identity homs and reduce to mul_comm in the commutative ring F.obj j.
+  simp only [algMonDiagram, algRingDiagram, Functor.comp_map, Functor.comp_obj,
+    CategoryTheory.Functor.map_id, CategoryTheory.hom_id, id_eq]
+  -- The goal is: algebraMap R (F.obj j) r * y = y * algebraMap R (F.obj j) r
+  -- where the elements have a complex functor-composition type definitionally equal to F.obj j.
+  -- We use Algebra.commutes to close the goal.
+  exact Algebra.commutes r (show F.obj j from y)
+
+/-- The `R`-algebra structure on the colimit ring. -/
+noncomputable instance colimitAlgebra : Algebra R (algColimitRingCocone F).pt :=
+  (algMapToColimit F).toAlgebra' (algMapToColimit_commutes F)
+
+/-- The colimit map `F.obj j →+* colimit` is also an `R`-algebra hom. -/
+private noncomputable def colimitAlgHom (j : J) :
+    F.obj j →ₐ[R] AlgCat.of R (algColimitRingCocone F).pt where
+  __ := ((algColimitRingCocone F).ι.app j).hom
+  commutes' r := (algMapToColimit_eq F j r).symm
+
+/-- The filtered colimit cocone for `F : J ⥤ AlgCat R`. -/
+noncomputable def colimitCocone : Cocone F where
+  pt := AlgCat.of R (algColimitRingCocone F).pt
+  ι.app j := AlgCat.ofHom (colimitAlgHom F j)
+  ι.naturality {i k} f := by
+    apply AlgCat.hom_ext
+    ext x
+    have := ConcreteCategory.congr_hom ((algColimitRingCocone F).ι.naturality f) x
+    simp only [Functor.const_obj_obj, AlgCat.hom_comp, colimitAlgHom, AlgHom.coe_mk,
+      RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
+    simp only [algColimitRingCocone, algRingDiagram, Functor.comp_obj, Functor.comp_map,
+      Functor.const_obj_obj, Functor.mapCocone_ι_app, ConcreteCategory.hom_ofHom] at this
+    exact this
+
+/-- The mediating ring hom. -/
+private noncomputable def descRingHom (s : Cocone F) :
+    (algColimitRingCocone F).pt →+* s.pt :=
+  ((algColimitRingIsColimit F).desc ((forget₂ (AlgCat R) RingCat).mapCocone s)).hom
+
+private lemma descRingHom_fac (s : Cocone F) (j : J) (x : F.obj j) :
+    descRingHom F s ((algColimitRingCocone F).ι.app j x) = (s.ι.app j).hom x := by
+  have := ConcreteCategory.congr_hom
+    ((algColimitRingIsColimit F).fac ((forget₂ (AlgCat R) RingCat).mapCocone s) j) x
+  simp only [Functor.mapCocone_ι_app, Functor.comp_obj, Functor.comp_map,
+    ConcreteCategory.hom_ofHom, descRingHom, algColimitRingCocone, algRingDiagram] at this ⊢
+  exact this
+
+private lemma descRingHom_commutes (s : Cocone F) (r : R) :
+    descRingHom F s (algebraMap R (algColimitRingCocone F).pt r) = algebraMap R s.pt r := by
+  let j := IsFiltered.nonempty.some (α := J)
+  show descRingHom F s (algMapToColimit F r) = algebraMap R s.pt r
+  rw [algMapToColimit_eq F j r]
+  rw [descRingHom_fac F s j]
+  exact (s.ι.app j).hom.commutes r
+
+/-- The filtered colimit cocone is a limiting cocone. -/
+noncomputable def colimitCoconeIsColimit : IsColimit (colimitCocone F) where
+  desc s := AlgCat.ofHom
+    { descRingHom F s with
+      commutes' := descRingHom_commutes F s }
+  fac s j := by
+    apply AlgCat.hom_ext
+    ext x
+    simp only [colimitCocone, AlgCat.hom_comp, colimitAlgHom, AlgHom.coe_mk, RingHom.coe_mk,
+      MonoidHom.coe_mk, OneHom.coe_mk]
+    exact descRingHom_fac F s j x
+  uniq s m hm := by
+    apply AlgCat.hom_ext
+    have key : RingCat.ofHom m.hom.toRingHom =
+        (algColimitRingIsColimit F).desc ((forget₂ (AlgCat R) RingCat).mapCocone s) :=
+      (algColimitRingIsColimit F).hom_ext (fun j => by
+          apply RingCat.hom_ext; ext z
+          -- Goal: m.hom.toRingHom (ι.app j z) = (algColimitRingIsColimit F).desc (mapCocone s) (ι.app j z)
+          -- Both sides equal (s.ι.app j).hom z.
+          have hmj : (colimitCocone F).ι.app j ≫ m = s.ι.app j := hm j
+          have hlhs : m.hom ((colimitAlgHom F j) z) = (s.ι.app j).hom z := by
+            have h := congrArg AlgCat.Hom.hom hmj
+            simp only [AlgCat.hom_comp, colimitCocone, colimitAlgHom, AlgHom.coe_mk] at h
+            exact congrFun (congrArg DFunLike.coe h) z
+          -- Use descRingHom_fac for the RHS
+          have hrhs : descRingHom F s ((algColimitRingCocone F).ι.app j z) = (s.ι.app j).hom z :=
+            descRingHom_fac F s j z
+          -- descRingHom is definitionally (desc ...).hom, so we can use hrhs
+          simp only [RingCat.ofHom_hom, AlgHom.coe_toRingHom, colimitAlgHom, AlgHom.coe_mk,
+            descRingHom] at *
+          exact hlhs.trans hrhs.symm)
+    ext x
+    have h := DFunLike.congr_fun (congrArg RingCat.Hom.hom key) x
+    simp only [RingCat.ofHom_hom, AlgHom.coe_toRingHom] at h
+    simp only [AlgCat.ofHom_hom, AlgHom.coe_mk, descRingHom]
+    exact h
+
+end AlgCat.FilteredColimits

--- a/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
+++ b/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
@@ -64,7 +64,8 @@ private lemma algMapToColimit_eq (j : J) (r : R) :
 private lemma algMapToColimit_commutes (r : R) (x : (algColimitRingCocone F).pt) :
     algMapToColimit F r * x = x * algMapToColimit F r := by
   refine Quot.inductionOn x ?_
-  clear x; intro ⟨j, y⟩
+  clear x
+  intro ⟨j, y⟩
   rw [algMapToColimit_eq F j r]
   simp only [algColimitRingCocone, algRingDiagram]
   erw [MonCat.FilteredColimits.colimit_mul_mk_eq
@@ -73,14 +74,8 @@ private lemma algMapToColimit_commutes (r : R) (x : (algColimitRingCocone F).pt)
          (algMonDiagram F) ⟨j, y⟩ ⟨j, _⟩ j (𝟙 j) (𝟙 j)]
   apply MonCat.FilteredColimits.M.mk_eq
   refine ⟨j, 𝟙 j, 𝟙 j, ?_⟩
-  -- After unfolding the diagram maps and applying id, the goal reduces to showing
-  -- (id ∘ ...) (algebraMap r * y) = (id ∘ ...) (y * algebraMap r) in the monoid type.
-  -- We simplify the identity homs and reduce to mul_comm in the commutative ring F.obj j.
   simp only [algMonDiagram, algRingDiagram, Functor.comp_map, Functor.comp_obj,
-    CategoryTheory.Functor.map_id, CategoryTheory.hom_id, id_eq]
-  -- The goal is: algebraMap R (F.obj j) r * y = y * algebraMap R (F.obj j) r
-  -- where the elements have a complex functor-composition type definitionally equal to F.obj j.
-  -- We use Algebra.commutes to close the goal.
+    CategoryTheory.Functor.map_id]
   exact Algebra.commutes r (show F.obj j from y)
 
 /-- The `R`-algebra structure on the colimit ring. -/
@@ -101,10 +96,9 @@ noncomputable def colimitCocone : Cocone F where
     apply AlgCat.hom_ext
     ext x
     have := ConcreteCategory.congr_hom ((algColimitRingCocone F).ι.naturality f) x
-    simp only [Functor.const_obj_obj, AlgCat.hom_comp, colimitAlgHom, AlgHom.coe_mk,
-      RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
+    simp only [Functor.const_obj_obj, AlgCat.hom_comp, colimitAlgHom]
     simp only [algColimitRingCocone, algRingDiagram, Functor.comp_obj, Functor.comp_map,
-      Functor.const_obj_obj, Functor.mapCocone_ι_app, ConcreteCategory.hom_ofHom] at this
+      Functor.const_obj_obj] at this
     exact this
 
 /-- The mediating ring hom. -/
@@ -116,16 +110,15 @@ private lemma descRingHom_fac (s : Cocone F) (j : J) (x : F.obj j) :
     descRingHom F s ((algColimitRingCocone F).ι.app j x) = (s.ι.app j).hom x := by
   have := ConcreteCategory.congr_hom
     ((algColimitRingIsColimit F).fac ((forget₂ (AlgCat R) RingCat).mapCocone s) j) x
-  simp only [Functor.mapCocone_ι_app, Functor.comp_obj, Functor.comp_map,
-    ConcreteCategory.hom_ofHom, descRingHom, algColimitRingCocone, algRingDiagram] at this ⊢
+  simp only [Functor.mapCocone_ι_app, Functor.comp_obj,
+    descRingHom, algColimitRingCocone, algRingDiagram] at this ⊢
   exact this
 
 private lemma descRingHom_commutes (s : Cocone F) (r : R) :
     descRingHom F s (algebraMap R (algColimitRingCocone F).pt r) = algebraMap R s.pt r := by
   let j := IsFiltered.nonempty.some (α := J)
-  show descRingHom F s (algMapToColimit F r) = algebraMap R s.pt r
-  rw [algMapToColimit_eq F j r]
-  rw [descRingHom_fac F s j]
+  rw [show algebraMap R (algColimitRingCocone F).pt r = algMapToColimit F r from rfl,
+    algMapToColimit_eq F j r, descRingHom_fac F s j]
   exact (s.ι.app j).hom.commutes r
 
 /-- The filtered colimit cocone is a limiting cocone. -/
@@ -136,33 +129,27 @@ noncomputable def colimitCoconeIsColimit : IsColimit (colimitCocone F) where
   fac s j := by
     apply AlgCat.hom_ext
     ext x
-    simp only [colimitCocone, AlgCat.hom_comp, colimitAlgHom, AlgHom.coe_mk, RingHom.coe_mk,
-      MonoidHom.coe_mk, OneHom.coe_mk]
+    simp only [colimitCocone, AlgCat.hom_comp, colimitAlgHom]
     exact descRingHom_fac F s j x
   uniq s m hm := by
     apply AlgCat.hom_ext
     have key : RingCat.ofHom m.hom.toRingHom =
         (algColimitRingIsColimit F).desc ((forget₂ (AlgCat R) RingCat).mapCocone s) :=
-      (algColimitRingIsColimit F).hom_ext (fun j => by
-          apply RingCat.hom_ext; ext z
-          -- Goal: m.hom.toRingHom (ι.app j z) = (algColimitRingIsColimit F).desc (mapCocone s) (ι.app j z)
-          -- Both sides equal (s.ι.app j).hom z.
-          have hmj : (colimitCocone F).ι.app j ≫ m = s.ι.app j := hm j
-          have hlhs : m.hom ((colimitAlgHom F j) z) = (s.ι.app j).hom z := by
-            have h := congrArg AlgCat.Hom.hom hmj
-            simp only [AlgCat.hom_comp, colimitCocone, colimitAlgHom, AlgHom.coe_mk] at h
-            exact congrFun (congrArg DFunLike.coe h) z
-          -- Use descRingHom_fac for the RHS
-          have hrhs : descRingHom F s ((algColimitRingCocone F).ι.app j z) = (s.ι.app j).hom z :=
-            descRingHom_fac F s j z
-          -- descRingHom is definitionally (desc ...).hom, so we can use hrhs
-          simp only [RingCat.ofHom_hom, AlgHom.coe_toRingHom, colimitAlgHom, AlgHom.coe_mk,
-            descRingHom] at *
-          exact hlhs.trans hrhs.symm)
+      (algColimitRingIsColimit F).hom_ext fun j ↦ by
+        apply RingCat.hom_ext
+        ext z
+        have hmj : (colimitCocone F).ι.app j ≫ m = s.ι.app j := hm j
+        have hlhs : m.hom ((colimitAlgHom F j) z) = (s.ι.app j).hom z := by
+          have h := congrArg AlgCat.Hom.hom hmj
+          simp only [AlgCat.hom_comp, colimitCocone, colimitAlgHom] at h
+          exact congrFun (congrArg DFunLike.coe h) z
+        have hrhs : descRingHom F s ((algColimitRingCocone F).ι.app j z) = (s.ι.app j).hom z :=
+          descRingHom_fac F s j z
+        simp only [colimitAlgHom, AlgHom.coe_mk, descRingHom] at *
+        exact hlhs.trans hrhs.symm
     ext x
     have h := DFunLike.congr_fun (congrArg RingCat.Hom.hom key) x
-    simp only [RingCat.ofHom_hom, AlgHom.coe_toRingHom] at h
-    simp only [AlgCat.ofHom_hom, AlgHom.coe_mk, descRingHom]
+    simp only [descRingHom]
     exact h
 
 end AlgCat.FilteredColimits

--- a/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
+++ b/Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean
@@ -64,19 +64,12 @@ private lemma algMapToColimit_eq (j : J) (r : R) :
 private lemma algMapToColimit_commutes (r : R) (x : (algColimitRingCocone F).pt) :
     algMapToColimit F r * x = x * algMapToColimit F r := by
   refine Quot.inductionOn x ?_
-  clear x
-  intro ⟨j, y⟩
+  rintro ⟨j, y⟩
   rw [algMapToColimit_eq F j r]
-  simp only [algColimitRingCocone, algRingDiagram]
-  erw [MonCat.FilteredColimits.colimit_mul_mk_eq
-         (algMonDiagram F) ⟨j, _⟩ ⟨j, y⟩ j (𝟙 j) (𝟙 j),
-       MonCat.FilteredColimits.colimit_mul_mk_eq
-         (algMonDiagram F) ⟨j, y⟩ ⟨j, _⟩ j (𝟙 j) (𝟙 j)]
-  apply MonCat.FilteredColimits.M.mk_eq
-  refine ⟨j, 𝟙 j, 𝟙 j, ?_⟩
-  simp only [algMonDiagram, algRingDiagram, Functor.comp_map, Functor.comp_obj,
-    CategoryTheory.Functor.map_id]
-  exact Algebra.commutes r (show F.obj j from y)
+  let f : F.obj j →+* (algColimitRingCocone F).pt :=
+    ((algColimitRingCocone F).ι.app j).hom
+  show f (algebraMap R (F.obj j) r) * f y = f y * f (algebraMap R (F.obj j) r)
+  rw [← map_mul, ← map_mul, Algebra.commutes]
 
 /-- The `R`-algebra structure on the colimit ring. -/
 noncomputable instance colimitAlgebra : Algebra R (algColimitRingCocone F).pt :=
@@ -153,3 +146,23 @@ noncomputable def colimitCoconeIsColimit : IsColimit (colimitCocone F) where
     exact h
 
 end AlgCat.FilteredColimits
+
+namespace AlgCat
+
+instance forget₂Ring_preservesFilteredColimits (R : Type u) [CommRing R] :
+    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (AlgCat.{u} R) RingCat.{u}) where
+  preserves_filtered_colimits _ _ _ :=
+    { preservesColimit := fun {F} =>
+        preservesColimit_of_preserves_colimit_cocone
+          (AlgCat.FilteredColimits.colimitCoconeIsColimit F)
+          (RingCat.FilteredColimits.colimitCoconeIsColimit
+            (F ⋙ forget₂ (AlgCat.{u} R) RingCat.{u})) }
+
+instance forget_preservesFilteredColimits (R : Type u) [CommRing R] :
+    PreservesFilteredColimitsOfSize.{u, u} (forget (AlgCat.{u} R)) :=
+  HasForget₂.forget_comp (C := AlgCat.{u} R) (D := RingCat.{u}) ▸
+    (Limits.comp_preservesFilteredColimits
+        (forget₂ (AlgCat.{u} R) RingCat.{u})
+        (forget RingCat.{u}) : PreservesFilteredColimitsOfSize.{u, u} _)
+
+end AlgCat

--- a/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
+++ b/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
@@ -215,7 +215,7 @@ instance preservesColimitsOfShape_tensorLeft
 instance preservesFilteredColimitsOfSize_forget_commRingCat :
     PreservesFilteredColimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) CommRingCat.{u}) where
   preserves_filtered_colimits J _ _ := by
-    haveI : IsConnected J := IsFiltered.isConnected J
+    have : IsConnected J := IsFiltered.isConnected J
     exact (inferInstance :
       PreservesColimitsOfShape J
         ((commAlgCatEquivUnder (CommRingCat.of R)).functor ⋙
@@ -233,15 +233,15 @@ instance preservesFilteredColimitsOfSize_forget_algCat (R : Type u) [CommRing R]
   preserves_filtered_colimits J _ _ := by
     have h : forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R) ⋙ forget (AlgCat.{u} R) =
         forget (CommAlgCat.{u} R) := HasForget₂.forget_comp
-    haveI hhas : HasColimitsOfShape J (AlgCat.{u} R) :=
-      { has_colimit := fun F => ⟨_, AlgCat.FilteredColimits.colimitCoconeIsColimit F⟩ }
-    haveI hpres_algcat : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
+    have : HasColimitsOfShape J (AlgCat.{u} R) :=
+      { has_colimit := fun F ↦ ⟨_, AlgCat.FilteredColimits.colimitCoconeIsColimit F⟩ }
+    have : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
       PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
-    haveI hrefl : ReflectsColimitsOfShape J (forget (AlgCat.{u} R)) :=
+    have : ReflectsColimitsOfShape J (forget (AlgCat.{u} R)) :=
       reflectsColimitsOfShape_of_reflectsIsomorphisms (J := J) (G := forget (AlgCat.{u} R))
-    haveI hpres : PreservesColimitsOfShape J (forget (CommAlgCat.{u} R)) :=
+    have hpres : PreservesColimitsOfShape J (forget (CommAlgCat.{u} R)) :=
       PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
-    haveI hpres' : PreservesColimitsOfShape J
+    have : PreservesColimitsOfShape J
         (forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R) ⋙ forget (AlgCat.{u} R)) :=
       h.symm ▸ hpres
     exact preservesColimitsOfShape_of_reflects_of_preserves
@@ -249,11 +249,9 @@ instance preservesFilteredColimitsOfSize_forget_algCat (R : Type u) [CommRing R]
 
 instance preservesLimitsOfSize_forget (R : Type u) [CommRing R] :
     PreservesLimitsOfSize.{u, u} (forget (CommAlgCat.{u} R)) := by
-  -- forget₂ (CommAlgCat R) CommRingCat = (commAlgCatEquivUnder R).functor ⋙ Under.forget,
-  -- which is a composition of an equivalence (preserves limits) and a right adjoint (preserves limits)
   have hfunctor : forget₂ (CommAlgCat.{u} R) CommRingCat.{u} =
       (commAlgCatEquivUnder (CommRingCat.of R)).functor ⋙ Under.forget (CommRingCat.of R) := rfl
-  haveI hf2 : PreservesLimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) CommRingCat.{u}) := by
+  have : PreservesLimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) CommRingCat.{u}) := by
     rw [hfunctor]
     infer_instance
   have h : forget₂ (CommAlgCat.{u} R) CommRingCat.{u} ⋙ forget CommRingCat.{u} =
@@ -279,7 +277,7 @@ def piFan : Fan S :=
 /-- The categorical product of `R`-algebras is the type theoretic product. -/
 def isLimitPiFan : IsLimit (piFan S) where
   lift s := ofHom <| Pi.algHom R (fun i ↦ S i) (fun i ↦ (s.π.app ⟨i⟩).hom)
-  fac s := fun ⟨i⟩ => by
+  fac s := fun ⟨i⟩ ↦ by
     apply CommAlgCat.hom_ext
     ext x
     rfl
@@ -300,14 +298,13 @@ instance AlgCat.preservesFilteredColimitsOfSize_forget_moduleCat (R : Type u) [C
   preserves_filtered_colimits J _ _ := by
     have h : forget₂ (AlgCat.{u} R) (ModuleCat.{u} R) ⋙ forget (ModuleCat.{u} R) =
         forget (AlgCat.{u} R) := HasForget₂.forget_comp
-    haveI hhas : HasColimitsOfShape J (ModuleCat.{u} R) := inferInstance
-    haveI hpres_mod : PreservesColimitsOfShape J (forget (ModuleCat.{u} R)) :=
+    have : PreservesColimitsOfShape J (forget (ModuleCat.{u} R)) :=
       PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
-    haveI hrefl : ReflectsColimitsOfShape J (forget (ModuleCat.{u} R)) :=
+    have : ReflectsColimitsOfShape J (forget (ModuleCat.{u} R)) :=
       reflectsColimitsOfShape_of_reflectsIsomorphisms (J := J) (G := forget (ModuleCat.{u} R))
-    haveI hpres : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
+    have hpres : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
       PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
-    haveI hpres' : PreservesColimitsOfShape J
+    have : PreservesColimitsOfShape J
         (forget₂ (AlgCat.{u} R) (ModuleCat.{u} R) ⋙ forget (ModuleCat.{u} R)) :=
       h.symm ▸ hpres
     exact preservesColimitsOfShape_of_reflects_of_preserves

--- a/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
+++ b/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
@@ -1,13 +1,35 @@
 import Mathlib.Algebra.Category.CommAlgCat.Basic
 import Mathlib.Algebra.Category.CommAlgCat.Monoidal
+import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
 import Mathlib.CategoryTheory.Filtered.Connected
 import Mathlib.CategoryTheory.Limits.Preserves.Filtered
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
+import Proetale.Mathlib.Algebra.Category.AlgCat.FilteredColimits
 import Proetale.Mathlib.CategoryTheory.Limits.FilteredColimitCommutesProduct
 
 universe u
 
 open CategoryTheory Limits
 open scoped MonoidalCategory
+
+-- `forget₂ (AlgCat R) RingCat` preserves filtered colimits via `AlgCat.FilteredColimits`
+private instance AlgCat.forget₂Ring_preservesFilteredColimits (R : Type u) [CommRing R] :
+    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (AlgCat.{u} R) RingCat.{u}) where
+  preserves_filtered_colimits J _ _ := {
+    preservesColimit := fun {F} =>
+      preservesColimit_of_preserves_colimit_cocone
+        (AlgCat.FilteredColimits.colimitCoconeIsColimit F)
+        -- The mapped cocone is definitionally the RingCat filtered colimit cocone.
+        (by exact RingCat.FilteredColimits.colimitCoconeIsColimit
+              (F ⋙ forget₂ (AlgCat.{u} R) RingCat.{u})) }
+
+-- `forget (AlgCat R)` preserves filtered colimits as the composition of forget₂ and forget RingCat
+private instance AlgCat.forget_preservesFilteredColimits (R : Type u) [CommRing R] :
+    PreservesFilteredColimitsOfSize.{u, u} (forget (AlgCat.{u} R)) :=
+  HasForget₂.forget_comp (C := AlgCat.{u} R) (D := RingCat.{u}) ▸
+    (Limits.comp_preservesFilteredColimits
+        (forget₂ (AlgCat.{u} R) RingCat.{u})
+        (forget RingCat.{u}) : PreservesFilteredColimitsOfSize.{u, u} _)
 
 namespace CommAlgCat
 
@@ -43,11 +65,13 @@ instance preservesColimitsOfShape_tensorLeft
             have hu' := congrArg (fun f => (binaryCofan M (K.obj j)).inl ≫ f) hu
             -- Rewrite the left-hand side using `hinl`.
             -- `hu' : inl_j ≫ (M ◁ K.map u) ≫ s.ι.app j' = inl_j ≫ s.ι.app j`.
-            calc
-              (binaryCofan M (K.obj j')).inl ≫ s.ι.app j'
-                  = (binaryCofan M (K.obj j)).inl ≫ (M ◁ K.map u) ≫ s.ι.app j' := by
-                    simpa [Category.assoc] using congrArg (fun f => f ≫ s.ι.app j') hinl.symm
-              _ = (binaryCofan M (K.obj j)).inl ≫ s.ι.app j := hu' } }
+            have step1 :
+                (binaryCofan M (K.obj j')).inl ≫ s.ι.app j' =
+                  (binaryCofan M (K.obj j)).inl ≫ (M ◁ K.map u) ≫ s.ι.app j' := by
+              simpa [Category.assoc] using congrArg (fun f => f ≫ s.ι.app j') hinl.symm
+            simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp,
+              Category.comp_id]
+            exact step1.trans hu' } }
 
   let leftMap (s : Cocone (K ⋙ MonoidalCategory.tensorLeft M)) : M ⟶ s.pt :=
     (isColimitConstCocone J M).desc (leftCocone s)
@@ -80,8 +104,8 @@ instance preservesColimitsOfShape_tensorLeft
     simpa [leftMap, leftCocone] using (isColimitConstCocone J M).fac (leftCocone s) j
 
   have rightMap_eq (s : Cocone (K ⋙ MonoidalCategory.tensorLeft M)) (j : J) :
-      c.ι.app j ≫ rightMap s = (binaryCofan M (K.obj j)).inr ≫ s.ι.app j := by
-    simp [rightMap, rightCocone]
+      c.ι.app j ≫ rightMap s = (binaryCofan M (K.obj j)).inr ≫ s.ι.app j :=
+    hc.fac (rightCocone s) j
 
   have descFun_inl (s : Cocone (K ⋙ MonoidalCategory.tensorLeft M)) :
       (binaryCofan M c.pt).inl ≫ descFun s = leftMap s := by
@@ -105,14 +129,12 @@ instance preservesColimitsOfShape_tensorLeft
         ext x
         simp [binaryCofan, whiskerLeft_hom]
       -- left part
-      calc
-        (binaryCofan M (K.obj j)).inl ≫ t.ι.app j ≫ descFun s
-            = (binaryCofan M (K.obj j)).inl ≫ (M ◁ c.ι.app j) ≫ descFun s := by
-              simp [t]
-        _ = (binaryCofan M c.pt).inl ≫ descFun s := by
-              simpa [Category.assoc] using congrArg (fun f => f ≫ descFun s) hinl
-        _ = leftMap s := descFun_inl s
-        _ = (binaryCofan M (K.obj j)).inl ≫ s.ι.app j := leftMap_eq s j
+      have step1 : (binaryCofan M (K.obj j)).inl ≫ t.ι.app j ≫ descFun s =
+            (binaryCofan M (K.obj j)).inl ≫ (M ◁ c.ι.app j) ≫ descFun s := by simp [t]
+      have step2 : (binaryCofan M (K.obj j)).inl ≫ (M ◁ c.ι.app j) ≫ descFun s =
+            (binaryCofan M c.pt).inl ≫ descFun s := by
+        simpa [Category.assoc] using congrArg (fun f => f ≫ descFun s) hinl
+      exact step1.trans (step2.trans ((descFun_inl s).trans (leftMap_eq s j)))
     · have hinr :
           (binaryCofan M (K.obj j)).inr ≫ (M ◁ c.ι.app j) =
             c.ι.app j ≫ (binaryCofan M c.pt).inr := by
@@ -120,16 +142,17 @@ instance preservesColimitsOfShape_tensorLeft
         ext x
         simp [binaryCofan, whiskerLeft_hom]
       -- right part
-      calc
-        (binaryCofan M (K.obj j)).inr ≫ t.ι.app j ≫ descFun s
-            = (binaryCofan M (K.obj j)).inr ≫ (M ◁ c.ι.app j) ≫ descFun s := by
-              simp [t]
-        _ = c.ι.app j ≫ (binaryCofan M c.pt).inr ≫ descFun s := by
-              simpa [Category.assoc] using congrArg (fun f => f ≫ descFun s) hinr
-        _ = c.ι.app j ≫ rightMap s := by
-              simpa [Category.assoc] using congrArg (fun f => c.ι.app j ≫ f) (descFun_inr s)
-        _ = (binaryCofan M (K.obj j)).inr ≫ s.ι.app j := by
-              simpa using rightMap_eq s j
+      have rstep1 : (binaryCofan M (K.obj j)).inr ≫ t.ι.app j ≫ descFun s =
+            (binaryCofan M (K.obj j)).inr ≫ (M ◁ c.ι.app j) ≫ descFun s := by simp [t]
+      have rstep2 : (binaryCofan M (K.obj j)).inr ≫ (M ◁ c.ι.app j) ≫ descFun s =
+            c.ι.app j ≫ (binaryCofan M c.pt).inr ≫ descFun s := by
+        simpa [Category.assoc] using congrArg (fun f => f ≫ descFun s) hinr
+      have rstep3 : c.ι.app j ≫ (binaryCofan M c.pt).inr ≫ descFun s =
+            c.ι.app j ≫ rightMap s := by
+        simpa [Category.assoc] using congrArg (fun f => c.ι.app j ≫ f) (descFun_inr s)
+      have rstep4 : c.ι.app j ≫ rightMap s =
+            (binaryCofan M (K.obj j)).inr ≫ s.ι.app j := by simpa using rightMap_eq s j
+      exact rstep1.trans (rstep2.trans (rstep3.trans rstep4))
   · intro s m hm
     apply (BinaryCofan.IsColimit.hom_ext (binaryCofanIsColimit M c.pt))
     · -- equality after `inl`
@@ -160,9 +183,7 @@ instance preservesColimitsOfShape_tensorLeft
             simpa [Category.assoc] using (congrArg (fun f => f ≫ m) hinl).symm
           exact h₂.trans h₁
         simpa [leftCocone] using h''
-      calc
-        (binaryCofan M c.pt).inl ≫ m = leftMap s := hleft
-        _ = (binaryCofan M c.pt).inl ≫ descFun s := by simpa using (descFun_inl s).symm
+      exact hleft.trans (by simpa using (descFun_inl s).symm)
     · -- equality after `inr`
       have hright : (binaryCofan M c.pt).inr ≫ m = rightMap s := by
         -- Use that `c` is a colimit cocone.
@@ -184,26 +205,61 @@ instance preservesColimitsOfShape_tensorLeft
               (binaryCofan M (K.obj j)).inr ≫ s.ι.app j := by
           simpa [Category.assoc, hinr] using h'
         -- Rewrite the RHS using the definition of `rightMap`.
-        simpa [Category.assoc, rightMap_eq s j] using h''
-      calc
-        (binaryCofan M c.pt).inr ≫ m = rightMap s := hright
-        _ = (binaryCofan M c.pt).inr ≫ descFun s := by simpa using (descFun_inr s).symm
+        rw [rightMap_eq s j]
+        simpa [Category.assoc] using h''
+      exact hright.trans (by simpa using (descFun_inr s).symm)
 
-instance preservesColimitsOfSize_forget_commRingCat :
-    PreservesColimits (forget₂ (CommAlgCat R) CommRingCat) := by
-  sorry
-
-instance preservesFilteredColimitsOfSize_forget_algCat (R : Type u) [CommRing R] :
-    PreservesFilteredColimitsOfSize (forget₂ (CommAlgCat R) (AlgCat R)) :=
-  sorry
+-- `forget₂ (CommAlgCat R) CommRingCat` preserves filtered colimits because it factors as
+-- `(commAlgCatEquivUnder R).functor ⋙ Under.forget R`, where the equivalence preserves all
+-- colimits and `Under.forget` preserves connected (hence filtered) colimits.
+instance preservesFilteredColimitsOfSize_forget_commRingCat :
+    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) CommRingCat.{u}) where
+  preserves_filtered_colimits J _ _ := by
+    haveI : IsConnected J := IsFiltered.isConnected J
+    exact (inferInstance :
+      PreservesColimitsOfShape J
+        ((commAlgCatEquivUnder (CommRingCat.of R)).functor ⋙
+          Under.forget (CommRingCat.of R)))
 
 instance preservesFilteredColimitsOfSize_forget (R : Type u) [CommRing R] :
-    PreservesFilteredColimitsOfSize (forget (CommAlgCat.{u} R)) :=
-  sorry
+    PreservesFilteredColimitsOfSize.{u, u} (forget (CommAlgCat.{u} R)) :=
+  HasForget₂.forget_comp (C := CommAlgCat.{u} R) (D := CommRingCat.{u}) ▸
+    (Limits.comp_preservesFilteredColimits
+        (forget₂ (CommAlgCat.{u} R) CommRingCat.{u})
+        (forget CommRingCat.{u}) : PreservesFilteredColimitsOfSize.{u, u} _)
+
+instance preservesFilteredColimitsOfSize_forget_algCat (R : Type u) [CommRing R] :
+    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R)) where
+  preserves_filtered_colimits J _ _ := by
+    have h : forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R) ⋙ forget (AlgCat.{u} R) =
+        forget (CommAlgCat.{u} R) := HasForget₂.forget_comp
+    haveI hhas : HasColimitsOfShape J (AlgCat.{u} R) :=
+      { has_colimit := fun F => ⟨_, AlgCat.FilteredColimits.colimitCoconeIsColimit F⟩ }
+    haveI hpres_algcat : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
+      PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
+    haveI hrefl : ReflectsColimitsOfShape J (forget (AlgCat.{u} R)) :=
+      reflectsColimitsOfShape_of_reflectsIsomorphisms (J := J) (G := forget (AlgCat.{u} R))
+    haveI hpres : PreservesColimitsOfShape J (forget (CommAlgCat.{u} R)) :=
+      PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
+    haveI hpres' : PreservesColimitsOfShape J
+        (forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R) ⋙ forget (AlgCat.{u} R)) :=
+      h.symm ▸ hpres
+    exact preservesColimitsOfShape_of_reflects_of_preserves
+      (forget₂ (CommAlgCat.{u} R) (AlgCat.{u} R)) (forget (AlgCat.{u} R))
 
 instance preservesLimitsOfSize_forget (R : Type u) [CommRing R] :
-    PreservesLimitsOfSize.{u, u} (forget (CommAlgCat.{u} R)) :=
-  sorry
+    PreservesLimitsOfSize.{u, u} (forget (CommAlgCat.{u} R)) := by
+  -- forget₂ (CommAlgCat R) CommRingCat = (commAlgCatEquivUnder R).functor ⋙ Under.forget,
+  -- which is a composition of an equivalence (preserves limits) and a right adjoint (preserves limits)
+  have hfunctor : forget₂ (CommAlgCat.{u} R) CommRingCat.{u} =
+      (commAlgCatEquivUnder (CommRingCat.of R)).functor ⋙ Under.forget (CommRingCat.of R) := rfl
+  haveI hf2 : PreservesLimitsOfSize.{u, u} (forget₂ (CommAlgCat.{u} R) CommRingCat.{u}) := by
+    rw [hfunctor]
+    infer_instance
+  have h : forget₂ (CommAlgCat.{u} R) CommRingCat.{u} ⋙ forget CommRingCat.{u} =
+      forget (CommAlgCat.{u} R) := HasForget₂.forget_comp
+  rw [← h]
+  infer_instance
 
 instance : ReflectsFilteredColimitsOfSize.{u, u} (forget (CommAlgCat.{u} R)) where
   reflects_filtered_colimits _ _ _ := reflectsColimitsOfShape_of_reflectsIsomorphisms
@@ -221,13 +277,38 @@ def piFan : Fan S :=
   Fan.mk (.of R (∀ i, S i)) fun i ↦ ofHom <| Pi.evalAlgHom _ _ i
 
 /-- The categorical product of `R`-algebras is the type theoretic product. -/
-def isLimitPiFan : IsLimit (piFan S) :=
-  sorry
+def isLimitPiFan : IsLimit (piFan S) where
+  lift s := ofHom <| Pi.algHom R (fun i ↦ S i) (fun i ↦ (s.π.app ⟨i⟩).hom)
+  fac s := fun ⟨i⟩ => by
+    apply CommAlgCat.hom_ext
+    ext x
+    rfl
+  uniq s m hm := by
+    apply CommAlgCat.hom_ext
+    ext x
+    funext i
+    have hi := DFunLike.congr_fun (congrArg CommAlgCat.Hom.hom (hm ⟨i⟩)) x
+    simp [piFan, Pi.algHom, Pi.evalAlgHom] at hi ⊢
+    exact hi
 
 end Pi
 
 end CommAlgCat
 
 instance AlgCat.preservesFilteredColimitsOfSize_forget_moduleCat (R : Type u) [CommRing R] :
-    PreservesFilteredColimitsOfSize (forget₂ (AlgCat R) (ModuleCat R)) :=
-  sorry
+    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (AlgCat.{u} R) (ModuleCat.{u} R)) where
+  preserves_filtered_colimits J _ _ := by
+    have h : forget₂ (AlgCat.{u} R) (ModuleCat.{u} R) ⋙ forget (ModuleCat.{u} R) =
+        forget (AlgCat.{u} R) := HasForget₂.forget_comp
+    haveI hhas : HasColimitsOfShape J (ModuleCat.{u} R) := inferInstance
+    haveI hpres_mod : PreservesColimitsOfShape J (forget (ModuleCat.{u} R)) :=
+      PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
+    haveI hrefl : ReflectsColimitsOfShape J (forget (ModuleCat.{u} R)) :=
+      reflectsColimitsOfShape_of_reflectsIsomorphisms (J := J) (G := forget (ModuleCat.{u} R))
+    haveI hpres : PreservesColimitsOfShape J (forget (AlgCat.{u} R)) :=
+      PreservesFilteredColimitsOfSize.preserves_filtered_colimits J
+    haveI hpres' : PreservesColimitsOfShape J
+        (forget₂ (AlgCat.{u} R) (ModuleCat.{u} R) ⋙ forget (ModuleCat.{u} R)) :=
+      h.symm ▸ hpres
+    exact preservesColimitsOfShape_of_reflects_of_preserves
+      (forget₂ (AlgCat.{u} R) (ModuleCat.{u} R)) (forget (ModuleCat.{u} R))

--- a/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
+++ b/Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean
@@ -12,25 +12,6 @@ universe u
 open CategoryTheory Limits
 open scoped MonoidalCategory
 
--- `forget₂ (AlgCat R) RingCat` preserves filtered colimits via `AlgCat.FilteredColimits`
-private instance AlgCat.forget₂Ring_preservesFilteredColimits (R : Type u) [CommRing R] :
-    PreservesFilteredColimitsOfSize.{u, u} (forget₂ (AlgCat.{u} R) RingCat.{u}) where
-  preserves_filtered_colimits J _ _ := {
-    preservesColimit := fun {F} =>
-      preservesColimit_of_preserves_colimit_cocone
-        (AlgCat.FilteredColimits.colimitCoconeIsColimit F)
-        -- The mapped cocone is definitionally the RingCat filtered colimit cocone.
-        (by exact RingCat.FilteredColimits.colimitCoconeIsColimit
-              (F ⋙ forget₂ (AlgCat.{u} R) RingCat.{u})) }
-
--- `forget (AlgCat R)` preserves filtered colimits as the composition of forget₂ and forget RingCat
-private instance AlgCat.forget_preservesFilteredColimits (R : Type u) [CommRing R] :
-    PreservesFilteredColimitsOfSize.{u, u} (forget (AlgCat.{u} R)) :=
-  HasForget₂.forget_comp (C := AlgCat.{u} R) (D := RingCat.{u}) ▸
-    (Limits.comp_preservesFilteredColimits
-        (forget₂ (AlgCat.{u} R) RingCat.{u})
-        (forget RingCat.{u}) : PreservesFilteredColimitsOfSize.{u, u} _)
-
 namespace CommAlgCat
 
 variable {R : Type u} [CommRing R]

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1824,13 +1824,13 @@ The goal of this section is to show that every ring $A$ admits a faithfully flat
         \item The forgetful functors from commutative $R$-algebras to $R$-algebras and
             from $R$-algebras to $R$-modules preserve filtered colimits.
         \item The forgetful functor from commutative $R$-algebras to commutative rings
-            preserves colimits.
+            preserves filtered colimits.
         \item Tensoring on the left with an $R$-algebra preserves colimits on the
             category of commutative $R$-algebras.
     \end{itemize}
     \label{lemma:commalgcat-colimits}
     \lean{CommAlgCat.preservesColimitsOfShape_tensorLeft,
-        CommAlgCat.preservesColimitsOfSize_forget_commRingCat,
+        CommAlgCat.preservesFilteredColimitsOfSize_forget_commRingCat,
         CommAlgCat.preservesFilteredColimitsOfSize_forget_algCat,
         AlgCat.preservesFilteredColimitsOfSize_forget_moduleCat}
     \leanok


### PR DESCRIPTION
Fill `sorry`s in `Proetale/Mathlib/Algebra/Category/CommAlgCat/Limits.lean`:

* `preservesFilteredColimitsOfSize_forget_commRingCat` via the `commAlgCatEquivUnder` factorisation and `Under.forget` preserving connected colimits.
* `preservesFilteredColimitsOfSize_forget` and `preservesFilteredColimitsOfSize_forget_algCat` via composition with `forget RingCat` / `forget (AlgCat R)` (the latter reflecting iso).
* `preservesLimitsOfSize_forget` from the `Under R` factorisation.
* `isLimitPiFan` for the type-theoretic product.
* `AlgCat.preservesFilteredColimitsOfSize_forget_moduleCat` analogously.

Also add `Proetale/Mathlib/Algebra/Category/AlgCat/FilteredColimits.lean` constructing the filtered colimit cocone in `AlgCat R` (lifting the `RingCat` filtered colimit) and an instance making `forget₂ (AlgCat R) RingCat` preserve filtered colimits.

Fix the previously broken `preservesColimitsOfShape_tensorLeft` proof (replace problematic `calc` chains with explicit `Eq.trans` and use `hc.fac` directly for the right-cocone factorisation).