### PR TITLE
feat(Topology/Flat/QuasiCompactCover): fill sorry for finite affine cover

### DIFF
--- a/Proetale/Topology/Flat/QuasiCompactCover.lean
+++ b/Proetale/Topology/Flat/QuasiCompactCover.lean
@@ -89,7 +89,12 @@ lemma exists_hom [P.IsMultiplicative] {S : Scheme.{u}} (𝒰 : S.Cover (precover
   · infer_instance
 
 instance {S : Scheme.{u}} [IsAffine S] (𝒰 : S.AffineCover P) [Finite 𝒰.I₀] :
-    QuasiCompactCover 𝒰.cover.toPreZeroHypercover :=
-  sorry
+    QuasiCompactCover 𝒰.cover.toPreZeroHypercover where
+  isCompactOpenCovered_of_isAffineOpen {U} hU := by
+    have : Finite 𝒰.cover.I₀ := inferInstanceAs (Finite 𝒰.I₀)
+    have (i : 𝒰.I₀) : IsAffine (𝒰.cover.X i) := isAffine_Spec _
+    have (i : 𝒰.I₀) : QuasiCompact (𝒰.cover.f i) := inferInstance
+    exact .of_finite_of_isSpectralMap (fun i ↦ (𝒰.cover.f i).isSpectralMap)
+      (fun x _ ↦ ⟨𝒰.idx x, 𝒰.covers x⟩) U.2 hU.isCompact
 
 end AlgebraicGeometry.Scheme.Cover.QuasiCompact


### PR DESCRIPTION
## Summary

Replaces the `sorry` in the `QuasiCompactCover 𝒰.cover.toPreZeroHypercover` instance for a finite `AffineCover` of an affine scheme in `Proetale/Topology/Flat/QuasiCompactCover.lean`.

The proof goes through `IsCompactOpenCovered.of_finite_of_isSpectralMap`:
- the component maps `𝒰.cover.f i` all go between affine schemes hence are quasi-compact, hence spectral;
- the cover surjectivity comes directly from the `AffineCover.covers` field.

Proof was lifted from the `archon` branch (issue #53).

## Test plan

- [ ] `lake build Proetale.Topology.Flat.QuasiCompactCover` succeeds.
- [ ] CI green.
