### PR TITLE
feat(Morphisms/WeaklyEtale): fill `Etale` and `Spec_iff` sorries

### DIFF
--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -228,4 +228,11 @@ lemma weaklyEtale_algebraMap_iff [Algebra R S] :
     (algebraMap R S).WeaklyEtale ↔ Algebra.WeaklyEtale R S := by
   rw [WeaklyEtale, toAlgebra_algebraMap]
 
+/-- A weakly étale ring map is formally unramified. -/
+lemma WeaklyEtale.formallyUnramified {f : R →+* S} (hf : f.WeaklyEtale) :
+    f.FormallyUnramified := by
+  algebraize [f]
+  have : Algebra.WeaklyEtale R S := hf
+  exact (inferInstance : Algebra.FormallyUnramified R S)
+
 end RingHom

--- a/Proetale/Morphisms/WeaklyEtale.lean
+++ b/Proetale/Morphisms/WeaklyEtale.lean
@@ -23,17 +23,37 @@ variable {X Y : Scheme.{u}} (f : X ⟶ Y)
 
 namespace WeaklyEtale
 
-instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f :=
-  sorry
+instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
+  haveI := HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget @WeaklyEtale.{u}
+  refine HasRingHomProperty.copy (P := @WeaklyEtale.{u}) rfl ?_
+  intro R S _ _ f
+  letI : Algebra R S := f.toAlgebra
+  have hf : f = algebraMap R S := rfl
+  rw [hf, weaklyEtale_iff, diagonal_SpecMap R S,
+    MorphismProperty.cancel_right_of_respectsIso (P := @Flat),
+    HasRingHomProperty.Spec_iff (P := @Flat), HasRingHomProperty.Spec_iff (P := @Flat)]
+  simp only [CommRingCat.hom_ofHom, autoParam, RingHom.flat_algebraMap_iff,
+    RingHom.weaklyEtale_algebraMap_iff, Algebra.weaklyEtale_iff]
+
+/-- A weakly étale ring map is formally unramified. -/
+private lemma _root_.RingHom.WeaklyEtale.formallyUnramified
+    {R S : Type*} [CommRing R] [CommRing S] {f : R →+* S} (hf : f.WeaklyEtale) :
+    f.FormallyUnramified := by
+  letI := f.toAlgebra
+  have : Algebra.WeaklyEtale R S := hf
+  exact (inferInstance : Algebra.FormallyUnramified R S)
+
+instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f := by
+  have : FormallyUnramified f := by
+    rw [HasRingHomProperty.iff_appLE (P := @FormallyUnramified)]
+    intro U V e
+    exact (HasRingHomProperty.appLE @WeaklyEtale.{u} f ‹_› U V e).formallyUnramified
+  exact Etale.of_formallyUnramified_of_flat f
 
 @[simp]
 lemma Spec_iff {R S : CommRingCat.{u}} (f : R ⟶ S) :
-    WeaklyEtale (Spec.map f) ↔ f.hom.WeaklyEtale := by
-  sorry
-
-instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
-  convert HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget @WeaklyEtale.{u}
-  simp
+    WeaklyEtale (Spec.map f) ↔ f.hom.WeaklyEtale :=
+  HasRingHomProperty.Spec_iff (P := @WeaklyEtale.{u})
 
 end WeaklyEtale
 

--- a/Proetale/Morphisms/WeaklyEtale.lean
+++ b/Proetale/Morphisms/WeaklyEtale.lean
@@ -24,24 +24,16 @@ variable {X Y : Scheme.{u}} (f : X ⟶ Y)
 namespace WeaklyEtale
 
 instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
-  haveI := HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget @WeaklyEtale.{u}
+  have := HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget @WeaklyEtale.{u}
   refine HasRingHomProperty.copy (P := @WeaklyEtale.{u}) rfl ?_
   intro R S _ _ f
-  letI : Algebra R S := f.toAlgebra
+  algebraize [f]
   have hf : f = algebraMap R S := rfl
   rw [hf, weaklyEtale_iff, diagonal_SpecMap R S,
     MorphismProperty.cancel_right_of_respectsIso (P := @Flat),
     HasRingHomProperty.Spec_iff (P := @Flat), HasRingHomProperty.Spec_iff (P := @Flat)]
   simp only [CommRingCat.hom_ofHom, autoParam, RingHom.flat_algebraMap_iff,
     RingHom.weaklyEtale_algebraMap_iff, Algebra.weaklyEtale_iff]
-
-/-- A weakly étale ring map is formally unramified. -/
-private lemma _root_.RingHom.WeaklyEtale.formallyUnramified
-    {R S : Type*} [CommRing R] [CommRing S] {f : R →+* S} (hf : f.WeaklyEtale) :
-    f.FormallyUnramified := by
-  letI := f.toAlgebra
-  have : Algebra.WeaklyEtale R S := hf
-  exact (inferInstance : Algebra.FormallyUnramified R S)
 
 instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f := by
   have : FormallyUnramified f := by


### PR DESCRIPTION
## Summary

Fill the two `sorry`s in `Proetale/Morphisms/WeaklyEtale.lean`, upstreamed from the `archon` branch.

- `instance : HasRingHomProperty @WeaklyEtale RingHom.WeaklyEtale` now uses `HasRingHomProperty.copy` to explicitly identify the predicate produced by `of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget` with `RingHom.WeaklyEtale`, replacing the previous `convert ... simp` form.
- `instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f` is now derived through `FormallyUnramified` using `HasRingHomProperty.iff_appLE` and `Etale.of_formallyUnramified_of_flat`. The helper `RingHom.WeaklyEtale.formallyUnramified` is added as a `private` lemma to transport the algebra-level `Algebra.FormallyUnramified` to the ring-hom form.
- `Spec_iff` follows directly from `HasRingHomProperty.Spec_iff`.

No new sorries; the file is sorry-free after this change.

## Test plan

- [x] `lake build Proetale.Morphisms.WeaklyEtale` succeeds.
- [x] `lake build` (full project) succeeds.
- [x] `lake exe mk_all --git --check` passes.
- [x] `grep -n "sorry" Proetale/Morphisms/WeaklyEtale.lean` returns nothing.
