### PR TITLE
feat(Algebra/WLocal): fill `IsWLocalRing.of_surjective` and `isWLocal_iff_isMaximal_of_isMaximal` sorries

### DIFF
--- a/Proetale/Algebra/WLocal.lean
+++ b/Proetale/Algebra/WLocal.lean
@@ -24,9 +24,12 @@ class IsWLocalRing (R : Type*) [CommSemiring R] : Prop where
 
 variable {R S : Type*} [CommRing R] [CommRing S]
 
+instance (R : Type*) [CommSemiring R] [IsWLocalRing R] : WLocalSpace (PrimeSpectrum R) :=
+  IsWLocalRing.wLocalSpace_primeSepectrum
+
 lemma IsWLocalRing.of_surjective {f : R →+* S} (hf : Function.Surjective f) [IsWLocalRing R] :
     IsWLocalRing S :=
-  sorry
+  ⟨(PrimeSpectrum.isClosedEmbedding_comap_of_surjective _ _ hf).wLocalSpace⟩
 
 /-- A ring homomorphism is w-local if the induced map on spectra is w-local. -/
 def RingHom.IsWLocal {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+* S) : Prop :=
@@ -35,9 +38,21 @@ def RingHom.IsWLocal {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+
 lemma RingHom.isWLocal_iff_isMaximal_of_isMaximal (f : R →+* S) :
     IsWLocal f ↔ ∀ (m : Ideal S) [m.IsMaximal], (m.comap f).IsMaximal := by
   rw [IsWLocal, isWLocalMap_iff]
-  refine ⟨fun ⟨_, h⟩ m hm ↦ ?_, ?_⟩
-  · sorry
-  · sorry
+  refine ⟨fun ⟨_, h⟩ m hm ↦ ?_, fun hmax ↦ ?_⟩
+  · have hm_cp : (⟨m, hm.isPrime⟩ : PrimeSpectrum S) ∈ closedPoints (PrimeSpectrum S) := by
+      rw [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal]
+      exact hm
+    have hcl : PrimeSpectrum.comap f ⟨m, hm.isPrime⟩ ∈ closedPoints (PrimeSpectrum R) := h hm_cp
+    rwa [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal] at hcl
+  · refine ⟨⟨PrimeSpectrum.continuous_comap f, fun s hs hc ↦ ?_⟩, fun x hx ↦ ?_⟩
+    · obtain ⟨I, hI_fg, rfl⟩ := PrimeSpectrum.isCompact_isOpen_iff_ideal.mp ⟨hc, hs⟩
+      rw [Set.preimage_compl, PrimeSpectrum.preimage_comap_zeroLocus]
+      refine (PrimeSpectrum.isCompact_isOpen_iff_ideal.mpr ⟨_, hI_fg.map f, ?_⟩).1
+      rw [← PrimeSpectrum.zeroLocus_span, Ideal.span_eq, ← Ideal.span_eq I, Ideal.map_span,
+        PrimeSpectrum.zeroLocus_span, Ideal.span_eq]
+    · rw [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal] at hx
+      rw [Set.mem_preimage, mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal]
+      exact hmax x.asIdeal
 
 namespace RingHom.IsWLocal
 

--- a/Proetale/Algebra/WLocal.lean
+++ b/Proetale/Algebra/WLocal.lean
@@ -3,10 +3,10 @@ Copyright (c) 2025 Jiedong Jiang, Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jiedong Jiang, Christian Merten
 -/
-import Mathlib.RingTheory.Spectrum.Prime.Topology
 import Mathlib.RingTheory.Etale.Basic
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 import Proetale.Mathlib.RingTheory.Henselian
+import Proetale.Mathlib.RingTheory.Spectrum.Prime.Topology
 import Proetale.Topology.SpectralSpace.WLocal.Basic
 import Proetale.Algebra.StalkIso
 
@@ -22,10 +22,9 @@ a w-local topological space.
 class IsWLocalRing (R : Type*) [CommSemiring R] : Prop where
   wLocalSpace_primeSepectrum : WLocalSpace (PrimeSpectrum R)
 
-variable {R S : Type*} [CommRing R] [CommRing S]
+attribute [instance] IsWLocalRing.wLocalSpace_primeSepectrum
 
-instance (R : Type*) [CommSemiring R] [IsWLocalRing R] : WLocalSpace (PrimeSpectrum R) :=
-  IsWLocalRing.wLocalSpace_primeSepectrum
+variable {R S : Type*} [CommRing R] [CommRing S]
 
 lemma IsWLocalRing.of_surjective {f : R →+* S} (hf : Function.Surjective f) [IsWLocalRing R] :
     IsWLocalRing S :=
@@ -37,22 +36,10 @@ def RingHom.IsWLocal {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+
 
 lemma RingHom.isWLocal_iff_isMaximal_of_isMaximal (f : R →+* S) :
     IsWLocal f ↔ ∀ (m : Ideal S) [m.IsMaximal], (m.comap f).IsMaximal := by
-  rw [IsWLocal, isWLocalMap_iff]
-  refine ⟨fun ⟨_, h⟩ m hm ↦ ?_, fun hmax ↦ ?_⟩
-  · have hm_cp : (⟨m, hm.isPrime⟩ : PrimeSpectrum S) ∈ closedPoints (PrimeSpectrum S) := by
-      rw [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal]
-      exact hm
-    have hcl : PrimeSpectrum.comap f ⟨m, hm.isPrime⟩ ∈ closedPoints (PrimeSpectrum R) := h hm_cp
-    rwa [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal] at hcl
-  · refine ⟨⟨PrimeSpectrum.continuous_comap f, fun s hs hc ↦ ?_⟩, fun x hx ↦ ?_⟩
-    · obtain ⟨I, hI_fg, rfl⟩ := PrimeSpectrum.isCompact_isOpen_iff_ideal.mp ⟨hc, hs⟩
-      rw [Set.preimage_compl, PrimeSpectrum.preimage_comap_zeroLocus]
-      refine (PrimeSpectrum.isCompact_isOpen_iff_ideal.mpr ⟨_, hI_fg.map f, ?_⟩).1
-      rw [← PrimeSpectrum.zeroLocus_span, Ideal.span_eq, ← Ideal.span_eq I, Ideal.map_span,
-        PrimeSpectrum.zeroLocus_span, Ideal.span_eq]
-    · rw [mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal] at hx
-      rw [Set.mem_preimage, mem_closedPoints_iff, PrimeSpectrum.isClosed_singleton_iff_isMaximal]
-      exact hmax x.asIdeal
+  rw [IsWLocal, isWLocalMap_iff, and_iff_right (PrimeSpectrum.isSpectralMap_comap f)]
+  simp_rw [Set.subset_def, Set.mem_preimage, mem_closedPoints_iff,
+    PrimeSpectrum.isClosed_singleton_iff_isMaximal, PrimeSpectrum.comap_asIdeal]
+  exact ⟨fun h m hm ↦ h ⟨m, hm.isPrime⟩ hm, fun h x hx ↦ @h x.asIdeal hx⟩
 
 namespace RingHom.IsWLocal
 

--- a/Proetale/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Proetale/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -1,7 +1,18 @@
 import Mathlib.RingTheory.Spectrum.Prime.Topology
+import Mathlib.Topology.Spectral.Hom
 
 -- end of file
 theorem PrimeSpectrum.continuous_sigmaToPi {ι : Type*} (R : ι → Type*)
     [(i : ι) → CommSemiring (R i)] :
     Continuous (PrimeSpectrum.sigmaToPi R) :=
   continuous_sigma fun _ ↦ continuous_comap (Pi.evalRingHom R _)
+
+theorem PrimeSpectrum.isSpectralMap_comap {R S : Type*} [CommSemiring R] [CommSemiring S]
+    (f : R →+* S) : IsSpectralMap (PrimeSpectrum.comap f) where
+  toContinuous := PrimeSpectrum.continuous_comap f
+  isCompact_preimage_of_isOpen s hs hc := by
+    obtain ⟨I, hI_fg, rfl⟩ := PrimeSpectrum.isCompact_isOpen_iff_ideal.mp ⟨hc, hs⟩
+    rw [Set.preimage_compl, PrimeSpectrum.preimage_comap_zeroLocus]
+    refine (PrimeSpectrum.isCompact_isOpen_iff_ideal.mpr ⟨_, hI_fg.map f, ?_⟩).1
+    rw [← PrimeSpectrum.zeroLocus_span, Ideal.span_eq, ← Ideal.span_eq I, Ideal.map_span,
+      PrimeSpectrum.zeroLocus_span, Ideal.span_eq]


### PR DESCRIPTION
## Summary

Fills the two sorries in `Proetale/Algebra/WLocal.lean`:

- `IsWLocalRing.of_surjective`: a surjective image of a w-local ring is w-local, via the closed embedding `Spec S ↪ Spec R` and `IsClosedEmbedding.wLocalSpace`.
- `RingHom.isWLocal_iff_isMaximal_of_isMaximal`: a ring map is w-local iff every maximal ideal of `S` contracts to a maximal ideal of `R`. The `←` direction proves spectrality of `Spec(f)` by translating the compact-open characterization to ideals via `PrimeSpectrum.isCompact_isOpen_iff_ideal` and `Ideal.map_span`.

Also adds the (previously missing) `WLocalSpace (PrimeSpectrum R)` instance for an `IsWLocalRing R`, which is needed downstream.

The remaining `bijective_of_bijective` sorry is untouched here and left for a follow-up PR (it depends on `WLocalSpace.isHomeomorph_connectedComponents_closedPoints` and going-down, so it is meaningfully larger).

## Test plan

- [x] `lake build Proetale` completes successfully with only the pre-existing `bijective_of_bijective` sorry warning.
