### PR TITLE
feat(Topology/SpectralSpace/WLocal/Pullback): fill sorries for w-local pullback (Stacks 096C)

### DIFF
--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -5,6 +5,7 @@ Authors: Jiedong Jiang, Christian Merten
 -/
 import Proetale.Topology.SpectralSpace.ConnectedComponent
 import Proetale.Topology.SpectralSpace.WLocal.ClosedPoints
+import Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
 
 /-!
@@ -19,23 +20,158 @@ universe u
 variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
     [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
 
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma ConnectedComponents.fg_injective_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+    {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
+  have inst_hp := pb.hasPullback
+  let E := homeoOfIso (pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+  have hE_g : ∀ y, (E y).val.1 = g y := fun y => by
+    change ((pb.isoPullback ≪≫
+      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
+    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+    exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
+  have hE_f : ∀ y, (E y).val.2 = f y := fun y => by
+    change ((pb.isoPullback ≪≫
+      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
+    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+    exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
+  apply E.injective
+  apply Subtype.ext
+  apply Prod.ext
+  · rw [hE_g, hE_g, hg]
+  · rw [hE_f, hE_f, hf]
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma ConnectedComponents.hw_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+    {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
+  ConcreteCategory.congr_hom pb.w y
+
+
+set_option linter.unusedSectionVars false in
+@[stacks 096C "second part"]
+theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback
+    {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
+    f ⁻¹' (closedPoints X) = closedPoints Y := by
+  have hw := hw_of_isPullback pb
+  ext y; constructor
+  · intro hy
+    rw [Set.mem_preimage, mem_closedPoints_iff] at hy
+    rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+    intro z hz
+    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+    by_cases hfzy : f z = f y
+    · have hgzy : g z ≠ g y := fun h => hz (fg_injective_of_isPullback pb hfzy h)
+      obtain ⟨U, V, hU, hV, hgzU, hgyV, hUV⟩ := t2_separation hgzy
+      exact ⟨g ⁻¹' U, fun w hw => by
+        simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+        intro heq; subst heq; exact Set.disjoint_left.mp hUV hw hgyV,
+        hU.preimage g.2, hgzU⟩
+    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw => ?_, hy.isOpen_compl.preimage f.2, ?_⟩
+      · simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw ⊢
+        intro heq; subst heq; exact hw rfl
+      · simp only [Set.mem_preimage, Set.mem_compl_iff, Set.mem_singleton_iff]
+        exact hfzy
+  · intro hy
+    rw [Set.mem_preimage, mem_closedPoints_iff]
+    rw [mem_closedPoints_iff] at hy
+    haveI : SpectralSpace Y := pb.spectralSpace
+    obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
+    have hcc : ConnectedComponents.mk x_c = ConnectedComponents.mk (f y) :=
+      ConnectedComponents.coe_eq_coe'.mpr (closure_minimal
+        (Set.singleton_subset_iff.mpr mem_connectedComponent)
+        isClosed_connectedComponent hfy_xc.mem_closure)
+    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
+    let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+      (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+      (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
+    have hgy_c : g y_c = g y := ConcreteCategory.congr_hom
+      (pb.lift_fst (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hfy_c : f y_c = x_c := ConcreteCategory.congr_hom
+      (pb.lift_snd (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hy_spec_yc : y ⤳ y_c := by
+      have inst_hp := pb.hasPullback
+      let E := homeoOfIso (pb.isoPullback ≪≫
+        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+      have hE_g : ∀ y', (E y').val.1 = g y' := fun y' => by
+        change ((pb.isoPullback ≪≫
+          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.1 = _
+        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+        exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y'
+      have hE_f : ∀ y', (E y').val.2 = f y' := fun y' => by
+        change ((pb.isoPullback ≪≫
+          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2 = _
+        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+        exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y'
+      have hval_spec : (E y).val ⤳ (E y_c).val := by
+        rw [specializes_prod]
+        exact ⟨by rw [hE_g, hE_g, hgy_c], by rw [hE_f, hE_f, hfy_c]; exact hfy_xc⟩
+      exact E.isInducing.specializes_iff.mp
+        (Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec)
+    have heq : y = y_c := by
+      have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
+      rw [hy.closure_eq, Set.mem_singleton_iff] at hmem; exact hmem.symm
+    rw [heq, hfy_c]; exact hx_c_closed
+
 @[stacks 096C "second part"]
 theorem ConnectedComponents.wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
     {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
     WLocalSpace Y where
   __ := pb.spectralSpace
-  eq_of_specializes := sorry
-  isClosed_closedPoints := sorry
+  eq_of_specializes := by
+    intro y c c' hc hc' hyc hyc'
+    have hfc : f c ∈ closedPoints X := by
+      have : c ∈ closedPoints Y := mem_closedPoints_iff.mpr hc
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hfc' : f c' ∈ closedPoints X := by
+      have : c' ∈ closedPoints Y := mem_closedPoints_iff.mpr hc'
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hf_eq : f c = f c' := WLocalSpace.eq_of_specializes
+      (mem_closedPoints_iff.mp hfc) (mem_closedPoints_iff.mp hfc')
+      (hyc.map f.2) (hyc'.map f.2)
+    have hg_eq : g c = g c' := (hyc.map g.2).eq.symm.trans (hyc'.map g.2).eq
+    exact fg_injective_of_isPullback pb hf_eq hg_eq
+  isClosed_closedPoints := by
+    rw [← preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
 
 @[stacks 096C "second part"]
 theorem ConnectedComponents.isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
     {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    IsWLocalMap f := sorry
-
-@[stacks 096C "second part"]
-theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)}
-    {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    f ⁻¹' (closedPoints X) = closedPoints Y := sorry
+    IsWLocalMap f where
+  toIsSpectralMap := by
+    haveI := pb.spectralSpace
+    haveI := wlocalSpace_of_isPullback pb
+    constructor
+    · exact f.2
+    · have inst_hp := pb.hasPullback
+      let E := homeoOfIso (pb.isoPullback ≪≫
+        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+      have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
+        isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
+      have hf_eq : ∀ y, f y = (E y).val.2 := fun y' => by
+        change f y' = ((pb.isoPullback ≪≫
+          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2
+        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+        exact (ConcreteCategory.congr_hom pb.isoPullback_hom_snd y').symm
+      have hf_proper : IsProperMap f := by
+        have heq : f = Prod.snd ∘ Subtype.val ∘ E := funext hf_eq
+        rw [heq]
+        exact (isProperMap_snd_of_compactSpace.comp
+          hclosed.isProperMap_subtypeVal).comp E.isProperMap
+      intro s hs hsc
+      exact hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc
+  closedPoints_subset_preimage_closedPoints := by
+    intro y hy
+    rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]

--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -19,74 +19,79 @@ open CategoryTheory TopCat
 universe u
 variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
     [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
+    {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
 
 omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-private lemma ConnectedComponents.fg_injective_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
+/-- The pullback `Y` of `f : Y → X` and `i : T → ConnectedComponents X` along the canonical
+projection `mk : X → ConnectedComponents X` is homeomorphic to the closed subspace
+`{p : T × X // i p.1 = mk p.2}` of `T × X`. -/
+private noncomputable def ConnectedComponents.pullbackHomeo
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
+    Y ≃ₜ {p : T × X // i p.1 = ConnectedComponents.mk p.2} :=
+  have := pb.hasPullback
+  homeoOfIso (pb.isoPullback ≪≫ pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma ConnectedComponents.pullbackHomeo_apply_fst
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) (y : Y) :
+    (ConnectedComponents.pullbackHomeo pb y).val.1 = g y := by
+  have := pb.hasPullback
+  change ((pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma ConnectedComponents.pullbackHomeo_apply_snd
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) (y : Y) :
+    (ConnectedComponents.pullbackHomeo pb y).val.2 = f y := by
+  have := pb.hasPullback
+  change ((pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma ConnectedComponents.fg_injective_of_isPullback
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
     {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
-  have inst_hp := pb.hasPullback
-  let E := homeoOfIso (pb.isoPullback ≪≫
-    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-  have hE_g : ∀ y, (E y).val.1 = g y := fun y => by
-    change ((pb.isoPullback ≪≫
-      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
-    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-    exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
-  have hE_f : ∀ y, (E y).val.2 = f y := fun y => by
-    change ((pb.isoPullback ≪≫
-      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
-    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-    exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
-  apply E.injective
-  apply Subtype.ext
-  apply Prod.ext
-  · rw [hE_g, hE_g, hg]
-  · rw [hE_f, hE_f, hf]
-
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-private lemma ConnectedComponents.hw_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-    (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
-  ConcreteCategory.congr_hom pb.w y
-
+  refine (ConnectedComponents.pullbackHomeo pb).injective (Subtype.ext (Prod.ext ?_ ?_))
+  · rw [pullbackHomeo_apply_fst, pullbackHomeo_apply_fst, hg]
+  · rw [pullbackHomeo_apply_snd, pullbackHomeo_apply_snd, hf]
 
 set_option linter.unusedSectionVars false in
 @[stacks 096C "second part"]
 theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback
-    {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
     f ⁻¹' (closedPoints X) = closedPoints Y := by
-  have hw := hw_of_isPullback pb
-  ext y; constructor
-  · intro hy
-    rw [Set.mem_preimage, mem_closedPoints_iff] at hy
+  ext y
+  refine ⟨fun hy ↦ ?_, fun hy ↦ ?_⟩
+  · rw [Set.mem_preimage, mem_closedPoints_iff] at hy
     rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
     rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
     by_cases hfzy : f z = f y
-    · have hgzy : g z ≠ g y := fun h => hz (fg_injective_of_isPullback pb hfzy h)
+    · have hgzy : g z ≠ g y := fun h ↦ hz (fg_injective_of_isPullback pb hfzy h)
       obtain ⟨U, V, hU, hV, hgzU, hgyV, hUV⟩ := t2_separation hgzy
-      exact ⟨g ⁻¹' U, fun w hw => by
-        simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
-        intro heq; subst heq; exact Set.disjoint_left.mp hUV hw hgyV,
-        hU.preimage g.2, hgzU⟩
-    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw => ?_, hy.isOpen_compl.preimage f.2, ?_⟩
+      refine ⟨g ⁻¹' U, fun w hw ↦ ?_, hU.preimage g.2, hgzU⟩
+      simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+      rintro rfl
+      exact Set.disjoint_left.mp hUV hw hgyV
+    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw ↦ ?_, hy.isOpen_compl.preimage f.2, ?_⟩
       · simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw ⊢
-        intro heq; subst heq; exact hw rfl
-      · simp only [Set.mem_preimage, Set.mem_compl_iff, Set.mem_singleton_iff]
-        exact hfzy
-  · intro hy
+        rintro rfl
+        exact hw rfl
+      · simpa using hfzy
+  · have hy_closed : IsClosed ({y} : Set Y) := mem_closedPoints_iff.mp hy
     rw [Set.mem_preimage, mem_closedPoints_iff]
-    rw [mem_closedPoints_iff] at hy
-    haveI : SpectralSpace Y := pb.spectralSpace
+    have : SpectralSpace Y := pb.spectralSpace
     obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
     have hcc : ConnectedComponents.mk x_c = ConnectedComponents.mk (f y) :=
       ConnectedComponents.coe_eq_coe'.mpr (closure_minimal
         (Set.singleton_subset_iff.mpr mem_connectedComponent)
         isClosed_connectedComponent hfy_xc.mem_closure)
-    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
+    have hmk_eq : mk x_c = i (g y) :=
+      hcc.trans (ConcreteCategory.congr_hom pb.w y).symm
     let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
       (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
       (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
@@ -99,32 +104,23 @@ theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback
         (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
         (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
     have hy_spec_yc : y ⤳ y_c := by
-      have inst_hp := pb.hasPullback
-      let E := homeoOfIso (pb.isoPullback ≪≫
-        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-      have hE_g : ∀ y', (E y').val.1 = g y' := fun y' => by
-        change ((pb.isoPullback ≪≫
-          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.1 = _
-        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-        exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y'
-      have hE_f : ∀ y', (E y').val.2 = f y' := fun y' => by
-        change ((pb.isoPullback ≪≫
-          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2 = _
-        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-        exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y'
-      have hval_spec : (E y).val ⤳ (E y_c).val := by
+      have hval_spec : (pullbackHomeo pb y).val ⤳ (pullbackHomeo pb y_c).val := by
         rw [specializes_prod]
-        exact ⟨by rw [hE_g, hE_g, hgy_c], by rw [hE_f, hE_f, hfy_c]; exact hfy_xc⟩
-      exact E.isInducing.specializes_iff.mp
+        refine ⟨?_, ?_⟩
+        · rw [pullbackHomeo_apply_fst, pullbackHomeo_apply_fst, hgy_c]
+        · rw [pullbackHomeo_apply_snd, pullbackHomeo_apply_snd, hfy_c]
+          exact hfy_xc
+      exact (pullbackHomeo pb).isInducing.specializes_iff.mp
         (Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec)
     have heq : y = y_c := by
       have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
-      rw [hy.closure_eq, Set.mem_singleton_iff] at hmem; exact hmem.symm
-    rw [heq, hfy_c]; exact hx_c_closed
+      rw [hy_closed.closure_eq, Set.mem_singleton_iff] at hmem
+      exact hmem.symm
+    rw [heq, hfy_c]
+    exact hx_c_closed
 
 @[stacks 096C "second part"]
-theorem ConnectedComponents.wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
+theorem ConnectedComponents.wLocalSpace_of_isPullback
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
     WLocalSpace Y where
   __ := pb.spectralSpace
@@ -146,32 +142,23 @@ theorem ConnectedComponents.wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)
     exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
 
 @[stacks 096C "second part"]
-theorem ConnectedComponents.isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
+theorem ConnectedComponents.isWLocalMap_of_isPullback
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
     IsWLocalMap f where
   toIsSpectralMap := by
-    haveI := pb.spectralSpace
-    haveI := wlocalSpace_of_isPullback pb
-    constructor
-    · exact f.2
-    · have inst_hp := pb.hasPullback
-      let E := homeoOfIso (pb.isoPullback ≪≫
-        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-      have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
-        isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
-      have hf_eq : ∀ y, f y = (E y).val.2 := fun y' => by
-        change f y' = ((pb.isoPullback ≪≫
-          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2
-        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-        exact (ConcreteCategory.congr_hom pb.isoPullback_hom_snd y').symm
-      have hf_proper : IsProperMap f := by
-        have heq : f = Prod.snd ∘ Subtype.val ∘ E := funext hf_eq
-        rw [heq]
-        exact (isProperMap_snd_of_compactSpace.comp
-          hclosed.isProperMap_subtypeVal).comp E.isProperMap
-      intro s hs hsc
-      exact hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc
+    have := pb.spectralSpace
+    have := wLocalSpace_of_isPullback pb
+    refine ⟨f.2, ?_⟩
+    have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
+      isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
+    have hf_eq : (f : Y → X) = Prod.snd ∘ Subtype.val ∘ pullbackHomeo pb :=
+      funext fun y ↦ (pullbackHomeo_apply_snd pb y).symm
+    have hf_proper : IsProperMap (f : Y → X) := by
+      rw [hf_eq]
+      exact (isProperMap_snd_of_compactSpace.comp
+        hclosed.isProperMap_subtypeVal).comp (pullbackHomeo pb).isProperMap
+    intro s hs hsc
+    exact hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc
   closedPoints_subset_preimage_closedPoints := by
     intro y hy
     rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1072,7 +1072,7 @@ a quasi-compact open $U$.
 \begin{lemma}[{\cite[\href{https://stacks.math.columbia.edu/tag/096C}{Tag 096C}, second part]{stacks-project}}]
 \label{thm:cartesian-profinite-w-local}
 \uses{def:w-local-space,def:w-local-space-map}
-\lean{ConnectedComponents.wlocalSpace_of_isPullback,ConnectedComponents.isWLocalMap_of_isPullback,ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback}
+\lean{ConnectedComponents.wLocalSpace_of_isPullback,ConnectedComponents.isWLocalMap_of_isPullback,ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback}
 \leanok
 Let $X$ be a spectral space. Let
 \[


### PR DESCRIPTION
## Summary

Fills the three `sorry`-placeholders in `Proetale/Topology/SpectralSpace/WLocal/Pullback.lean`, proving the main results of [Stacks 096C](https://stacks.math.columbia.edu/tag/096C) about pullbacks of w-local spaces:

- `ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback`: if `Y` is the pullback of `f : Y → X` and `i : T → ConnectedComponents X` over `mk : X → ConnectedComponents X` (with `T` compact Hausdorff totally disconnected), then `f ⁻¹' closedPoints X = closedPoints Y`.
- `ConnectedComponents.wlocalSpace_of_isPullback`: the pullback `Y` is w-local.
- `ConnectedComponents.isWLocalMap_of_isPullback`: the projection `f : Y → X` is a w-local map.

### Proof strategy

The key auxiliary lemma `fg_injective_of_isPullback` shows that the pair `(f, g)` separates points of `Y` by realising `Y` as a subspace of `T × X` via the pullback homeomorphism. The main theorem `preimage_closedPoints_eq_closedPoints_of_isPullback` is proved in both directions:

- **Forward**: if `f(y)` is closed in `X` then `{y}` is closed in `Y`, using T2-separation in `T` and closedness of `{f(y)}` to find separating opens.
- **Backward**: if `y` is closed in `Y` then `f(y)` is closed in `X`, by lifting the specialisation `f(y) ⤳ x_c` (to the unique closed point of `X` specialised by `f(y)`) to a specialisation `y ⤳ y_c` in `Y` via the pullback embedding into `T × X`.

The w-locality of `Y` and the w-locality of `f` then follow relatively directly.

Also adds the import `Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents` which provides `WLocalSpace.isHomeomorph_connectedComponents_closedPoints`.
