### PR TITLE
feat(Topology/Spectral): generalization hull of compact set is intersection of compact opens

### DIFF
--- a/Proetale/Mathlib/Topology/Spectral/Basic.lean
+++ b/Proetale/Mathlib/Topology/Spectral/Basic.lean
@@ -44,5 +44,30 @@ instance SpectralSpace.prod [SpectralSpace X] [SpectralSpace Y] : SpectralSpace 
 
 variable {X} in
 theorem generalizationHull.eq_sInter_of_isCompact [SpectralSpace X] {s : Set X} (hs : IsCompact s) :
-    ∃ S ⊆ {U : Set X | IsOpen U ∧ IsCompact U}, (generalizationHull s) = ⋂₀ S :=
-  sorry
+    ∃ S ⊆ {U : Set X | IsOpen U ∧ IsCompact U}, (generalizationHull s) = ⋂₀ S := by
+  refine ⟨{U : Set X | IsOpen U ∧ IsCompact U ∧ generalizationHull s ⊆ U},
+    fun _ h ↦ ⟨h.1, h.2.1⟩, subset_antisymm (fun _ hx _ hU ↦ hU.2.2 hx) ?_⟩
+  intro x hx
+  by_contra hxW
+  have hbasis := PrespectralSpace.isTopologicalBasis (X := X)
+  have hcov : ∀ y ∈ s, ∃ U, (IsOpen U ∧ IsCompact U) ∧ y ∈ U ∧ x ∉ U := by
+    intro y hy
+    have hxy : ¬ x ⤳ y := fun h ↦ hxW (mem_generalizationHull_iff.mpr ⟨y, hy, h⟩)
+    rw [specializes_iff_mem_closure] at hxy
+    obtain ⟨U, hU, hyU, hUsub⟩ :=
+      hbasis.exists_subset_of_mem_open hxy (isOpen_compl_iff.mpr isClosed_closure)
+    exact ⟨U, hU, hyU, fun hxU ↦ hUsub hxU (subset_closure rfl)⟩
+  choose U hU hyU hxnU using hcov
+  obtain ⟨t, ht⟩ := hs.elim_finite_subcover (fun y : s ↦ U y y.2)
+    (fun y ↦ (hU y y.2).1) (fun y hy ↦ Set.mem_iUnion.mpr ⟨⟨y, hy⟩, hyU y hy⟩)
+  set V := ⋃ y ∈ t, U y.1 y.2 with hV_def
+  have hVopen : IsOpen V := isOpen_biUnion fun y _ ↦ (hU y.1 y.2).1
+  have hVcompact : IsCompact V :=
+    t.finite_toSet.isCompact_biUnion fun y _ ↦ (hU y.1 y.2).2
+  have hWsub : generalizationHull s ⊆ V := fun z hz ↦ by
+    obtain ⟨y, hy, hzy⟩ := mem_generalizationHull_iff.mp hz
+    exact hzy.mem_open hVopen (ht hy)
+  have hxV : x ∈ V := hx V ⟨hVopen, hVcompact, hWsub⟩
+  obtain ⟨y, hyt, hxUy⟩ : ∃ y ∈ t, x ∈ U y.1 y.2 := by
+    simpa [hV_def] using hxV
+  exact hxnU y.1 y.2 hxUy

--- a/Proetale/Mathlib/Topology/Spectral/Basic.lean
+++ b/Proetale/Mathlib/Topology/Spectral/Basic.lean
@@ -43,16 +43,15 @@ instance SpectralSpace.prod [SpectralSpace X] [SpectralSpace Y] : SpectralSpace 
   toPrespectralSpace := inferInstance
 
 variable {X} in
-theorem generalizationHull.eq_sInter_of_isCompact [SpectralSpace X] {s : Set X} (hs : IsCompact s) :
-    ∃ S ⊆ {U : Set X | IsOpen U ∧ IsCompact U}, (generalizationHull s) = ⋂₀ S := by
-  refine ⟨{U : Set X | IsOpen U ∧ IsCompact U ∧ generalizationHull s ⊆ U},
-    fun _ h ↦ ⟨h.1, h.2.1⟩, subset_antisymm (fun _ hx _ hU ↦ hU.2.2 hx) ?_⟩
-  intro x hx
-  by_contra hxW
+/-- In a spectral space, if `s` is compact and `x` does not specialize to any point of `s`, then
+there exists a compact open containing `s` but not `x`. -/
+theorem IsCompact.exists_isOpen_isCompact_subset_of_forall_not_specializes [SpectralSpace X]
+    {s : Set X} (hs : IsCompact s) {x : X} (hxs : ∀ y ∈ s, ¬ x ⤳ y) :
+    ∃ V : Set X, IsOpen V ∧ IsCompact V ∧ s ⊆ V ∧ x ∉ V := by
   have hbasis := PrespectralSpace.isTopologicalBasis (X := X)
   have hcov : ∀ y ∈ s, ∃ U, (IsOpen U ∧ IsCompact U) ∧ y ∈ U ∧ x ∉ U := by
     intro y hy
-    have hxy : ¬ x ⤳ y := fun h ↦ hxW (mem_generalizationHull_iff.mpr ⟨y, hy, h⟩)
+    have hxy : ¬ x ⤳ y := hxs y hy
     rw [specializes_iff_mem_closure] at hxy
     obtain ⟨U, hU, hyU, hUsub⟩ :=
       hbasis.exists_subset_of_mem_open hxy (isOpen_compl_iff.mpr isClosed_closure)
