### PR TITLE
feat(Topology/SpectralSpace/Constructible): fill three sorries about constructible topology

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -84,6 +84,7 @@ import Proetale.Mathlib.Topology.Separation.Basic
 import Proetale.Mathlib.Topology.Separation.Hausdorff
 import Proetale.Mathlib.Topology.Sober
 import Proetale.Mathlib.Topology.Spectral.Basic
+import Proetale.Mathlib.Topology.Spectral.ConstructibleTopology
 import Proetale.Mathlib.Topology.Spectral.Prespectral
 import Proetale.Morphisms.ProAffineEtale
 import Proetale.Morphisms.WeaklyEtale

--- a/Proetale/Mathlib/Topology/Separation/Basic.lean
+++ b/Proetale/Mathlib/Topology/Separation/Basic.lean
@@ -9,3 +9,8 @@ lemma exists_isClosed_specializes {X : Type*} [TopologicalSpace X] [CompactSpace
     (Set.singleton_nonempty x |>.closure)
   use c, hc
   rwa [specializes_iff_mem_closure]
+
+/-- In a `T1Space`, every set is stable under specialization. -/
+lemma StableUnderSpecialization.of_t1Space {X : Type*} [TopologicalSpace X] [T1Space X]
+    (s : Set X) : StableUnderSpecialization s :=
+  fun _ _ hxy hx ↦ hxy.eq ▸ hx

--- a/Proetale/Mathlib/Topology/Spectral/ConstructibleTopology.lean
+++ b/Proetale/Mathlib/Topology/Spectral/ConstructibleTopology.lean
@@ -1,0 +1,12 @@
+import Mathlib.Topology.Spectral.ConstructibleTopology
+
+open Topology
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- A compact open is closed in the constructible topology. -/
+lemma IsCompact.isClosed_constructibleTopology_of_isOpen {s : Set X}
+    (hs : IsCompact s) (ho : IsOpen s) : IsClosed[constructibleTopology X] s := by
+  rw [← @isOpen_compl_iff]
+  apply TopologicalSpace.isOpen_generateFrom_of_mem
+  simp [constructibleTopologySubbasis, ho, hs]

--- a/Proetale/Topology/SpectralSpace/Constructible.lean
+++ b/Proetale/Topology/SpectralSpace/Constructible.lean
@@ -8,6 +8,7 @@ import Mathlib.Topology.Spectral.Basic
 import Mathlib.Topology.Spectral.ConstructibleTopology
 import Mathlib.Topology.JacobsonSpace
 import Mathlib.Data.Set.Card
+import Mathlib.Topology.Connected.Separation
 
 /-!
 # Constructible topology
@@ -25,8 +26,37 @@ it is the specialization of a point in `s`. -/
 @[stacks 0903 "(1)"]
 lemma exists_specializes_of_isClosed_constructibleTopology_of_mem_closure [SpectralSpace X]
     {s : Set X} (hs : IsClosed[constructibleTopology X] s) {x : X} (hx : x ∈ closure s) :
-    ∃ y ∈ s, y ⤳ x :=
-  sorry
+    ∃ y ∈ s, y ⤳ x := by
+  -- Compact opens are closed in the constructible topology.
+  have hU_closed_constr : ∀ (U : Set X), IsOpen U → IsCompact U →
+      @IsClosed (WithConstructibleTopology X) _ U := fun U hUo hUc => by
+    rw [← @isOpen_compl_iff (WithConstructibleTopology X)]
+    have hUcc : IsCompact Uᶜᶜ := by rwa [compl_compl]
+    exact hUcc.isOpen_constructibleTopology_of_isClosed hUo.isClosed_compl
+  -- The family of intersections `U ∩ s` indexed by compact opens `U` containing `x` consists of
+  -- closed sets in the constructible topology and has the finite intersection property in `X`
+  -- (since `x ∈ closure s` and any finite intersection of compact opens containing `x` is open).
+  let ι := { U : Set X // IsOpen U ∧ IsCompact U ∧ x ∈ U }
+  have hF_closed (i : ι) : @IsClosed (WithConstructibleTopology X) _ ((i : Set X) ∩ s) :=
+    (hU_closed_constr i i.2.1 i.2.2.1).inter hs
+  have h_inter : (⋂ i : ι, ((i : Set X) ∩ s)).Nonempty := by
+    refine CompactSpace.iInter_nonempty (X := WithConstructibleTopology X) hF_closed fun T => ?_
+    have hopen : IsOpen (⋂ j ∈ T, (j : Set X)) :=
+      Set.Finite.isOpen_biInter T.finite_toSet fun j _ => j.2.1
+    have hmem : x ∈ ⋂ j ∈ T, (j : Set X) := Set.mem_biInter fun j _ => j.2.2.2
+    obtain ⟨y, hyU, hys⟩ := mem_closure_iff_nhds.mp hx _ (hopen.mem_nhds hmem)
+    exact ⟨y, Set.mem_iInter₂.mpr fun j hj =>
+      ⟨(Set.mem_iInter₂.mp hyU) j hj, hys⟩⟩
+  -- Any point in the total intersection lies in `s` (taking `U = univ`) and specializes to `x`
+  -- (using that compact opens form a basis of the topology).
+  obtain ⟨y, hy⟩ := h_inter
+  rw [Set.mem_iInter] at hy
+  refine ⟨y, (hy ⟨Set.univ, isOpen_univ, CompactSpace.isCompact_univ, Set.mem_univ x⟩).2, ?_⟩
+  rw [specializes_iff_forall_open]
+  intro U hUo hxU
+  obtain ⟨W, ⟨hWo, hWc⟩, hxW, hWU⟩ :=
+    PrespectralSpace.isTopologicalBasis.exists_subset_of_mem_open hxU hUo
+  exact hWU (hy ⟨W, hWo, hWc, hxW⟩).1
 
 /-- If `s` is closed in the constructible topology and stable under specialization, it is closed. -/
 @[stacks 0903 "(2)"]
@@ -39,15 +69,42 @@ lemma IsClosed.of_isClosed_constructibleTopology [SpectralSpace X] {s : Set X}
     exists_specializes_of_isClosed_constructibleTopology_of_mem_closure hs hx
   exact h hx hy
 
+private lemma SpectralSpace.totallySeparatedSpace_of_isClosed_singleton [SpectralSpace X]
+    (h : ∀ x : X, IsClosed ({x} : Set X)) : TotallySeparatedSpace X := by
+  -- When all singletons are closed, the specialization order is discrete, so every subset is
+  -- stable under specialization.
+  have stable (s : Set X) : StableUnderSpecialization s := fun x y hxy hx => by
+    have hxy_eq : x = y := by
+      rw [specializes_iff_mem_closure, (h x).closure_eq, Set.mem_singleton_iff] at hxy
+      exact hxy.symm
+    rwa [← hxy_eq]
+  -- Hence every compact open `U` is clopen: it is constructibly closed (by
+  -- `IsCompact.isOpen_constructibleTopology_of_isClosed` applied to `Uᶜ`) and
+  -- specialization-stable.
+  have clopen (U : Set X) (hUo : IsOpen U) (hUc : IsCompact U) : IsClopen U := by
+    refine ⟨?_, hUo⟩
+    refine IsClosed.of_isClosed_constructibleTopology ?_ (stable U)
+    have hUcc : IsCompact Uᶜᶜ := by rwa [compl_compl]
+    exact @IsClosed.mk X (constructibleTopology X) U
+      (hUcc.isOpen_constructibleTopology_of_isClosed hUo.isClosed_compl)
+  -- Compact opens form a basis, so any two distinct points are separated by a clopen.
+  rw [totallySeparatedSpace_iff_exists_isClopen]
+  intro x y hxy
+  have hopen : IsOpen ({y} : Set X)ᶜ := (h y).isOpen_compl
+  obtain ⟨W, ⟨hWo, hWc⟩, hxW, hWy⟩ :=
+    PrespectralSpace.isTopologicalBasis.exists_subset_of_mem_open
+      (show x ∈ ({y} : Set X)ᶜ by simp [hxy]) hopen
+  refine ⟨W, clopen W hWo hWc, hxW, fun hyW => ?_⟩
+  exact hWy hyW (Set.mem_singleton y)
+
 @[stacks 0905 "(6) → (1)"]
 theorem SpectralSpace.t2Space_of_isClosed_singleton [SpectralSpace X]
     (h : ∀ x : X, IsClosed ({x} : Set X)) : T2Space X :=
-  sorry
+  letI := SpectralSpace.totallySeparatedSpace_of_isClosed_singleton h
+  inferInstance
 
 @[stacks 0905 "(6) → (1)"]
 theorem SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton [SpectralSpace X]
     (h : ∀ x : X, IsClosed ({x} : Set X)) : TotallyDisconnectedSpace X :=
-  sorry
--- use `isTotallyDisconnected_of_isClopen_set`
--- use `exists_specializes_of_isClosed_constructibleTopology_of_mem_closure,
--- IsClosed.of_isClosed_constructibleTopology`
+  letI := SpectralSpace.totallySeparatedSpace_of_isClosed_singleton h
+  inferInstance

--- a/Proetale/Topology/SpectralSpace/Constructible.lean
+++ b/Proetale/Topology/SpectralSpace/Constructible.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jiedong Jiang, Christian Merten
 -/
 import Proetale.Mathlib.Topology.Inseparable
+import Proetale.Mathlib.Topology.Separation.Basic
+import Proetale.Mathlib.Topology.Spectral.ConstructibleTopology
 import Mathlib.Topology.Spectral.Basic
-import Mathlib.Topology.Spectral.ConstructibleTopology
 import Mathlib.Topology.JacobsonSpace
 import Mathlib.Data.Set.Card
 import Mathlib.Topology.Connected.Separation
@@ -27,18 +28,14 @@ it is the specialization of a point in `s`. -/
 lemma exists_specializes_of_isClosed_constructibleTopology_of_mem_closure [SpectralSpace X]
     {s : Set X} (hs : IsClosed[constructibleTopology X] s) {x : X} (hx : x ∈ closure s) :
     ∃ y ∈ s, y ⤳ x := by
-  -- Compact opens are closed in the constructible topology.
-  have hU_closed_constr : ∀ (U : Set X), IsOpen U → IsCompact U →
-      @IsClosed (WithConstructibleTopology X) _ U := fun U hUo hUc => by
-    rw [← @isOpen_compl_iff (WithConstructibleTopology X)]
-    have hUcc : IsCompact Uᶜᶜ := by rwa [compl_compl]
-    exact hUcc.isOpen_constructibleTopology_of_isClosed hUo.isClosed_compl
   -- The family of intersections `U ∩ s` indexed by compact opens `U` containing `x` consists of
   -- closed sets in the constructible topology and has the finite intersection property in `X`
   -- (since `x ∈ closure s` and any finite intersection of compact opens containing `x` is open).
   let ι := { U : Set X // IsOpen U ∧ IsCompact U ∧ x ∈ U }
   have hF_closed (i : ι) : @IsClosed (WithConstructibleTopology X) _ ((i : Set X) ∩ s) :=
-    (hU_closed_constr i i.2.1 i.2.2.1).inter hs
+    have : @IsClosed (WithConstructibleTopology X) _ (i : Set X) :=
+      i.2.2.1.isClosed_constructibleTopology_of_isOpen i.2.1
+    this.inter hs
   have h_inter : (⋂ i : ι, ((i : Set X) ∩ s)).Nonempty := by
     refine CompactSpace.iInter_nonempty (X := WithConstructibleTopology X) hF_closed fun T => ?_
     have hopen : IsOpen (⋂ j ∈ T, (j : Set X)) :=
@@ -69,42 +66,19 @@ lemma IsClosed.of_isClosed_constructibleTopology [SpectralSpace X] {s : Set X}
     exists_specializes_of_isClosed_constructibleTopology_of_mem_closure hs hx
   exact h hx hy
 
-private lemma SpectralSpace.totallySeparatedSpace_of_isClosed_singleton [SpectralSpace X]
-    (h : ∀ x : X, IsClosed ({x} : Set X)) : TotallySeparatedSpace X := by
-  -- When all singletons are closed, the specialization order is discrete, so every subset is
-  -- stable under specialization.
-  have stable (s : Set X) : StableUnderSpecialization s := fun x y hxy hx => by
-    have hxy_eq : x = y := by
-      rw [specializes_iff_mem_closure, (h x).closure_eq, Set.mem_singleton_iff] at hxy
-      exact hxy.symm
-    rwa [← hxy_eq]
-  -- Hence every compact open `U` is clopen: it is constructibly closed (by
-  -- `IsCompact.isOpen_constructibleTopology_of_isClosed` applied to `Uᶜ`) and
-  -- specialization-stable.
-  have clopen (U : Set X) (hUo : IsOpen U) (hUc : IsCompact U) : IsClopen U := by
-    refine ⟨?_, hUo⟩
-    refine IsClosed.of_isClosed_constructibleTopology ?_ (stable U)
-    have hUcc : IsCompact Uᶜᶜ := by rwa [compl_compl]
-    exact @IsClosed.mk X (constructibleTopology X) U
-      (hUcc.isOpen_constructibleTopology_of_isClosed hUo.isClosed_compl)
+@[stacks 0905 "(6) → (1)"]
+instance SpectralSpace.totallySeparatedSpace [SpectralSpace X] [T1Space X] :
+    TotallySeparatedSpace X := by
+  -- Every compact open `U` is clopen: it is constructibly closed (by
+  -- `IsCompact.isClosed_constructibleTopology_of_isOpen`) and specialization-stable
+  -- because `X` is T1.
+  have clopen (U : Set X) (hUo : IsOpen U) (hUc : IsCompact U) : IsClopen U :=
+    ⟨(hUc.isClosed_constructibleTopology_of_isOpen hUo).of_isClosed_constructibleTopology
+      (.of_t1Space U), hUo⟩
   -- Compact opens form a basis, so any two distinct points are separated by a clopen.
   rw [totallySeparatedSpace_iff_exists_isClopen]
   intro x y hxy
-  have hopen : IsOpen ({y} : Set X)ᶜ := (h y).isOpen_compl
   obtain ⟨W, ⟨hWo, hWc⟩, hxW, hWy⟩ :=
     PrespectralSpace.isTopologicalBasis.exists_subset_of_mem_open
-      (show x ∈ ({y} : Set X)ᶜ by simp [hxy]) hopen
-  refine ⟨W, clopen W hWo hWc, hxW, fun hyW => ?_⟩
-  exact hWy hyW (Set.mem_singleton y)
-
-@[stacks 0905 "(6) → (1)"]
-theorem SpectralSpace.t2Space_of_isClosed_singleton [SpectralSpace X]
-    (h : ∀ x : X, IsClosed ({x} : Set X)) : T2Space X :=
-  letI := SpectralSpace.totallySeparatedSpace_of_isClosed_singleton h
-  inferInstance
-
-@[stacks 0905 "(6) → (1)"]
-theorem SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton [SpectralSpace X]
-    (h : ∀ x : X, IsClosed ({x} : Set X)) : TotallyDisconnectedSpace X :=
-  letI := SpectralSpace.totallySeparatedSpace_of_isClosed_singleton h
-  inferInstance
+      (show x ∈ ({y} : Set X)ᶜ by simp [hxy]) isClosed_singleton.isOpen_compl
+  exact ⟨W, clopen W hWo hWc, hxW, fun hyW ↦ hWy hyW rfl⟩

--- a/Proetale/Topology/SpectralSpace/Constructible.lean
+++ b/Proetale/Topology/SpectralSpace/Constructible.lean
@@ -32,10 +32,10 @@ lemma exists_specializes_of_isClosed_constructibleTopology_of_mem_closure [Spect
   -- closed sets in the constructible topology and has the finite intersection property in `X`
   -- (since `x ∈ closure s` and any finite intersection of compact opens containing `x` is open).
   let ι := { U : Set X // IsOpen U ∧ IsCompact U ∧ x ∈ U }
-  have hF_closed (i : ι) : @IsClosed (WithConstructibleTopology X) _ ((i : Set X) ∩ s) :=
-    have : @IsClosed (WithConstructibleTopology X) _ (i : Set X) :=
+  have hF_closed (i : ι) : IsClosed[constructibleTopology X] ((i : Set X) ∩ s) :=
+    have hi : IsClosed[constructibleTopology X] (i : Set X) :=
       i.2.2.1.isClosed_constructibleTopology_of_isOpen i.2.1
-    this.inter hs
+    @IsClosed.inter X _ _ (constructibleTopology X) hi hs
   have h_inter : (⋂ i : ι, ((i : Set X) ∩ s)).Nonempty := by
     refine CompactSpace.iInter_nonempty (X := WithConstructibleTopology X) hF_closed fun T => ?_
     have hopen : IsOpen (⋂ j ∈ T, (j : Set X)) :=

--- a/Proetale/Topology/SpectralSpace/WLocal/Basic.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Basic.lean
@@ -117,13 +117,6 @@ lemma Topology.IsClosedEmbedding.wLocalSpace {f : X → Y} (hf : IsClosedEmbeddi
   hf.isEmbedding.wLocalSpace_of_stableUnderSpecialization_range
     hf.isClosedMap.isClosed_range.stableUnderSpecialization
 
--- In process of being PRed to mathlib #39332
-lemma IsCompact.isClosed_constructibleTopology_of_isOpen {s : Set X}
-    (hs : IsCompact s) (ho : IsOpen s) : IsClosed[constructibleTopology X] s := by
-  rw [← @isOpen_compl_iff]
-  apply TopologicalSpace.isOpen_generateFrom_of_mem
-  simp [constructibleTopologySubbasis, ho, hs]
-
 lemma isClosed_generalizationHull_of_wLocalSpace [WLocalSpace X] {s : Set X} (hs : IsClosed s) :
     IsClosed (generalizationHull s) := by
   have ⟨u, hu1, hu2⟩ := generalizationHull.eq_sInter_of_isCompact

--- a/Proetale/Topology/SpectralSpace/WLocal/ClosedPoints.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/ClosedPoints.lean
@@ -20,16 +20,11 @@ namespace WLocalSpace
 instance spectralSpace_closedPoints [WLocalSpace X] : SpectralSpace (closedPoints X) :=
   SpectralSpace.of_isClosed X
 
-instance t2Space_closedPoints [WLocalSpace X] :
-    T2Space (closedPoints X) :=
-  SpectralSpace.t2Space_of_isClosed_singleton  closedPoints.isClosed_singleton
+instance t1Space_closedPoints : T1Space (closedPoints X) where
+  t1 := closedPoints.isClosed_singleton
 
 instance CompactSpace_closedPoints [WLocalSpace X] :
     CompactSpace (closedPoints X) :=
   (IsClosed.isClosedEmbedding_subtypeVal inferInstance).compactSpace
-
-instance totallyDisconnected_closedPoints [WLocalSpace X] :
-    TotallyDisconnectedSpace (closedPoints X) :=
-  SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton closedPoints.isClosed_singleton
 
 end WLocalSpace

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -900,7 +900,7 @@ Obviously, every w-purely-local morphism is w-local.
 \begin{lemma}[{\cite[\href{https://stacks.math.columbia.edu/tag/0905}{Tag 0905}, (6) $\implies$ (1)]{stacks-project}}]
   Let $X$ be a spectral space such that every point is closed. Then $X$ is profinite.
   \label{lemma:spectral-closed-points-profinite}
-  \lean{SpectralSpace.t2Space_of_isClosed_singleton,SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton}
+  \lean{SpectralSpace.totallySeparatedSpace}
   \leanok
 \end{lemma}
 
@@ -913,7 +913,7 @@ Obviously, every w-purely-local morphism is w-local.
     Let $X$ be a w-local space. Then the set of closed points $X^c$ of $X$ is profinite.
     \uses{def:w-local-space}
     \label{lemma:w-local-closed-points-profinite}
-    \lean{WLocalSpace.t2Space_closedPoints,WLocalSpace.CompactSpace_closedPoints,WLocalSpace.totallyDisconnected_closedPoints}
+    \lean{WLocalSpace.CompactSpace_closedPoints}
     \leanok
 \end{lemma}
 

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -150,7 +150,7 @@ of this property.
 \end{proof}
 
 \begin{lemma}[\stacksproject{092J}]
-    \lemma{lem:weakly-etale-comp}
+    \label{lem:weakly-etale-comp}
     If $A \to B$ and $B \to C$ are weakly étale, then $A \to C$ is weakly étale.
 \end{lemma}
 


### PR DESCRIPTION
Fills three sorries in `Proetale/Topology/SpectralSpace/Constructible.lean` upstreamed from the `archon` branch.

## Summary

- `exists_specializes_of_isClosed_constructibleTopology_of_mem_closure` (Stacks 0903 (1)): a point in the closure of a constructibly-closed set `s` is a specialization of some point in `s`. The proof uses the compactness of `WithConstructibleTopology X` (applied to the family of closed sets `(U ∩ s)` indexed by compact opens `U ∋ x`) together with the fact that compact opens form a basis of the topology of a spectral space.
- `SpectralSpace.t2Space_of_isClosed_singleton` and `SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton` (Stacks 0905 (6) → (1)): both follow from the new private helper `SpectralSpace.totallySeparatedSpace_of_isClosed_singleton`. That helper observes that if all singletons are closed, every subset is stable under specialization, so by `IsClosed.of_isClosed_constructibleTopology` every compact open is clopen — and compact opens form a basis, so any two distinct points are separated by a clopen.

Adds an import of `Mathlib.Topology.Connected.Separation` for `totallySeparatedSpace_iff_exists_isClopen` and the `TotallySeparatedSpace → T2Space` / `→ TotallyDisconnectedSpace` instances.

## Test plan

- [x] `lake build Proetale.Topology.SpectralSpace.Constructible` succeeds with no warnings.
- [x] Full `lake build` succeeds (no downstream regressions).