### PR TITLE
feat(Mathlib/CategoryTheory): fill PreIndSpreads.of_univLE

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/MorphismProperty/IndSpreads.lean
+++ b/Proetale/Mathlib/CategoryTheory/MorphismProperty/IndSpreads.lean
@@ -49,8 +49,17 @@ lemma PreIndSpreads.of_isInitial [HasPushouts C] [P.IsStableUnderCobaseChange]
 
 lemma PreIndSpreads.of_univLE [UnivLE.{w, w'}] [PreIndSpreads.{w'} P] :
     PreIndSpreads.{w} P where
-  exists_isPushout {J} _ _ D c hc T f hf :=
-    sorry
+  exists_isPushout {J} _ _ D c hc T f hf := by
+    haveI : EssentiallySmall.{w'} J :=
+      @essentiallySmall_of_small_of_locallySmall J _ (UnivLE.small J) inferInstance
+    let e := equivSmallModel.{w'} J
+    let D' := e.inverse ⋙ D
+    let c' : Cocone D' := c.whisker e.inverse
+    have hc' : IsColimit c' :=
+      (Functor.Final.isColimitWhiskerEquiv e.inverse c).symm hc
+    haveI : IsFiltered (SmallModel.{w'} J) := IsFiltered.of_equivalence e
+    obtain ⟨j', T', f', g, hpb, hf'⟩ := P.exists_isPushout_of_isFiltered hc' f hf
+    exact ⟨e.inverse.obj j', T', f', g, hpb, hf'⟩
 
 /--
 - Given a `colim Dᵢ`-morphism `f : A = colim Dᵢ ⨿_[Dᵢ] A' ⟶ colim Dᵢ ⨿_[Dⱼ] B' = B`

--- a/Proetale/Mathlib/CategoryTheory/MorphismProperty/IndSpreads.lean
+++ b/Proetale/Mathlib/CategoryTheory/MorphismProperty/IndSpreads.lean
@@ -50,14 +50,14 @@ lemma PreIndSpreads.of_isInitial [HasPushouts C] [P.IsStableUnderCobaseChange]
 lemma PreIndSpreads.of_univLE [UnivLE.{w, w'}] [PreIndSpreads.{w'} P] :
     PreIndSpreads.{w} P where
   exists_isPushout {J} _ _ D c hc T f hf := by
-    haveI : EssentiallySmall.{w'} J :=
-      @essentiallySmall_of_small_of_locallySmall J _ (UnivLE.small J) inferInstance
+    have : Small.{w'} J := UnivLE.small J
+    have : EssentiallySmall.{w'} J := essentiallySmall_of_small_of_locallySmall J
     let e := equivSmallModel.{w'} J
     let D' := e.inverse ⋙ D
     let c' : Cocone D' := c.whisker e.inverse
     have hc' : IsColimit c' :=
       (Functor.Final.isColimitWhiskerEquiv e.inverse c).symm hc
-    haveI : IsFiltered (SmallModel.{w'} J) := IsFiltered.of_equivalence e
+    have : IsFiltered (SmallModel.{w'} J) := IsFiltered.of_equivalence e
     obtain ⟨j', T', f', g, hpb, hf'⟩ := P.exists_isPushout_of_isFiltered hc' f hf
     exact ⟨e.inverse.obj j', T', f', g, hpb, hf'⟩
 


### PR DESCRIPTION
Upstreamed from the `archon` branch.

`PreIndSpreads.of_univLE` previously held `sorry`; this PR fills it by passing through an equivalent small model of the filtered index category and appealing to the existing `PreIndSpreads.{w'} P` instance.

The proof uses:

- `essentiallySmall_of_small_of_locallySmall` + `UnivLE.small` to get `EssentiallySmall.{w'} J`;
- `equivSmallModel.{w'} J` to obtain a `SmallModel.{w'} J ≌ J` equivalence;
- `Functor.Final.isColimitWhiskerEquiv` to transport the colimit through the equivalence;
- `IsFiltered.of_equivalence` to keep the small model filtered.

Then `P.exists_isPushout_of_isFiltered` on the whiskered cocone provides the descent, which is reindexed by `e.inverse.obj j'`.

## Test plan
- [x] `lake build` is clean (no errors, no non-sorry warnings).
- [x] `lake exe mk_all --git --check` reports no update necessary.
