### PR TITLE
fix: address remaining lint warnings

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Proetale/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -3,8 +3,8 @@ import Mathlib.CategoryTheory.Sites.Grothendieck
 namespace CategoryTheory
 
 lemma GrothendieckTopology.transitive_of_presieve {C : Type*} [Category* C]
-    {J : GrothendieckTopology C} {X : C} (R : Presieve X) (hR : Sieve.generate R ∈ J X) (S : Sieve X)
-    (h : ∀ ⦃Y : C⦄ (g : Y ⟶ X), R g → S.pullback g ∈ J Y) :
+    {J : GrothendieckTopology C} {X : C} (R : Presieve X) (hR : Sieve.generate R ∈ J X)
+    (S : Sieve X) (h : ∀ ⦃Y : C⦄ (g : Y ⟶ X), R g → S.pullback g ∈ J Y) :
     S ∈ J X := by
   refine J.transitive hR _ ?_
   rintro Y f ⟨W, g, v, hv, rfl⟩

--- a/Proetale/Mathlib/CategoryTheory/Sites/Hypercover/Zero.lean
+++ b/Proetale/Mathlib/CategoryTheory/Sites/Hypercover/Zero.lean
@@ -21,7 +21,7 @@ lemma PreZeroHypercover.mem_of_iso {C : Type*} [Category* C] {K : Precoverage C}
   have : F.presieve₀ =
       Presieve.ofArrows (fun (i : Σ (_ : F.I₀), Unit) ↦ _)
         (fun i ↦ e.inv.h₀ i.1 ≫ E.f _) := by
-    simp [PreZeroHypercover.presieve₀]
+    simp only [Hom.w₀]
     refine le_antisymm ?_ ?_
     · rw [Presieve.ofArrows_le_iff]
       intro i

--- a/Proetale/Mathlib/CategoryTheory/Sites/InducedTopology.lean
+++ b/Proetale/Mathlib/CategoryTheory/Sites/InducedTopology.lean
@@ -133,7 +133,7 @@ lemma Functor.coinducedTopology_comp (J : GrothendieckTopology C) (F : C ⥤ D) 
     (F ⋙ G).coinducedTopology J = G.coinducedTopology (F.coinducedTopology J) := by
   refine le_antisymm ?_ ?_
   · intro X S hS
-    simp [Functor.mem_coinducedTopology_iff] at hS ⊢
+    simp only [Functor.mem_coinducedTopology_iff] at hS ⊢
     intro V f U g
     rw [← Sieve.functorPullback_pullback, ← Sieve.functorPullback_comp, ← Sieve.pullback_comp]
     apply hS
@@ -359,9 +359,9 @@ lemma foobarasdfasdf (J : GrothendieckTopology C) :
     (F.coinducedTopology J) F :=
     CoverPreserving.of_isContinuous _ _ _
   have := this.cover_preserve hS
-  simp [Functor.mem_coinducedTopology_iff] at this
+  simp only [Functor.mem_coinducedTopology_iff] at this
   have := this U (𝟙 _)
-  simp at this
+  simp only [Sieve.pullback_id] at this
   refine J.superset_covering ?_ this
   sorry
 

--- a/Proetale/Topology/Comparison/Affine.lean
+++ b/Proetale/Topology/Comparison/Affine.lean
@@ -110,7 +110,8 @@ lemma toProEt_obj_hom (X : S.AffineProEt) : ((toProEt S).obj X).hom = X.hom := r
 instance : (toProEt S).Full :=
   inferInstanceAs <| (MorphismProperty.Over.changeProp _ proAffineEtale_le_weaklyEtale _).Full
 instance : (toProEt S).Faithful :=
-  inferInstanceAs <| (MorphismProperty.Over.changeProp _ proAffineEtale_le_weaklyEtale le_rfl).Faithful
+  inferInstanceAs <|
+    (MorphismProperty.Over.changeProp _ proAffineEtale_le_weaklyEtale le_rfl).Faithful
 
 instance : HasPullbacks (AffineProEt S) :=
   sorry
@@ -120,7 +121,8 @@ of the proof is the commutative algebra lemma `RingHom.WeaklyEtale.exists_indEta
 instance isCoverDense_toProEt : (toProEt S).IsCoverDense (ProEt.topology S) := by
   wlog hS : ∃ R, S = Spec R generalizing S
   · let X (i : S.affineCover.I₀) : S.AffineProEt := .ofEtale (S.affineCover.f i)
-    let f (i : S.affineCover.I₀) : (toProEt S).obj (X i) ⟶ .mk (𝟙 S) := Over.homMk (S.affineCover.f i)
+    let f (i : S.affineCover.I₀) : (toProEt S).obj (X i) ⟶ .mk (𝟙 S) :=
+      Over.homMk (S.affineCover.f i)
     refine .of_coversTop _ _ (fun i : S.affineCover.I₀ ↦ X i) ?_ ?_
     · dsimp
       rw [GrothendieckTopology.coversTop_iff_of_isTerminal _ (.mk (𝟙 S))]
@@ -222,7 +224,8 @@ instance isCoverDense_toProEt : (toProEt S).IsCoverDense (ProEt.topology S) := b
       ProEt.mk_left, Presieve.map_singleton, toProEt_obj_left, Functor.comp_map, ProEt.forget_map,
       Over.forget_map]
     apply Hom.singleton_mem_propQCPrecoverage
-    simp [g']
+    change WeaklyEtale (Spec.map (CommRingCat.ofHom g))
+    rw [WeaklyEtale.Spec_iff]
     exact h₁.weaklyEtale
 
 instance : (toProEt S).LocallyCoverDense (ProEt.zariskiTopology S) :=


### PR DESCRIPTION
## Summary
- Wrap two long lines (`Grothendieck.lean`, `Affine.lean`) under the 100-char cap.
- Replace bare `simp [...]` with `simp only [...]` in `Hypercover/Zero.lean`, `InducedTopology.lean` and `Affine.lean` (flexible-tactic linter).
- Rewrite the `simp [g']; exact h₁.weaklyEtale` step in `Affine.lean` as an explicit `change … ; rw [WeaklyEtale.Spec_iff]` so the goal change is rigid.

After this `lake build` reports zero non-sorry warnings.

## Test plan
- [x] `lake build` succeeds with no lint warnings (only `declaration uses sorry` remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)