### PR TITLE
feat(Mathlib/CategoryTheory/Sites/InducedTopology): fill `IsCocontinuous.of_iso` sorry

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/Sites/InducedTopology.lean
+++ b/Proetale/Mathlib/CategoryTheory/Sites/InducedTopology.lean
@@ -144,7 +144,11 @@ lemma Functor.IsCocontinuous.of_iso {J : GrothendieckTopology C} {K : Grothendie
     {F G : C ⥤ D} (e : F ≅ G) [F.IsCocontinuous J K] :
     G.IsCocontinuous J K where
   cover_lift {U} S hS := by
-    sorry
+    refine J.superset_covering ?_
+      (F.cover_lift J K (K.pullback_stable (e.hom.app U) hS))
+    intro Y f (hf : S.arrows (F.map f ≫ e.hom.app U))
+    have := S.downward_closed hf (e.inv.app Y)
+    rwa [e.hom.naturality f, ← Category.assoc, Iso.inv_hom_id_app, Category.id_comp] at this
 
 lemma Functor.IsCocontinuous.iff_of_iso {J : GrothendieckTopology C} {K : GrothendieckTopology D}
     {F G : C ⥤ D} (e : F ≅ G) :


### PR DESCRIPTION
Fill the sorry in `Functor.IsCocontinuous.of_iso`: if `F ≅ G` and `F`
is cocontinuous between two Grothendieck topologies, then so is `G`.

Given a `K`-covering sieve `S` on `G.obj U`, pull it back along
`e.hom.app U` to get a `K`-cover, then lift via `F`'s cocontinuity.
Naturality `F.map f ≫ e.hom.app U = e.hom.app Y ≫ G.map f` together
with the downward closure of `S` along `e.inv.app Y` produces the
required `S.arrows (G.map f)`, so the lifted sieve is contained in
`Sieve.functorPullback G S`.

This unblocks `Functor.IsCocontinuous.iff_of_iso` and
`Functor.coinducedTopology_eq_of_iso`, which already consume `of_iso`
in both directions.

Part of the upstreaming effort from the `archon` branch (issue #53).