### PR TITLE
feat(Topology/Comparison/Etale): fill `isContinuous_toProEtale`

### DIFF
--- a/Proetale/Topology/Comparison/Etale.lean
+++ b/Proetale/Topology/Comparison/Etale.lean
@@ -32,10 +32,28 @@ instance : (toProEtale S).Full :=
 instance : (toProEtale S).Faithful :=
   inferInstanceAs <| (MorphismProperty.Over.changeProp _ etale_le_weaklyEtale le_rfl).Faithful
 
+instance : HasFiniteLimits S.Etale :=
+  inferInstanceAs <| HasFiniteLimits (MorphismProperty.Over @Etale ⊤ S)
+
+instance : PreservesFiniteLimits (toProEtale S) := by
+  have : PreservesFiniteLimits (toProEtale S ⋙ ProEt.forget S) :=
+    inferInstanceAs <| PreservesFiniteLimits (MorphismProperty.Over.forget @Etale ⊤ S)
+  exact preservesFiniteLimits_of_reflects_of_preserves (toProEtale S) (ProEt.forget S)
+
+instance representablyFlat_toProEtale : RepresentablyFlat (toProEtale S) :=
+  flat_of_preservesFiniteLimits _
+
 /-- The inclusion of the étale site into the pro-étale site is continuous. -/
 instance isContinuous_toProEtale :
     (toProEtale S).IsContinuous (smallEtaleTopology S) (ProEt.topology S) := by
-  sorry
+  refine Functor.isContinuous_of_coverPreserving
+    (compatiblePreservingOfFlat _ (toProEtale S)) ?_
+  refine ⟨fun {X R} hR ↦ ?_⟩
+  rw [ProEt.topology_eq_inducedTopology, Functor.mem_inducedTopology_sieves_iff,
+    ← Sieve.functorPushforward_comp]
+  have hR' : R.functorPushforward (Over.forget @Etale ⊤ S) ∈ etaleTopology.over S _ := hR
+  rw [GrothendieckTopology.mem_over_iff] at hR' ⊢
+  exact etaleTopology_le_proetaleTopology _ hR'
 
 namespace ProEt
 


### PR DESCRIPTION
Upstreams the `isContinuous_toProEtale` proof and its supporting instances
from the `archon` branch.

## Changes

In `Proetale/Topology/Comparison/Etale.lean`, four sorry-free instances are added:

- `HasFiniteLimits S.Etale` — transferred from
  `HasFiniteLimits (MorphismProperty.Over @Etale ⊤ S)`.
- `PreservesFiniteLimits (toProEtale S)` — via
  `preservesFiniteLimits_of_reflects_of_preserves` using that
  `toProEtale S ⋙ ProEt.forget S = Over.forget @Etale ⊤ S`.
- `RepresentablyFlat (toProEtale S)` — from `flat_of_preservesFiniteLimits`.
- `isContinuous_toProEtale` (was `sorry`) — via
  `Functor.isContinuous_of_coverPreserving` with `compatiblePreservingOfFlat`
  for compatibility and `etaleTopology_le_proetaleTopology` for the
  cover-preservation step.

The remaining `sorry` on `isIso_unit_sheafAdjunction` is unrelated and
untouched.

## Verification

- `lake build` succeeds with no errors or warnings (other than the
  pre-existing `declaration uses 'sorry'` messages).

Resolves part of #53.