### PR TITLE
feat(Algebra/WeaklyEtale): prove FormallyUnramified.of_flat_lmul'

### DIFF
--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -152,7 +152,38 @@ lemma RingHom.Flat.lift_includeLeft_includeRight {R S : Type u} (T A : Type u)
           (by simp [IsScalarTower.algebraMap_eq R S A]) ≪≫
         (CommRingCat.isPushout_tensorProduct R T A).isoPushout.symm
     · exact (CommRingCat.isPushout_tensorProduct S T A).isoPushout.symm
-    all_goals ext <;> simp
+    · apply pushout.hom_ext
+      · simp only [Category.assoc, pushout.inl_desc_assoc, Category.id_comp, Iso.trans_hom,
+          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inl_desc_assoc]
+        rw [(CommRingCat.isPushout_tensorProduct R T A).inl_isoPushout_inv,
+            reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inl_isoPushout_inv]
+        ext x; simp
+      · simp only [Category.assoc, pushout.inr_desc_assoc, Category.id_comp, Iso.trans_hom,
+          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inr_desc_assoc]
+        rw [(CommRingCat.isPushout_tensorProduct R T A).inr_isoPushout_inv,
+            reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inr_isoPushout_inv]
+        ext x; simp
+    · apply pushout.hom_ext
+      · simp only [Iso.refl_hom, Category.comp_id, Iso.symm_hom]
+        rw [reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inl_isoPushout_inv]
+        ext x; simp
+      · simp only [Iso.refl_hom, Category.comp_id, Iso.symm_hom]
+        rw [reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inr_isoPushout_inv]
+        ext x; simp
+    · apply pushout.hom_ext
+      · simp only [Category.assoc, pushout.inl_desc_assoc, Category.id_comp, Iso.trans_hom,
+          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inl_desc_assoc]
+        rw [(CommRingCat.isPushout_tensorProduct S T A).inl_isoPushout_inv,
+            reassoc_of% (CommRingCat.isPushout_tensorProduct R T A).inl_isoPushout_inv]
+        ext x; simp
+      · simp only [Category.assoc, pushout.inr_desc_assoc, Category.id_comp, Iso.trans_hom,
+          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inr_desc_assoc]
+        rw [(CommRingCat.isPushout_tensorProduct S T A).inr_isoPushout_inv,
+            reassoc_of% (CommRingCat.isPushout_tensorProduct R T A).inr_isoPushout_inv]
+        ext x; simp
+    · rw [Iso.refl_hom, Category.id_comp, Iso.symm_hom, Category.assoc,
+        (CommRingCat.isPushout_tensorProduct S T A).inl_isoPushout_inv]
+      ext x; simp
 
 namespace Algebra
 
@@ -199,9 +230,46 @@ end
 
 variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 
+private lemma RingHom.isIdempotentElem_ker_of_flat_surjective {A B : Type*} [CommRing A]
+    [CommRing B] (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
+    IsIdempotentElem (RingHom.ker f) := by
+  rw [← Ideal.cotangent_subsingleton_iff]
+  letI := f.toAlgebra
+  have hflat : Module.Flat A B := by
+    rwa [← RingHom.flat_algebraMap_iff, RingHom.algebraMap_toAlgebra]
+  have e_alg : (A ⧸ RingHom.ker f) ≃ₐ[A] B :=
+    Ideal.quotientKerAlgEquivOfSurjective (f := Algebra.ofId A B) hsurj
+  have hflat' : Module.Flat A (A ⧸ RingHom.ker f) := hflat.of_linearEquiv e_alg.toLinearEquiv
+  have hinj : Function.Injective
+      ((RingHom.ker f : Submodule A A).subtype.lTensor (A ⧸ RingHom.ker f)) :=
+    hflat'.lTensor_preserves_injective_linearMap _ (Submodule.injective_subtype _)
+  rw [subsingleton_iff_forall_eq 0]
+  intro y
+  obtain ⟨⟨x, hx⟩, rfl⟩ := Ideal.toCotangent_surjective _ y
+  rw [Ideal.toCotangent_eq_zero]
+  have hzero : (RingHom.ker f : Submodule A A).subtype.lTensor (A ⧸ RingHom.ker f)
+      ((1 : A ⧸ RingHom.ker f) ⊗ₜ[A] (⟨x, hx⟩ : (RingHom.ker f : Submodule A A))) = 0 := by
+    simp only [LinearMap.lTensor_tmul, Submodule.subtype_apply]
+    apply (AlgebraTensorModule.rid A A (A ⧸ RingHom.ker f)).injective
+    simp only [map_zero, AlgebraTensorModule.rid_tmul, Algebra.smul_def, mul_one]
+    exact Ideal.Quotient.eq_zero_iff_mem.mpr hx
+  have hzero' : (1 : A ⧸ RingHom.ker f) ⊗ₜ[A]
+      (⟨x, hx⟩ : (RingHom.ker f : Submodule A A)) = 0 := hinj hzero
+  rw [pow_two]
+  refine (Submodule.mem_smul_top_iff _ _ ⟨x, hx⟩).mp ?_
+  have hker := @LinearMap.ker_tensorProductMk A _
+    (↥(RingHom.ker f : Submodule A A))
+    (Submodule.addCommGroup _) (Submodule.module _) (RingHom.ker f)
+  have hmem : (⟨x, hx⟩ : (RingHom.ker f : Submodule A A)) ∈
+      ((TensorProduct.mk A (A ⧸ RingHom.ker f) (↥(RingHom.ker f : Submodule A A))) 1).ker :=
+    hzero'
+  exact hker ▸ hmem
+
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
-    FormallyUnramified R S :=
-  sorry
+    FormallyUnramified R S := by
+  rw [formallyUnramified_iff]
+  exact (Ideal.cotangent_subsingleton_iff _).mpr
+    (RingHom.isIdempotentElem_ker_of_flat_surjective _ h (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩))
 
 namespace WeaklyEtale
 

--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -203,14 +203,13 @@ variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 lemma _root_.RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B]
     (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
     (RingHom.ker f).Pure := by
-  letI := f.toAlgebra
-  haveI : Module.Flat A B := by rwa [← RingHom.flat_algebraMap_iff, RingHom.algebraMap_toAlgebra]
+  algebraize [f]
   exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
     (f := Algebra.ofId A B) hsurj).toLinearEquiv
 
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
     FormallyUnramified R S := by
