### PR TITLE
feat(Algebra/WLocalization): fill `indZariski` sorry

### DIFF
--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -262,51 +262,34 @@ lemma zeroLocus_ideal_eq : zeroLocus (ideal A) = closedPoints (PrimeSpectrum (WL
 instance isWLocalRing : IsWLocalRing (WLocalization A) :=
   sorry
 
-/-- `Stratification.Index E` is finite: each index is determined by its `left` ⊆ E,
-since `right = E \ left`. -/
-private instance finite_stratification_index (E : Finset A) :
-    Finite (Stratification.Index E) := by
+instance (E : Finset A) : Finite (Stratification.Index E) := by
   classical
-  have left_mem : ∀ i : Stratification.Index E, i.left ∈ E.powerset := fun i =>
-    Finset.mem_powerset.mpr fun a ha =>
-      Finset.mem_coe.mp (i.union_eq ▸ Set.mem_union_left _ (Finset.mem_coe.mpr ha))
-  apply Finite.of_injective
-    (fun i => (⟨i.left, left_mem i⟩ : {s // s ∈ E.powerset}))
-  intro i j hij
-  simp only [Subtype.mk.injEq] at hij
-  have hri : ∀ k : Stratification.Index E, k.right = E \ k.left := by
-    intro k
+  refine Finite.of_injective (β := Set ↥E × Set ↥E)
+    (fun i ↦ ((↑) ⁻¹' (i.left : Set A), (↑) ⁻¹' (i.right : Set A))) ?_
+  rintro ⟨l₁, r₁, _, u₁⟩ ⟨l₂, r₂, _, u₂⟩ heq
+  obtain ⟨hL, hR⟩ := Prod.mk.inj heq
+  have aux : ∀ {s₁ s₂ : Finset A}, (s₁ : Set A) ⊆ E → (s₂ : Set A) ⊆ E →
+      ((↑) : ↥E → A) ⁻¹' (s₁ : Set A) = ((↑) : ↥E → A) ⁻¹' (s₂ : Set A) → s₁ = s₂ := by
+    intro s₁ s₂ h₁ h₂ hst
     ext a
-    simp only [Finset.mem_sdiff]
-    refine ⟨fun ha => ⟨?_, ?_⟩, fun ⟨haE, hal⟩ => ?_⟩
-    · exact Finset.mem_coe.mp
-        (k.union_eq ▸ Set.mem_union_right _ (Finset.mem_coe.mpr ha))
-    · exact fun h => Finset.disjoint_left.mp k.disjoint h ha
-    · have hmem : (a : A) ∈ (k.left : Set A) ∪ (k.right : Set A) :=
-        k.union_eq ▸ Finset.mem_coe.mpr haE
-      exact hmem.resolve_left (Finset.mem_coe.mp · |> hal)
-  have hr : i.right = j.right := by rw [hri i, hri j, hij]
-  cases i; cases j; simp only [Stratification.Index.mk.injEq]; exact ⟨hij, hr⟩
+    refine ⟨fun ha ↦ (Set.ext_iff.mp hst ⟨a, h₁ ha⟩).mp ha,
+            fun ha ↦ (Set.ext_iff.mp hst ⟨a, h₂ ha⟩).mpr ha⟩
+  have sub : ∀ {l r : Finset A}, (l : Set A) ∪ r = E →
+      (l : Set A) ⊆ E ∧ (r : Set A) ⊆ E :=
+    fun h ↦ ⟨fun a ha ↦ h ▸ Set.mem_union_left _ ha,
+            fun a ha ↦ h ▸ Set.mem_union_right _ ha⟩
+  obtain ⟨hl₁, hr₁⟩ := sub u₁
+  obtain ⟨hl₂, hr₂⟩ := sub u₂
+  exact (Stratification.Index.mk.injEq ..).mpr ⟨aux hl₁ hl₂ hL, aux hr₁ hr₂ hR⟩
 
-set_option maxHeartbeats 1200000 in
--- Typeclass synthesis here unfolds the (definitionally large) `ProdStrata` and
--- `Generalization` definitions, so the higher heartbeat limit is needed.
-private lemma prodStrata_indZariski (E : Finset A) :
+lemma indZariski_prodStrata (E : Finset A) :
     Algebra.IndZariski A (ProdStrata E) := by
   change Algebra.IndZariski A
     (∀ i : Stratification.Index E, Generalization i.function i.ideal)
-  obtain ⟨n, ⟨e_fin⟩⟩ := Finite.exists_equiv_fin (Stratification.Index E)
-  let e : ULift.{u} (Fin n) ≃ Stratification.Index E :=
-    Equiv.ulift.trans e_fin.symm
-  let S : Stratification.Index E → Type u := fun i => Generalization i.function i.ideal
-  have h1 : Algebra.IndZariski A (∀ k : ULift.{u} (Fin n), S (e k)) :=
-    Algebra.IndZariski.pi A (fun k => S (e k))
-  exact Algebra.IndZariski.of_equiv
-    (R := A) (S := ∀ k : ULift.{u} (Fin n), S (e k)) (T := ∀ i, S i)
-    (AlgEquiv.piCongrLeft A S e)
+  exact Algebra.IndZariski.pi A _
 
 instance indZariski : Algebra.IndZariski A (WLocalization A) := by
-  have h := fun E => prodStrata_indZariski (A := A) E
+  have h := fun E => indZariski_prodStrata (A := A) E
   exact @Algebra.IndZariski.of_colimitPresentation A (WLocalization A) _ _ _
     (Finset A) _ _ colimitPresentation h
 

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -262,8 +262,53 @@ lemma zeroLocus_ideal_eq : zeroLocus (ideal A) = closedPoints (PrimeSpectrum (WL
 instance isWLocalRing : IsWLocalRing (WLocalization A) :=
   sorry
 
-instance indZariski : Algebra.IndZariski A (WLocalization A) :=
-  sorry
+/-- `Stratification.Index E` is finite: each index is determined by its `left` ⊆ E,
+since `right = E \ left`. -/
+private instance finite_stratification_index (E : Finset A) :
+    Finite (Stratification.Index E) := by
+  classical
+  have left_mem : ∀ i : Stratification.Index E, i.left ∈ E.powerset := fun i =>
+    Finset.mem_powerset.mpr fun a ha =>
+      Finset.mem_coe.mp (i.union_eq ▸ Set.mem_union_left _ (Finset.mem_coe.mpr ha))
+  apply Finite.of_injective
+    (fun i => (⟨i.left, left_mem i⟩ : {s // s ∈ E.powerset}))
+  intro i j hij
+  simp only [Subtype.mk.injEq] at hij
+  have hri : ∀ k : Stratification.Index E, k.right = E \ k.left := by
+    intro k
+    ext a
+    simp only [Finset.mem_sdiff]
+    refine ⟨fun ha => ⟨?_, ?_⟩, fun ⟨haE, hal⟩ => ?_⟩
+    · exact Finset.mem_coe.mp
+        (k.union_eq ▸ Set.mem_union_right _ (Finset.mem_coe.mpr ha))
+    · exact fun h => Finset.disjoint_left.mp k.disjoint h ha
+    · have hmem : (a : A) ∈ (k.left : Set A) ∪ (k.right : Set A) :=
+        k.union_eq ▸ Finset.mem_coe.mpr haE
+      exact hmem.resolve_left (Finset.mem_coe.mp · |> hal)
+  have hr : i.right = j.right := by rw [hri i, hri j, hij]
+  cases i; cases j; simp only [Stratification.Index.mk.injEq]; exact ⟨hij, hr⟩
+
+set_option maxHeartbeats 1200000 in
+-- Typeclass synthesis here unfolds the (definitionally large) `ProdStrata` and
+-- `Generalization` definitions, so the higher heartbeat limit is needed.
+private lemma prodStrata_indZariski (E : Finset A) :
+    Algebra.IndZariski A (ProdStrata E) := by
+  change Algebra.IndZariski A
+    (∀ i : Stratification.Index E, Generalization i.function i.ideal)
+  obtain ⟨n, ⟨e_fin⟩⟩ := Finite.exists_equiv_fin (Stratification.Index E)
+  let e : ULift.{u} (Fin n) ≃ Stratification.Index E :=
+    Equiv.ulift.trans e_fin.symm
+  let S : Stratification.Index E → Type u := fun i => Generalization i.function i.ideal
+  have h1 : Algebra.IndZariski A (∀ k : ULift.{u} (Fin n), S (e k)) :=
+    Algebra.IndZariski.pi A (fun k => S (e k))
+  exact Algebra.IndZariski.of_equiv
+    (R := A) (S := ∀ k : ULift.{u} (Fin n), S (e k)) (T := ∀ i, S i)
+    (AlgEquiv.piCongrLeft A S e)
+
+instance indZariski : Algebra.IndZariski A (WLocalization A) := by
+  have h := fun E => prodStrata_indZariski (A := A) E
+  exact @Algebra.IndZariski.of_colimitPresentation A (WLocalization A) _ _ _
+    (Finset A) _ _ colimitPresentation h
 
 instance faithfullyFlat : Module.FaithfullyFlat A (WLocalization A) :=
   sorry


### PR DESCRIPTION
## Summary

Fills the `Algebra.IndZariski A (WLocalization A)` instance (previously `sorry`) in `Proetale/Algebra/WLocalization/Basic.lean`.

The proof applies `Algebra.IndZariski.of_colimitPresentation` to the existing `colimitPresentation` of the `WLocalization` as the colimit of the `ProdStrata` algebras. The supporting facts:

- A private `Finite (Stratification.Index E)` instance: every index is determined by its `left` component (since `right = E \ left`).
- A private `prodStrata_indZariski` helper: `ProdStrata E` is a finite product of generalizations, each already known to be ind-Zariski. The proof reduces the index type to `ULift (Fin n)` via `AlgEquiv.piCongrLeft` before applying `Algebra.IndZariski.pi`, which keeps the typeclass synthesis tractable.

Upstreamed from the `archon` branch.

## Test plan

- [x] `lake build Proetale.Algebra.WLocalization.Basic` succeeds.
- [x] Full `lake build` succeeds with no new warnings.
