### PR TITLE
feat(Topology/SpectralSpace): T2 and totally disconnected closed points

### DIFF
--- a/Proetale/Topology/SpectralSpace/Constructible.lean
+++ b/Proetale/Topology/SpectralSpace/Constructible.lean
@@ -82,3 +82,17 @@ instance SpectralSpace.totallySeparatedSpace [SpectralSpace X] [T1Space X] :
     PrespectralSpace.isTopologicalBasis.exists_subset_of_mem_open
       (show x ∈ ({y} : Set X)ᶜ by simp [hxy]) isClosed_singleton.isOpen_compl
   exact ⟨W, clopen W hWo hWc, hxW, fun hyW ↦ hWy hyW rfl⟩
+
+/-- A spectral space in which every singleton is closed is Hausdorff. -/
+@[stacks 0905 "(6) → (1)"]
+theorem SpectralSpace.t2Space_of_isClosed_singleton [SpectralSpace X]
+    (h : ∀ x : X, IsClosed ({x} : Set X)) : T2Space X :=
+  haveI : T1Space X := ⟨h⟩
+  inferInstance
+
+/-- A spectral space in which every singleton is closed is totally disconnected. -/
+@[stacks 0905 "(6) → (1)"]
+theorem SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton [SpectralSpace X]
+    (h : ∀ x : X, IsClosed ({x} : Set X)) : TotallyDisconnectedSpace X :=
+  haveI : T1Space X := ⟨h⟩
+  inferInstance

--- a/Proetale/Topology/SpectralSpace/WLocal/ClosedPoints.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/ClosedPoints.lean
@@ -23,8 +23,15 @@ instance spectralSpace_closedPoints [WLocalSpace X] : SpectralSpace (closedPoint
 instance t1Space_closedPoints : T1Space (closedPoints X) where
   t1 := closedPoints.isClosed_singleton
 
+instance t2Space_closedPoints [WLocalSpace X] : T2Space (closedPoints X) :=
+  SpectralSpace.t2Space_of_isClosed_singleton closedPoints.isClosed_singleton
+
 instance CompactSpace_closedPoints [WLocalSpace X] :
     CompactSpace (closedPoints X) :=
   (IsClosed.isClosedEmbedding_subtypeVal inferInstance).compactSpace
+
+instance totallyDisconnectedSpace_closedPoints [WLocalSpace X] :
+    TotallyDisconnectedSpace (closedPoints X) :=
+  SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton closedPoints.isClosed_singleton
 
 end WLocalSpace


### PR DESCRIPTION
Adds:

- `SpectralSpace.t2Space_of_isClosed_singleton`
- `SpectralSpace.totallyDisconnectedSpace_of_isClosed_singleton`
- `WLocalSpace.t2Space_closedPoints`
- `WLocalSpace.totallyDisconnectedSpace_closedPoints`

The first two are derived from the existing `SpectralSpace.totallySeparatedSpace`
instance and are used to register the `T2Space` and `TotallyDisconnectedSpace`
instances on the closed points of a w-local space.

Upstreamed from the `archon` branch.