@@ -60,14 +59,33 @@ theorem generalizationHull.eq_sInter_of_isCompact [SpectralSpace X] {s : Set X} 
   choose U hU hyU hxnU using hcov
   obtain ⟨t, ht⟩ := hs.elim_finite_subcover (fun y : s ↦ U y y.2)
     (fun y ↦ (hU y y.2).1) (fun y hy ↦ Set.mem_iUnion.mpr ⟨⟨y, hy⟩, hyU y hy⟩)
-  set V := ⋃ y ∈ t, U y.1 y.2 with hV_def
-  have hVopen : IsOpen V := isOpen_biUnion fun y _ ↦ (hU y.1 y.2).1
-  have hVcompact : IsCompact V :=
-    t.finite_toSet.isCompact_biUnion fun y _ ↦ (hU y.1 y.2).2
-  have hWsub : generalizationHull s ⊆ V := fun z hz ↦ by
-    obtain ⟨y, hy, hzy⟩ := mem_generalizationHull_iff.mp hz
-    exact hzy.mem_open hVopen (ht hy)
-  have hxV : x ∈ V := hx V ⟨hVopen, hVcompact, hWsub⟩
-  obtain ⟨y, hyt, hxUy⟩ : ∃ y ∈ t, x ∈ U y.1 y.2 := by
-    simpa [hV_def] using hxV
+  refine ⟨⋃ y ∈ t, U y.1 y.2, isOpen_biUnion fun y _ ↦ (hU y.1 y.2).1,
+    t.finite_toSet.isCompact_biUnion fun y _ ↦ (hU y.1 y.2).2, fun z hz ↦ ht hz, fun hxV ↦ ?_⟩
+  obtain ⟨y, hyt, hxUy⟩ : ∃ y ∈ t, x ∈ U y.1 y.2 := by simpa using hxV
   exact hxnU y.1 y.2 hxUy
+
+variable {X} in
+/-- In a spectral space, any compact set closed under generalization equals the intersection of
+all compact opens containing it. -/
+theorem IsCompact.eq_sInter_isOpen_isCompact_of_stableUnderGeneralization [SpectralSpace X]
+    {s : Set X} (hs : IsCompact s) (hgen : StableUnderGeneralization s) :
+    s = ⋂₀ {U : Set X | IsOpen U ∧ IsCompact U ∧ s ⊆ U} := by
+  refine subset_antisymm (fun _ hx _ hU ↦ hU.2.2 hx) fun x hx ↦ ?_
+  by_contra hxs
+  obtain ⟨V, hVopen, hVcompact, hsV, hxV⟩ :=
+    hs.exists_isOpen_isCompact_subset_of_forall_not_specializes
+      (fun y hy hxy ↦ hxs (hgen hxy hy))
+  exact hxV (hx V ⟨hVopen, hVcompact, hsV⟩)
+
+variable {X} in
+theorem generalizationHull.eq_sInter_of_isCompact [SpectralSpace X] {s : Set X} (hs : IsCompact s) :
+    ∃ S ⊆ {U : Set X | IsOpen U ∧ IsCompact U}, (generalizationHull s) = ⋂₀ S := by
+  refine ⟨{U : Set X | IsOpen U ∧ IsCompact U ∧ s ⊆ U}, fun _ h ↦ ⟨h.1, h.2.1⟩,
+    subset_antisymm (fun x hx U hU ↦ ?_) (fun x hx ↦ ?_)⟩
+  · obtain ⟨y, hys, hxy⟩ := mem_generalizationHull_iff.mp hx
+    exact hU.1.stableUnderGeneralization hxy (hU.2.2 hys)
+  · by_contra hxs
+    obtain ⟨V, hVopen, hVcompact, hsV, hxV⟩ :=
+      hs.exists_isOpen_isCompact_subset_of_forall_not_specializes
+        (fun y hy hxy ↦ hxs (mem_generalizationHull_iff.mpr ⟨y, hy, hxy⟩))
+    exact hxV (hx V ⟨hVopen, hVcompact, hsV⟩)


### PR DESCRIPTION
Fills the `sorry` in `generalizationHull.eq_sInter_of_isCompact` in `Proetale/Mathlib/Topology/Spectral/Basic.lean`.

This is the lemma [Stacks 0A31, (3) ⟹ (4)](https://stacks.math.columbia.edu/tag/0A31): in a spectral space, the generalization hull of a quasi-compact set is the intersection of the quasi-compact opens that contain it.

### Proof outline
Let `W := generalizationHull s` and take the family `S` of quasi-compact opens `U` with `W ⊆ U`. The inclusion `W ⊆ ⋂₀ S` is immediate. For `⋂₀ S ⊆ W`, suppose `x ∈ ⋂₀ S` with `x ∉ W`. Then for every `y ∈ s` we have `¬ x ⤳ y`, so `y` lies in the open set `(closure {x})ᶜ`. Using a basis of quasi-compact opens we find a quasi-compact open `U_y ∋ y` with `x ∉ U_y`. By quasi-compactness of `s` a finite subfamily covers `s`; its union `V` is a quasi-compact open with `s ⊆ V`, hence `W ⊆ V` (using `Specializes.mem_open`), and `x ∉ V`. So `V ∈ S` contradicts `x ∈ ⋂₀ S`.

The blueprint already references the lemma with `\leanok` (lemma:spectral-generalization-intersection-open) and `Proetale/Topology/SpectralSpace/WLocal/Basic.lean` already uses it; both still build after this change.

Sourced from the `archon` branch (issue #53).