-  haveI : (KaehlerDifferential.ideal R S).Pure :=
+  have hp : (KaehlerDifferential.ideal R S).Pure :=
     RingHom.ker_pure_of_flat_surjective (TensorProduct.lmul' (S := S) R).toRingHom h
       (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
   rw [formallyUnramified_iff]

--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -152,38 +152,7 @@ lemma RingHom.Flat.lift_includeLeft_includeRight {R S : Type u} (T A : Type u)
           (by simp [IsScalarTower.algebraMap_eq R S A]) ≪≫
         (CommRingCat.isPushout_tensorProduct R T A).isoPushout.symm
     · exact (CommRingCat.isPushout_tensorProduct S T A).isoPushout.symm
-    · apply pushout.hom_ext
-      · simp only [Category.assoc, pushout.inl_desc_assoc, Category.id_comp, Iso.trans_hom,
-          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inl_desc_assoc]
-        rw [(CommRingCat.isPushout_tensorProduct R T A).inl_isoPushout_inv,
-            reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inl_isoPushout_inv]
-        ext x; simp
-      · simp only [Category.assoc, pushout.inr_desc_assoc, Category.id_comp, Iso.trans_hom,
-          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inr_desc_assoc]
-        rw [(CommRingCat.isPushout_tensorProduct R T A).inr_isoPushout_inv,
-            reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inr_isoPushout_inv]
-        ext x; simp
-    · apply pushout.hom_ext
-      · simp only [Iso.refl_hom, Category.comp_id, Iso.symm_hom]
-        rw [reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inl_isoPushout_inv]
-        ext x; simp
-      · simp only [Iso.refl_hom, Category.comp_id, Iso.symm_hom]
-        rw [reassoc_of% (CommRingCat.isPushout_tensorProduct R S S).inr_isoPushout_inv]
-        ext x; simp
-    · apply pushout.hom_ext
-      · simp only [Category.assoc, pushout.inl_desc_assoc, Category.id_comp, Iso.trans_hom,
-          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inl_desc_assoc]
-        rw [(CommRingCat.isPushout_tensorProduct S T A).inl_isoPushout_inv,
-            reassoc_of% (CommRingCat.isPushout_tensorProduct R T A).inl_isoPushout_inv]
-        ext x; simp
-      · simp only [Category.assoc, pushout.inr_desc_assoc, Category.id_comp, Iso.trans_hom,
-          Iso.symm_hom, pushout.congrHom, asIso_hom, pushout.inr_desc_assoc]
-        rw [(CommRingCat.isPushout_tensorProduct S T A).inr_isoPushout_inv,
-            reassoc_of% (CommRingCat.isPushout_tensorProduct R T A).inr_isoPushout_inv]
-        ext x; simp
-    · rw [Iso.refl_hom, Category.id_comp, Iso.symm_hom, Category.assoc,
-        (CommRingCat.isPushout_tensorProduct S T A).inl_isoPushout_inv]
-      ext x; simp
+    all_goals ext <;> simp
 
 namespace Algebra
 
@@ -230,46 +199,22 @@ end
 
 variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 
-private lemma RingHom.isIdempotentElem_ker_of_flat_surjective {A B : Type*} [CommRing A]
-    [CommRing B] (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
-    IsIdempotentElem (RingHom.ker f) := by
-  rw [← Ideal.cotangent_subsingleton_iff]
+/-- The kernel of a flat surjective ring map is a pure ideal. -/
+lemma _root_.RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B]
+    (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
+    (RingHom.ker f).Pure := by
   letI := f.toAlgebra
-  have hflat : Module.Flat A B := by
-    rwa [← RingHom.flat_algebraMap_iff, RingHom.algebraMap_toAlgebra]
-  have e_alg : (A ⧸ RingHom.ker f) ≃ₐ[A] B :=
-    Ideal.quotientKerAlgEquivOfSurjective (f := Algebra.ofId A B) hsurj
-  have hflat' : Module.Flat A (A ⧸ RingHom.ker f) := hflat.of_linearEquiv e_alg.toLinearEquiv
-  have hinj : Function.Injective
-      ((RingHom.ker f : Submodule A A).subtype.lTensor (A ⧸ RingHom.ker f)) :=
-    hflat'.lTensor_preserves_injective_linearMap _ (Submodule.injective_subtype _)
-  rw [subsingleton_iff_forall_eq 0]
-  intro y
-  obtain ⟨⟨x, hx⟩, rfl⟩ := Ideal.toCotangent_surjective _ y
-  rw [Ideal.toCotangent_eq_zero]
-  have hzero : (RingHom.ker f : Submodule A A).subtype.lTensor (A ⧸ RingHom.ker f)
-      ((1 : A ⧸ RingHom.ker f) ⊗ₜ[A] (⟨x, hx⟩ : (RingHom.ker f : Submodule A A))) = 0 := by
-    simp only [LinearMap.lTensor_tmul, Submodule.subtype_apply]
-    apply (AlgebraTensorModule.rid A A (A ⧸ RingHom.ker f)).injective
-    simp only [map_zero, AlgebraTensorModule.rid_tmul, Algebra.smul_def, mul_one]
-    exact Ideal.Quotient.eq_zero_iff_mem.mpr hx
-  have hzero' : (1 : A ⧸ RingHom.ker f) ⊗ₜ[A]
-      (⟨x, hx⟩ : (RingHom.ker f : Submodule A A)) = 0 := hinj hzero
-  rw [pow_two]
-  refine (Submodule.mem_smul_top_iff _ _ ⟨x, hx⟩).mp ?_
-  have hker := @LinearMap.ker_tensorProductMk A _
-    (↥(RingHom.ker f : Submodule A A))
-    (Submodule.addCommGroup _) (Submodule.module _) (RingHom.ker f)
-  have hmem : (⟨x, hx⟩ : (RingHom.ker f : Submodule A A)) ∈
-      ((TensorProduct.mk A (A ⧸ RingHom.ker f) (↥(RingHom.ker f : Submodule A A))) 1).ker :=
-    hzero'
-  exact hker ▸ hmem
+  haveI : Module.Flat A B := by rwa [← RingHom.flat_algebraMap_iff, RingHom.algebraMap_toAlgebra]
+  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
+    (f := Algebra.ofId A B) hsurj).toLinearEquiv
 
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
     FormallyUnramified R S := by
+  haveI : (KaehlerDifferential.ideal R S).Pure :=
+    RingHom.ker_pure_of_flat_surjective (TensorProduct.lmul' (S := S) R).toRingHom h
+      (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
   rw [formallyUnramified_iff]
-  exact (Ideal.cotangent_subsingleton_iff _).mpr
-    (RingHom.isIdempotentElem_ker_of_flat_surjective _ h (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩))
+  exact (Ideal.cotangent_subsingleton_iff _).mpr (Ideal.isIdempotentElem_of_pure _)
 
 namespace WeaklyEtale
 


### PR DESCRIPTION
## Summary

- Fills the sorry in `FormallyUnramified.of_flat_lmul'`: if the multiplication map `lmul' : S ⊗[R] S → S` is flat, then `R → S` is formally unramified.
- Adds private helper `RingHom.isIdempotentElem_ker_of_flat_surjective`: a flat surjective ring map has idempotent kernel. The proof uses flatness of `A ⧸ ker f ≅ B` to show the lTensor map `(A ⧸ ker f) ⊗[A] ker f → (A ⧸ ker f) ⊗[A] A` is injective, deduces `1 ⊗ₜ x = 0` for `x ∈ ker f`, and concludes via `LinearMap.ker_tensorProductMk` that `x ∈ (ker f)²`.
- Fixes the proof of `lift_includeLeft_includeRight`: replaces the broken `all_goals ext <;> simp` with explicit `pushout.hom_ext` subgoal proofs.

## Test plan

- [x] `lake build Proetale.Algebra.WeaklyEtale` succeeds with no errors or warnings
- [x] No `sorry` in the changed file
