### PR TITLE
feat(Algebra/IndZariski): local isomorphisms are finitely presented

### DIFF
--- a/Proetale/Algebra/IndEtale.lean
+++ b/Proetale/Algebra/IndEtale.lean
@@ -21,10 +21,6 @@ open CategoryTheory Limits
 
 variable (R : Type u) {S : Type u} [CommRing R] [CommRing S] [Algebra R S]
 
-/-- The object property on commutative `R`-algebras of being finitely presented. -/
-def CommAlgCat.finitePresentation : ObjectProperty (CommAlgCat.{u} R) :=
-  fun S ↦ RingHom.FinitePresentation (algebraMap R S)
-
 /-- The object property on commutative `R`-algebras of being étale. -/
 def CommAlgCat.etale : ObjectProperty (CommAlgCat.{u} R) :=
   fun S ↦ Algebra.Etale R S
@@ -54,19 +50,6 @@ lemma trans (T : Type u) [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower
     Algebra.IndEtale R T :=
   sorry
 
-/-- Finitely presented `R`-algebras are finitely presentable objects in `CommAlgCat R`. -/
-lemma finitePresentation_le_isFinitelyPresentable :
-    CommAlgCat.finitePresentation R ≤
-      ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := by
-  intro S hS
-  have hunder : IsFinitelyPresentable.{u} ((commAlgCatEquivUnder (.of R)).functor.obj S) :=
-    CommRingCat.isFinitelyPresentable_under _ _ (by convert hS using 1)
-  have : Fact (Cardinal.aleph0 : Cardinal.{u}).IsRegular := Cardinal.fact_isRegular_aleph0
-  exact (@isCardinalPresentable_iff_of_isEquivalence
-    (CommAlgCat.{u} R) _ S (Cardinal.aleph0 : Cardinal.{u}) this
-    (Under (CommRingCat.of.{u} R)) _
-    (commAlgCatEquivUnder (.of R)).functor inferInstance).mp hunder
-
 /-- Étale `R`-algebras are finitely presented. -/
 lemma etale_le_finitePresentation :
     CommAlgCat.etale R ≤ CommAlgCat.finitePresentation R := by
@@ -78,25 +61,14 @@ then `S` is ind-étale over `R`. -/
 theorem of_colimitPresentation {ι : Type u} [SmallCategory ι] [IsFiltered ι]
     (P : ColimitPresentation ι (CommAlgCat.of R S))
     (h : ∀ (i : ι), Algebra.IndEtale R (P.diag.obj i)) : Algebra.IndEtale R S := by
-  rw [iff_ind_etale, ← ObjectProperty.ind_ind
-    (etale_le_finitePresentation R |>.trans (finitePresentation_le_isFinitelyPresentable R))]
+  rw [iff_ind_etale, ← ObjectProperty.ind_ind (etale_le_finitePresentation R |>.trans
+    (CommAlgCat.finitePresentation_le_isFinitelyPresentable R))]
   exact ⟨ι, ‹_›, ‹_›, P, fun i => (iff_ind_etale R _).mp (h i)⟩
 
-/-- Local isomorphisms of `R`-algebras are étale. -/
-lemma Algebra.IsLocalIso.etale [Algebra.IsLocalIso R S] : Algebra.Etale R S := by
-  rw [← RingHom.etale_algebraMap]
-  let s : Set S := {g | Algebra.IsStandardOpenImmersion R (Localization.Away g)}
-  have hs : Ideal.span s = ⊤ := Algebra.IsLocalIso.span_isStandardOpenImmersion_eq_top R S
-  refine RingHom.Etale.ofLocalizationSpanTarget (algebraMap R S) s hs fun ⟨g, hg⟩ => ?_
-  obtain ⟨r, hr⟩ := hg.exists_away
-  have : Algebra.Etale R (Localization.Away g) := Algebra.Etale.of_isLocalizationAway r
-  rw [← IsScalarTower.algebraMap_eq R S (Localization.Away g)]
-  exact RingHom.etale_algebraMap.mpr inferInstance
-
 lemma isLocalIso_le_etale (R : Type u) [CommRing R] :
-    CommAlgCat.isLocalIso R ≤ CommAlgCat.etale R := by
-  intro X hX
-  exact @Algebra.IsLocalIso.etale R X _ _ _ hX
+    CommAlgCat.isLocalIso R ≤ CommAlgCat.etale R := fun X hX ↦
+  have : Algebra.IsLocalIso R X := hX
+  Algebra.IsLocalIso.etale R X
 
 /-- An ind-Zariski algebra is ind-étale, since localizations are étale. -/
 instance (priority := 100) of_indZariski [IndZariski R S] : IndEtale R S := by

--- a/Proetale/Algebra/IndZariski.lean
+++ b/Proetale/Algebra/IndZariski.lean
@@ -79,9 +79,8 @@ lemma Algebra.IsLocalIso.etale [Algebra.IsLocalIso R S] : Algebra.Etale R S :=
 
 /-- A local isomorphism of `R`-algebras is finitely presented. -/
 lemma Algebra.IsLocalIso.finitePresentation [Algebra.IsLocalIso R S] :
-    (algebraMap R S).FinitePresentation := by
+    Algebra.FinitePresentation R S := by
   have := Algebra.IsLocalIso.etale R S
-  rw [RingHom.finitePresentation_algebraMap]
   infer_instance
 
 /-- Finitely presented `R`-algebras are finitely presentable objects in `CommAlgCat R`. -/
@@ -100,8 +99,9 @@ lemma CommAlgCat.isLocalIso_le_isFinitelyPresentable :
     CommAlgCat.isLocalIso R ≤
       ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := fun S hS ↦
   have : Algebra.IsLocalIso R S := hS
+  have := Algebra.IsLocalIso.finitePresentation R S
   CommAlgCat.finitePresentation_le_isFinitelyPresentable R S
-    (Algebra.IsLocalIso.finitePresentation R S)
+    (RingHom.finitePresentation_algebraMap.mpr ‹_›)
 
 /-- An algebra is ind-Zariski if it can be written as the filtered colimit of locally isomorphic
 algebras. -/

--- a/Proetale/Algebra/IndZariski.lean
+++ b/Proetale/Algebra/IndZariski.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.Algebra.Category.Ring.FinitePresentation
+import Mathlib.RingTheory.RingHom.Etale
 import Mathlib.RingTheory.RingHom.FinitePresentation
 import Mathlib.RingTheory.RingHom.Flat
 import Proetale.Algebra.FaithfullyFlat
@@ -32,6 +33,10 @@ variable [Algebra R S] [Algebra R T]
 def CommAlgCat.isLocalIso : ObjectProperty (CommAlgCat.{u} R) :=
   fun S ↦ Algebra.IsLocalIso R S
 
+/-- The object property on commutative `R`-algebras of being finitely presented. -/
+def CommAlgCat.finitePresentation : ObjectProperty (CommAlgCat.{u} R) :=
+  fun S ↦ RingHom.FinitePresentation (algebraMap R S)
+
 lemma CommAlgCat.isLocalIso_eq : isLocalIso R = RingHom.toObjectProperty RingHom.IsLocalIso R := by
   ext S
   exact RingHom.isLocalIso_algebraMap.symm
@@ -55,33 +60,48 @@ instance : (CommAlgCat.isLocalIso R).IsClosedUnderFiniteProducts :=
     have inst (i : ι) : Algebra.IsLocalIso R (S i) := hF ⟨i⟩
     exact Algebra.IsLocalIso.pi_of_finite R (fun i ↦ S i)
 
+/-- Étaleness is local on the target: if `s` spans the unit ideal of `S` and every
+`Localization.Away g` for `g ∈ s` is étale over `R`, then `S` is étale over `R`. -/
+lemma Algebra.Etale.of_span_eq_top_target (s : Set S) (hs : Ideal.span s = ⊤)
+    (h : ∀ g ∈ s, Algebra.Etale R (Localization.Away g)) : Algebra.Etale R S := by
+  rw [← RingHom.etale_algebraMap]
+  refine RingHom.Etale.ofLocalizationSpanTarget (algebraMap R S) s hs fun ⟨g, hg⟩ ↦ ?_
+  have : Algebra.Etale R (Localization.Away g) := h g hg
+  rw [← IsScalarTower.algebraMap_eq R S (Localization.Away g)]
+  exact RingHom.etale_algebraMap.mpr inferInstance
+
+/-- Local isomorphisms of `R`-algebras are étale. -/
+lemma Algebra.IsLocalIso.etale [Algebra.IsLocalIso R S] : Algebra.Etale R S :=
+  Algebra.Etale.of_span_eq_top_target R S _
+    (Algebra.IsLocalIso.span_isStandardOpenImmersion_eq_top R S) fun g hg ↦ by
+      obtain ⟨r, _⟩ := hg.exists_away
+      exact Algebra.Etale.of_isLocalizationAway r
+
 /-- A local isomorphism of `R`-algebras is finitely presented. -/
 lemma Algebra.IsLocalIso.finitePresentation [Algebra.IsLocalIso R S] :
     (algebraMap R S).FinitePresentation := by
-  apply RingHom.finitePresentation_ofLocalizationSpanTarget
-    (algebraMap R S) _ (Algebra.IsLocalIso.span_isStandardOpenImmersion_eq_top R S)
-  rintro ⟨g, hg⟩
-  rw [show (algebraMap S (Localization.Away g)).comp (algebraMap R S) =
-        algebraMap R (Localization.Away g) from
-      (IsScalarTower.algebraMap_eq R S (Localization.Away g)).symm,
-    RingHom.finitePresentation_algebraMap]
-  obtain ⟨r, hr⟩ := hg.exists_away
-  exact IsLocalization.Away.finitePresentation r
+  have := Algebra.IsLocalIso.etale R S
+  rw [RingHom.finitePresentation_algebraMap]
+  infer_instance
+
+/-- Finitely presented `R`-algebras are finitely presentable objects in `CommAlgCat R`. -/
+lemma CommAlgCat.finitePresentation_le_isFinitelyPresentable :
+    CommAlgCat.finitePresentation R ≤
+      ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := by
+  intro S hS
+  have hunder : IsFinitelyPresentable.{u} ((commAlgCatEquivUnder (.of R)).functor.obj S) :=
+    CommRingCat.isFinitelyPresentable_under _ _ (by convert hS using 1)
+  have : Fact (Cardinal.aleph0 : Cardinal.{u}).IsRegular := Cardinal.fact_isRegular_aleph0
+  exact (isCardinalPresentable_iff_of_isEquivalence (X := S) (κ := .aleph0)
+    (commAlgCatEquivUnder (.of R)).functor).mp hunder
 
 /-- Local isomorphisms are finitely presentable in `CommAlgCat R`. -/
 lemma CommAlgCat.isLocalIso_le_isFinitelyPresentable :
     CommAlgCat.isLocalIso R ≤
-      ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := by
-  intro S hS
+      ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := fun S hS ↦
   have : Algebra.IsLocalIso R S := hS
-  have hfp : (algebraMap R S).FinitePresentation :=
-    Algebra.IsLocalIso.finitePresentation R S
-  have hunder : IsFinitelyPresentable.{u}
-      ((commAlgCatEquivUnder (.of R)).functor.obj S) :=
-    CommRingCat.isFinitelyPresentable_under _ _ (by convert hfp using 1)
-  have : Fact (Cardinal.aleph0 : Cardinal.{u}).IsRegular := Cardinal.fact_isRegular_aleph0
-  exact (isCardinalPresentable_iff_of_isEquivalence (X := S) (κ := .aleph0)
-    (commAlgCatEquivUnder (.of R)).functor).mp hunder
+  CommAlgCat.finitePresentation_le_isFinitelyPresentable R S
+    (Algebra.IsLocalIso.finitePresentation R S)
 
 /-- An algebra is ind-Zariski if it can be written as the filtered colimit of locally isomorphic
 algebras. -/

--- a/Proetale/Algebra/IndZariski.lean
+++ b/Proetale/Algebra/IndZariski.lean
@@ -3,6 +3,8 @@ Copyright (c) 2025 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
+import Mathlib.Algebra.Category.Ring.FinitePresentation
+import Mathlib.RingTheory.RingHom.FinitePresentation
 import Mathlib.RingTheory.RingHom.Flat
 import Proetale.Algebra.FaithfullyFlat
 import Proetale.Algebra.Ind
@@ -52,6 +54,34 @@ instance : (CommAlgCat.isLocalIso R).IsClosedUnderFiniteProducts :=
     apply (CommAlgCat.isLocalIso R).prop_of_iso (isoPi ≪≫ isoLim)
     have inst (i : ι) : Algebra.IsLocalIso R (S i) := hF ⟨i⟩
     exact Algebra.IsLocalIso.pi_of_finite R (fun i ↦ S i)
+
+/-- A local isomorphism of `R`-algebras is finitely presented. -/
+lemma Algebra.IsLocalIso.finitePresentation [Algebra.IsLocalIso R S] :
+    (algebraMap R S).FinitePresentation := by
+  apply RingHom.finitePresentation_ofLocalizationSpanTarget
+    (algebraMap R S) _ (Algebra.IsLocalIso.span_isStandardOpenImmersion_eq_top R S)
+  rintro ⟨g, hg⟩
+  rw [show (algebraMap S (Localization.Away g)).comp (algebraMap R S) =
+        algebraMap R (Localization.Away g) from
+      (IsScalarTower.algebraMap_eq R S (Localization.Away g)).symm,
+    RingHom.finitePresentation_algebraMap]
+  obtain ⟨r, hr⟩ := hg.exists_away
+  exact IsLocalization.Away.finitePresentation r
+
+/-- Local isomorphisms are finitely presentable in `CommAlgCat R`. -/
+lemma CommAlgCat.isLocalIso_le_isFinitelyPresentable :
+    CommAlgCat.isLocalIso R ≤
+      ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R) := by
+  intro S hS
+  have : Algebra.IsLocalIso R S := hS
+  have hfp : (algebraMap R S).FinitePresentation :=
+    Algebra.IsLocalIso.finitePresentation R S
+  have hunder : IsFinitelyPresentable.{u}
+      ((commAlgCatEquivUnder (.of R)).functor.obj S) :=
+    CommRingCat.isFinitelyPresentable_under _ _ (by convert hfp using 1)
+  have : Fact (Cardinal.aleph0 : Cardinal.{u}).IsRegular := Cardinal.fact_isRegular_aleph0
+  exact (isCardinalPresentable_iff_of_isEquivalence (X := S) (κ := .aleph0)
+    (commAlgCatEquivUnder (.of R)).functor).mp hunder
 
 /-- An algebra is ind-Zariski if it can be written as the filtered colimit of locally isomorphic
 algebras. -/


### PR DESCRIPTION
## Summary

Adds two small lemmas to `Proetale/Algebra/IndZariski.lean`:

- `Algebra.IsLocalIso.finitePresentation`: a local isomorphism of
  `R`-algebras is finitely presented as a ring homomorphism. The proof
  applies `RingHom.finitePresentation_ofLocalizationSpanTarget` to the
  standard-open-immersion span supplied by
  `Algebra.IsLocalIso.span_isStandardOpenImmersion_eq_top`, and uses
  `IsLocalization.Away.finitePresentation` on each piece.

- `CommAlgCat.isLocalIso_le_isFinitelyPresentable`: the object property
  `CommAlgCat.isLocalIso R` is contained in
  `ObjectProperty.isFinitelyPresentable.{u} (CommAlgCat.{u} R)`.
  Transported across the equivalence `commAlgCatEquivUnder` from
  `CommRingCat.isFinitelyPresentable_under`.

Both are prerequisites for further ind-Zariski development on the
`archon` branch (notably for chaining ind-Zariski against local
isomorphisms via `MorphismProperty.PreIndSpreads`).
