### PR TITLE
blueprint: add missing \leanok to formalised lemmas (easy case, round 2)

### DIFF
--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -108,6 +108,7 @@ In general, $\pi_0(X) \times \pi_0(Y)$ is continuous and bijective, but not nece
 \end{lemma}
 
 \begin{proof}
+  \leanok
   Use the universal property of connected components.
 \end{proof}
 
@@ -613,6 +614,7 @@ The second functor is fully faithful because \(f^\#\) is always an isomorphism, 
 \end{lemma}
 
 \begin{proof}
+    \leanok
     $S^{-1} A = \colim_{f \in S} A_f$ and $A \to A_f$ is a local isomorphism.
 \end{proof}
 
@@ -905,6 +907,7 @@ Obviously, every w-purely-local morphism is w-local.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{lemma:spectral-constructible-closed-closed}
   Since every point is closed, there are no nontrivial specializations between points. By \Cref{item:specialization-closed-spectral-constructible-closed-closed} in \Cref{lemma:spectral-constructible-closed-closed}, all constructible subsets of $X$ are closed. In particular, every compact open subset is also closed. Since $X$ is spectral, thus T0, for any two points there is a quasi-compact open (also closed) containing exactly one of them. Thus $X$ is profinite by \verb`isTotallyDisconnected_of_isClopen_set`.
 \end{proof}
@@ -933,6 +936,7 @@ Obviously, every w-purely-local morphism is w-local.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   Let $X$ be a spectral space and let $W$ denote $E^g$. Since every point of $W$ specializes to a point of $E$ we see that an open of $W$ which contains $E$ is equal to $W$. Hence since $E$ is quasi-compact, so is $W$. If $x \in X$, $x \notin W$, then $Z = \overline{\{x\}}$ is disjoint from $W$. Since $W$ is quasi-compact we can find a quasi-compact open $U$ (since there is a open basis of quasi-compact opens of $X$ and finitely many of them would suffice to cover $W$) with $W \subset U$ and $U \cap Z = \emptyset$. We conclude that $W$ is an intersection of quasi-compact open subsets.
 \end{proof}
 
@@ -1011,6 +1015,7 @@ a quasi-compact open $U$.
 \end{lemma}
 
 \begin{proof}
+    \leanok
     \uses{lemma:spectral-constructible-quasi-compact}
     It suffices to show the first claim. Let $x \in \overline{E}$
     and let $\{U_i\}_{i \in I}$ be the set of quasi-compact open neighbourhoods of $x$.
@@ -1121,6 +1126,7 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{thm:closed-subspace-w-local}
   This is \Cref{thm:closed-subspace-w-local}.
 \end{proof}
@@ -1434,6 +1440,7 @@ By the following lemma, we see $V(I_w)$ is the inverse limit of the closed subse
 \end{lemma}
 
 \begin{proof}
+  \leanok
   Omitted.
 \end{proof}
 
@@ -1446,6 +1453,7 @@ By the following lemma, we see $V(I_w)$ is the inverse limit of the closed subse
 \end{lemma}
 
 \begin{proof}
+    \leanok
     \uses{lemma:ind-Zariski-products, lemma:ind-ind-Zariski}
     For $E \subseteq A$ a finite subset, the $A$-algebra $A_E$ is ind-Zariski
     as a finite product of ind-Zariski algebras by \ref{lemma:ind-Zariski-products}.


### PR DESCRIPTION
Addresses #50 (easy case only).

Follow-up to #52. For each `\begin{proof}` block directly following a
`\lean{...}`-tagged lemma whose underlying Lean proof has become
sorry-free since #52 was merged, add `\leanok`.

## Scope

Only the **easy case** described in #50 — proof-level promotions for
`\lean{...}`-tagged lemmas whose Lean bodies are now sorry-free.

## What changed

8 proof-level `\leanok` insertions in
`blueprint/src/chapters/local-structure.tex`:

- `thm:pi0-isom` (`ConnectedComponents.mkHomeomorph`)
- `lemma:ind-Zariski-localization` (`Algebra.IndZariski.of_isLocalization`)
- `lemma:spectral-closed-points-profinite` (`SpectralSpace.totallySeparatedSpace`)
- `lemma:spectral-generalization-intersection-open` (`generalizationHull.eq_sInter_of_isCompact`)
- `lemma:spectral-constructible-closed-closed`
  (`exists_specializes_of_isClosed_constructibleTopology_of_mem_closure`,
   `IsClosed.of_isClosed_constructibleTopology`)
- `lemma:w-local-of-surjective` (`IsWLocalRing.of_surjective`)
- `lemma:colim-V` (`zeroLocus_eq_iInter_specComap_preimage`,
   `specComap_preimage_zeroLocus_subset`)
- `lemma:w-localization-ind-Zariski` (`WLocalization.indZariski`)

Other proof blocks still in #50's scope (e.g.
`Algebra.IndZariski.bijectiveOnStalks_algebraMap`,
`Algebra.IndEtale.trans`, `WLocalization.faithfullyFlat`,
`WLocalization.ProdStrata.*`, `WContractification.Restriction.*`,
`IsWContractibleRing.exists_retraction_of_zeroLocus_map_eq_closedPoints`,
…) still have `sorry` in their underlying Lean proofs and are left for
follow-ups.

The harder case from #50 (blueprint lemmas missing a `\lean{...}` tag
for an existing Lean declaration) is still untouched.