### PR TITLE
feat(CategoryTheory/MorphismProperty/Ind): fill four `univLE`/`unop` sorries

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/MorphismProperty/Ind.lean
+++ b/Proetale/Mathlib/CategoryTheory/MorphismProperty/Ind.lean
@@ -43,7 +43,10 @@ namespace ObjectProperty
 
 lemma ind_of_univLE (P : ObjectProperty C) [UnivLE.{w', w}] :
     ind.{w'} P ≤ ind.{w} P := by
-  sorry
+  intro X ⟨J, _, _, pres, H⟩
+  haveI : EssentiallySmall.{w} J :=
+    @essentiallySmall_of_small_of_locallySmall J _ (UnivLE.small J) inferInstance
+  exact of_essentiallySmall_index pres H
 
 @[gcongr]
 lemma ind_mono {P Q : ObjectProperty C} (h : P ≤ Q) :
@@ -59,7 +62,9 @@ instance [P.ContainsIdentities] : (ind.{w} P).ContainsIdentities where
   id_mem X := le_ind _ _ (P.id_mem X)
 
 lemma ind_of_univLE [UnivLE.{w', w}] : ind.{w'} P ≤ ind.{w} P := by
-  sorry
+  intro X Y f hf
+  rw [MorphismProperty.ind_iff_ind_underMk] at hf ⊢
+  exact ObjectProperty.ind_of_univLE P.underObj _ hf
 
 @[gcongr]
 lemma underObj_mono {P Q : MorphismProperty C} (h : P ≤ Q) (X : C) :
@@ -113,7 +118,13 @@ lemma pro_eq_unop_ind_op : pro.{w} P = (ind.{w} P.op).unop := by
       op_injective (hst _).2⟩⟩
 
 lemma ind_eq_unop_pro_op : ind.{w} P = (pro.{w} P.op).unop := by
-  sorry
+  ext X Y f
+  refine ⟨fun ⟨J, _, _, D, t, s, hs, hst⟩ ↦ ?_, fun ⟨J, _, _, D, t, s, hs, hst⟩ ↦ ?_⟩
+  · exact ⟨Jᵒᵖ, inferInstance, inferInstance, D.op, NatTrans.op t,
+      NatTrans.op s, hs.op, fun j ↦ ⟨(hst j.unop).1, by simp [← (hst j.unop).2]⟩⟩
+  · exact ⟨Jᵒᵖ, inferInstance, inferInstance, D.leftOp, NatTrans.leftOp t,
+      NatTrans.leftOp s, isColimitCoconeLeftOpOfCone D hs, fun j ↦ ⟨(hst j.unop).1,
+      Quiver.Hom.op_inj (hst j.unop).2⟩⟩
 
 @[gcongr]
 lemma unop_mono {P Q : MorphismProperty Cᵒᵖ} (h : P ≤ Q) : P.unop ≤ Q.unop :=
@@ -144,7 +155,8 @@ lemma pro_pro [LocallySmall.{w} C] (H : P ≤ isFinitelyPresentable.{w} C) :
 
 lemma pro_of_univLE [UnivLE.{w', w}] :
     pro.{w'} P ≤ pro.{w} P := by
-  sorry
+  grw [pro_eq_unop_ind_op, pro_eq_unop_ind_op]
+  exact unop_mono (ind_of_univLE P.op)
 
 @[gcongr]
 lemma pro_mono {P Q : MorphismProperty C} (h : P ≤ Q) : pro.{w} P ≤ pro.{w} Q := by

--- a/Proetale/Mathlib/CategoryTheory/MorphismProperty/Ind.lean
+++ b/Proetale/Mathlib/CategoryTheory/MorphismProperty/Ind.lean
@@ -44,8 +44,6 @@ namespace ObjectProperty
 lemma ind_of_univLE (P : ObjectProperty C) [UnivLE.{w', w}] :
     ind.{w'} P ≤ ind.{w} P := by
   intro X ⟨J, _, _, pres, H⟩
-  haveI : EssentiallySmall.{w} J :=
-    @essentiallySmall_of_small_of_locallySmall J _ (UnivLE.small J) inferInstance
   exact of_essentiallySmall_index pres H
 
 @[gcongr]


### PR DESCRIPTION
Upstreams four sorry-free proofs from the `archon` branch in
`Proetale/Mathlib/CategoryTheory/MorphismProperty/Ind.lean`:

- `ObjectProperty.ind_of_univLE`: closed via `essentiallySmall_of_small_of_locallySmall`
  and `of_essentiallySmall_index`.
- `MorphismProperty.ind_of_univLE`: reduced to the `ObjectProperty` version through
  `ind_iff_ind_underMk`.
- `ind_eq_unop_pro_op`: explicit construction of both directions using `D.op` /
  `D.leftOp`, `NatTrans.op` / `NatTrans.leftOp`, and
  `isColimitCoconeLeftOpOfCone`.
- `pro_of_univLE`: reduces to `ObjectProperty.ind_of_univLE` after rewriting with
  `pro_eq_unop_ind_op`.

The two remaining sorries in the file (`op_isFinitelyPresentable` and the
`IsStableUnderBaseChangeAlong` instance) are unrelated and untouched — they
are also open on `archon`.

Part of #53.