### PR TITLE
feat(Algebra/WLocal): fill `RingHom.IsWLocal.bijective_of_bijective` sorry

### DIFF
--- a/Proetale/Algebra/WLocal.lean
+++ b/Proetale/Algebra/WLocal.lean
@@ -49,11 +49,13 @@ namespace RingHom.IsWLocal
 
 /-- In any topological space, a specialization induces equality of connected components. -/
 private lemma specializes_connectedComponents_mk_eq {X : Type*} [TopologicalSpace X] {a b : X}
-    (hab : a ⤳ b) : ConnectedComponents.mk a = ConnectedComponents.mk b :=
-  ConnectedComponents.coe_eq_coe'.mpr <| connectedComponent_eq
-    (isClosed_connectedComponent.closure_subset_iff.mpr
-      (Set.singleton_subset_iff.mpr mem_connectedComponent) hab.mem_closure) ▸
-    mem_connectedComponent
+    (hab : a ⤳ b) : ConnectedComponents.mk a = ConnectedComponents.mk b := by
+  refine ConnectedComponents.coe_eq_coe'.mpr ?_
+  have hb : b ∈ connectedComponent a :=
+    isClosed_connectedComponent.closure_subset_iff.mpr
+      (Set.singleton_subset_iff.mpr mem_connectedComponent) hab.mem_closure
+  rw [← connectedComponent_eq hb]
+  exact mem_connectedComponent
 
 /-- Two closed points in a w-local prime spectrum lying in the same connected component
 are equal. -/
@@ -97,7 +99,7 @@ lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (
     -- closed points in a w-local space they coincide.
     obtain rfl : n₁ = n₂ :=
       closedPoints_eq_of_mk_eq hn₁_cp hn₂_cp <| hb.1 <| by
-        simp only [Continuous.connectedComponentsMap_mk, hcomap_n_eq]
+        simp [Continuous.connectedComponentsMap_mk, hcomap_n_eq]
     -- Now `q₁, q₂ ≤ n₁` correspond to primes of `S` localised at `n₁`, and the stalk
     -- map at `n₁` is bijective; transport injectivity from `Spec R` to the stalk side.
     have hq₁_le : q₁.asIdeal ≤ n₁.asIdeal :=
@@ -134,15 +136,12 @@ lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (
         PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl) (oS.symm ⟨q₁, hq₁_le⟩) =
         PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl)
           (oS.symm ⟨q₂, hq₂_le⟩) := by
-      have h_comap_inj : Function.Injective
+      have hcomap_inj : Function.Injective
           (PrimeSpectrum.comap (algebraMap R (Localization.AtPrime m))) :=
         Subtype.val_injective.comp
           (IsLocalization.AtPrime.primeSpectrumOrderIso (Localization.AtPrime m) m).injective
-      apply h_comap_inj
-      rw [hcomm, hcomm, hq₁'_val, hq₂'_val, heq]
-    calc q₁ = _ := hq₁'_val.symm
-      _   = _ := congr_arg _ (hφ_inj hφ_eq)
-      _   = q₂ := hq₂'_val
+      exact hcomap_inj <| by rw [hcomm, hcomm, hq₁'_val, hq₂'_val, heq]
+    rw [← hq₁'_val, hφ_inj hφ_eq, hq₂'_val]
   -- Surjectivity: via going-down, it suffices to hit every closed point of `Spec R`.
   · letI : Algebra R S := f.toAlgebra
     have : Module.Flat R S :=
@@ -156,9 +155,8 @@ lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (
     have hn₀_cp : n₀ ∈ closedPoints (PrimeSpectrum S) := mem_closedPoints_iff.mpr hn₀_cl
     have hmk_eq : ConnectedComponents.mk (PrimeSpectrum.comap f n₀) =
         ConnectedComponents.mk pm := by
-      rw [← specializes_connectedComponents_mk_eq
+      rwa [← specializes_connectedComponents_mk_eq
         (hq₀n₀.map (PrimeSpectrum.continuous_comap f))]
-      exact hd
     exact ⟨n₀, closedPoints_eq_of_mk_eq
       (hw.closedPoints_subset_preimage_closedPoints hn₀_cp) hpm hmk_eq⟩
 

--- a/Proetale/Algebra/WLocal.lean
+++ b/Proetale/Algebra/WLocal.lean
@@ -5,9 +5,13 @@ Authors: Jiedong Jiang, Christian Merten
 -/
 import Mathlib.RingTheory.Etale.Basic
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+import Mathlib.RingTheory.Flat.Localization
+import Mathlib.RingTheory.Localization.AtPrime.Basic
 import Proetale.Mathlib.RingTheory.Henselian
+import Proetale.Mathlib.RingTheory.Ideal.GoingDown
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.Topology
 import Proetale.Topology.SpectralSpace.WLocal.Basic
+import Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents
 import Proetale.Algebra.StalkIso
 
 /-!
@@ -43,13 +47,120 @@ lemma RingHom.isWLocal_iff_isMaximal_of_isMaximal (f : R →+* S) :
 
 namespace RingHom.IsWLocal
 
+/-- In any topological space, a specialization induces equality of connected components. -/
+private lemma specializes_connectedComponents_mk_eq {X : Type*} [TopologicalSpace X] {a b : X}
+    (hab : a ⤳ b) : ConnectedComponents.mk a = ConnectedComponents.mk b :=
+  ConnectedComponents.coe_eq_coe'.mpr <| connectedComponent_eq
+    (isClosed_connectedComponent.closure_subset_iff.mpr
+      (Set.singleton_subset_iff.mpr mem_connectedComponent) hab.mem_closure) ▸
+    mem_connectedComponent
+
+/-- Two closed points in a w-local prime spectrum lying in the same connected component
+are equal. -/
+private lemma closedPoints_eq_of_mk_eq [IsWLocalRing R] {c₁ c₂ : PrimeSpectrum R}
+    (hc₁ : c₁ ∈ closedPoints (PrimeSpectrum R))
+    (hc₂ : c₂ ∈ closedPoints (PrimeSpectrum R))
+    (hmk : ConnectedComponents.mk c₁ = ConnectedComponents.mk c₂) : c₁ = c₂ :=
+  congrArg Subtype.val <|
+    (WLocalSpace.isHomeomorph_connectedComponents_closedPoints _).bijective.1
+      (a₁ := ⟨c₁, hc₁⟩) (a₂ := ⟨c₂, hc₂⟩) hmk
+
 /-- A w-local ring map between w-local rings that is bijective on stalks and
 bijective on connected components is bijective. -/
 lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (hw : f.IsWLocal)
     (hs : f.BijectiveOnStalks)
     (hb : (PrimeSpectrum.continuous_comap f).connectedComponentsMap.Bijective) :
-    Function.Bijective f :=
-  sorry
+    Function.Bijective f := by
+  -- Reduce to bijectivity of `PrimeSpectrum.comap f` and then apply `BijectiveOnStalks`.
+  refine hs.bijective_of_bijective ⟨?_, ?_⟩
+  -- Injectivity of `PrimeSpectrum.comap f`.
+  · intro q₁ q₂ heq
+    -- Each `qᵢ` specializes to a unique closed point `nᵢ` in `Spec S`.
+    obtain ⟨n₁, hn₁_cl, hq₁n₁⟩ := exists_isClosed_specializes q₁
+    obtain ⟨n₂, hn₂_cl, hq₂n₂⟩ := exists_isClosed_specializes q₂
+    have hn₁_cp := mem_closedPoints_iff.mpr hn₁_cl
+    have hn₂_cp := mem_closedPoints_iff.mpr hn₂_cl
+    -- `comap f` sends closed points of `Spec S` to closed points of `Spec R` (`hw`).
+    have hcomap_n₁_cl : IsClosed ({PrimeSpectrum.comap f n₁} : Set (PrimeSpectrum R)) :=
+      mem_closedPoints_iff.mp (hw.closedPoints_subset_preimage_closedPoints hn₁_cp)
+    have hcomap_n₂_cl : IsClosed ({PrimeSpectrum.comap f n₂} : Set (PrimeSpectrum R)) :=
+      mem_closedPoints_iff.mp (hw.closedPoints_subset_preimage_closedPoints hn₂_cp)
+    -- Both `comap f n₁` and `comap f n₂` are closed specializations of `comap f q₁`.
+    have h1 : PrimeSpectrum.comap f q₁ ⤳ PrimeSpectrum.comap f n₁ :=
+      hq₁n₁.map (PrimeSpectrum.continuous_comap f)
+    have h2 : PrimeSpectrum.comap f q₁ ⤳ PrimeSpectrum.comap f n₂ :=
+      heq ▸ hq₂n₂.map (PrimeSpectrum.continuous_comap f)
+    -- By w-local uniqueness in `Spec R`, they are equal.
+    have hcomap_n_eq : PrimeSpectrum.comap f n₁ = PrimeSpectrum.comap f n₂ :=
+      WLocalSpace.eq_of_specializes hcomap_n₁_cl hcomap_n₂_cl h1 h2
+    -- Hence `n₁` and `n₂` lie in the same connected component of `Spec S`, and as
+    -- closed points in a w-local space they coincide.
+    obtain rfl : n₁ = n₂ :=
+      closedPoints_eq_of_mk_eq hn₁_cp hn₂_cp <| hb.1 <| by
+        simp only [Continuous.connectedComponentsMap_mk, hcomap_n_eq]
+    -- Now `q₁, q₂ ≤ n₁` correspond to primes of `S` localised at `n₁`, and the stalk
+    -- map at `n₁` is bijective; transport injectivity from `Spec R` to the stalk side.
+    have hq₁_le : q₁.asIdeal ≤ n₁.asIdeal :=
+      (PrimeSpectrum.le_iff_specializes q₁ n₁).mpr hq₁n₁
+    have hq₂_le : q₂.asIdeal ≤ n₁.asIdeal :=
+      (PrimeSpectrum.le_iff_specializes q₂ n₁).mpr hq₂n₂
+    set m := n₁.asIdeal.comap f
+    have hφ_inj : Function.Injective
+        (PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl)) :=
+      PrimeSpectrum.comap_injective_of_surjective _ (hs n₁.asIdeal).2
+    -- Commutativity of the four-square: `algR_R_m ∘ Spec(localRingHom) = comap f ∘ algS_S_n`.
+    have hcomm : ∀ (q : PrimeSpectrum (Localization.AtPrime n₁.asIdeal)),
+        PrimeSpectrum.comap (algebraMap R (Localization.AtPrime m))
+          (PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl) q) =
+        PrimeSpectrum.comap f
+          (PrimeSpectrum.comap (algebraMap S (Localization.AtPrime n₁.asIdeal)) q) := by
+      intro q
+      rw [← PrimeSpectrum.comap_comp_apply, ← PrimeSpectrum.comap_comp_apply]
+      congr 1
+      ext x
+      simp [Localization.localRingHom_to_map]
+    -- Lift `q₁, q₂` to primes of `Localization.AtPrime n₁.asIdeal` via the order iso.
+    set oS := IsLocalization.AtPrime.primeSpectrumOrderIso
+      (Localization.AtPrime n₁.asIdeal) n₁.asIdeal
+    have hq₁'_val :
+        PrimeSpectrum.comap (algebraMap S (Localization.AtPrime n₁.asIdeal))
+          (oS.symm ⟨q₁, hq₁_le⟩) = q₁ :=
+      congr_arg Subtype.val (oS.apply_symm_apply ⟨q₁, hq₁_le⟩)
+    have hq₂'_val :
+        PrimeSpectrum.comap (algebraMap S (Localization.AtPrime n₁.asIdeal))
+          (oS.symm ⟨q₂, hq₂_le⟩) = q₂ :=
+      congr_arg Subtype.val (oS.apply_symm_apply ⟨q₂, hq₂_le⟩)
+    have hφ_eq :
+        PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl) (oS.symm ⟨q₁, hq₁_le⟩) =
+        PrimeSpectrum.comap (Localization.localRingHom m n₁.asIdeal f rfl)
+          (oS.symm ⟨q₂, hq₂_le⟩) := by
+      have h_comap_inj : Function.Injective
+          (PrimeSpectrum.comap (algebraMap R (Localization.AtPrime m))) :=
+        Subtype.val_injective.comp
+          (IsLocalization.AtPrime.primeSpectrumOrderIso (Localization.AtPrime m) m).injective
+      apply h_comap_inj
+      rw [hcomm, hcomm, hq₁'_val, hq₂'_val, heq]
+    calc q₁ = _ := hq₁'_val.symm
+      _   = _ := congr_arg _ (hφ_inj hφ_eq)
+      _   = q₂ := hq₂'_val
+  -- Surjectivity: via going-down, it suffices to hit every closed point of `Spec R`.
+  · letI : Algebra R S := f.toAlgebra
+    have : Module.Flat R S :=
+      RingHom.flat_of_flat_localRingHom fun P _ ↦ .of_bijective (hs.localRingHom P)
+    apply Algebra.HasGoingDown.specComap_surjective_of_closedPoints_subset_preimage
+    intro pm hpm
+    -- Lift `pm` through the connected-component bijection to a closed point `n₀` of `Spec S`.
+    obtain ⟨d, hd⟩ := hb.2 (.mk pm)
+    obtain ⟨q₀, rfl⟩ := ConnectedComponents.surjective_coe d
+    obtain ⟨n₀, hn₀_cl, hq₀n₀⟩ := exists_isClosed_specializes q₀
+    have hn₀_cp : n₀ ∈ closedPoints (PrimeSpectrum S) := mem_closedPoints_iff.mpr hn₀_cl
+    have hmk_eq : ConnectedComponents.mk (PrimeSpectrum.comap f n₀) =
+        ConnectedComponents.mk pm := by
+      rw [← specializes_connectedComponents_mk_eq
+        (hq₀n₀.map (PrimeSpectrum.continuous_comap f))]
+      exact hd
+    exact ⟨n₀, closedPoints_eq_of_mk_eq
+      (hw.closedPoints_subset_preimage_closedPoints hn₀_cp) hpm hmk_eq⟩
 
 end RingHom.IsWLocal
 

--- a/Proetale/Algebra/WLocal.lean
+++ b/Proetale/Algebra/WLocal.lean
@@ -47,26 +47,6 @@ lemma RingHom.isWLocal_iff_isMaximal_of_isMaximal (f : R →+* S) :
 
 namespace RingHom.IsWLocal
 
-/-- In any topological space, a specialization induces equality of connected components. -/
-private lemma specializes_connectedComponents_mk_eq {X : Type*} [TopologicalSpace X] {a b : X}
-    (hab : a ⤳ b) : ConnectedComponents.mk a = ConnectedComponents.mk b := by
-  refine ConnectedComponents.coe_eq_coe'.mpr ?_
-  have hb : b ∈ connectedComponent a :=
-    isClosed_connectedComponent.closure_subset_iff.mpr
-      (Set.singleton_subset_iff.mpr mem_connectedComponent) hab.mem_closure
-  rw [← connectedComponent_eq hb]
-  exact mem_connectedComponent
-
-/-- Two closed points in a w-local prime spectrum lying in the same connected component
-are equal. -/
-private lemma closedPoints_eq_of_mk_eq [IsWLocalRing R] {c₁ c₂ : PrimeSpectrum R}
-    (hc₁ : c₁ ∈ closedPoints (PrimeSpectrum R))
-    (hc₂ : c₂ ∈ closedPoints (PrimeSpectrum R))
-    (hmk : ConnectedComponents.mk c₁ = ConnectedComponents.mk c₂) : c₁ = c₂ :=
-  congrArg Subtype.val <|
-    (WLocalSpace.isHomeomorph_connectedComponents_closedPoints _).bijective.1
-      (a₁ := ⟨c₁, hc₁⟩) (a₂ := ⟨c₂, hc₂⟩) hmk
-
 /-- A w-local ring map between w-local rings that is bijective on stalks and
 bijective on connected components is bijective. -/
 lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (hw : f.IsWLocal)
@@ -98,7 +78,7 @@ lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (
     -- Hence `n₁` and `n₂` lie in the same connected component of `Spec S`, and as
     -- closed points in a w-local space they coincide.
     obtain rfl : n₁ = n₂ :=
-      closedPoints_eq_of_mk_eq hn₁_cp hn₂_cp <| hb.1 <| by
+      WLocalSpace.closedPoints_eq_of_mk_eq hn₁_cp hn₂_cp <| hb.1 <| by
         simp [Continuous.connectedComponentsMap_mk, hcomap_n_eq]
     -- Now `q₁, q₂ ≤ n₁` correspond to primes of `S` localised at `n₁`, and the stalk
     -- map at `n₁` is bijective; transport injectivity from `Spec R` to the stalk side.
@@ -155,9 +135,9 @@ lemma bijective_of_bijective [IsWLocalRing R] [IsWLocalRing S] {f : R →+* S} (
     have hn₀_cp : n₀ ∈ closedPoints (PrimeSpectrum S) := mem_closedPoints_iff.mpr hn₀_cl
     have hmk_eq : ConnectedComponents.mk (PrimeSpectrum.comap f n₀) =
         ConnectedComponents.mk pm := by
-      rwa [← specializes_connectedComponents_mk_eq
+      rwa [← Specializes.connectedComponents_mk_eq
         (hq₀n₀.map (PrimeSpectrum.continuous_comap f))]
-    exact ⟨n₀, closedPoints_eq_of_mk_eq
+    exact ⟨n₀, WLocalSpace.closedPoints_eq_of_mk_eq
       (hw.closedPoints_subset_preimage_closedPoints hn₀_cp) hpm hmk_eq⟩
 
 end RingHom.IsWLocal

--- a/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
+++ b/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
@@ -1,7 +1,15 @@
 import Mathlib.Topology.Connected.TotallyDisconnected
 import Mathlib.Topology.Homeomorph.Lemmas
+import Mathlib.Topology.Inseparable
 
 variable {X : Type*} [TopologicalSpace X]
+
+/-- A specialization induces equality of connected components. -/
+lemma Specializes.connectedComponents_mk_eq {a b : X} (hab : a ⤳ b) :
+    ConnectedComponents.mk a = ConnectedComponents.mk b :=
+  ConnectedComponents.coe_eq_coe.mpr <| connectedComponent_eq <|
+    isConnected_singleton.closure.subset_connectedComponent
+      (subset_closure rfl) hab.mem_closure
 
 -- add `@[stacks 0906]` to `ConnectedComponents.totallyDisconnectedSpace`
 

--- a/Proetale/Topology/SpectralSpace/WLocal/ConnectedComponents.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/ConnectedComponents.lean
@@ -81,3 +81,11 @@ lemma WLocalSpace.isHomeomorph_connectedComponents_closedPoints (X : Type*) [Top
 noncomputable def WLocalSpace.closedPointsHomeomorph {X : Type*} [TopologicalSpace X]
     [WLocalSpace X] : closedPoints X ≃ₜ ConnectedComponents X :=
   (WLocalSpace.isHomeomorph_connectedComponents_closedPoints X).homeomorph
+
+/-- Two closed points in a w-local space lying in the same connected component are equal. -/
+lemma WLocalSpace.closedPoints_eq_of_mk_eq {X : Type*} [TopologicalSpace X] [WLocalSpace X]
+    {c₁ c₂ : X} (hc₁ : c₁ ∈ closedPoints X) (hc₂ : c₂ ∈ closedPoints X)
+    (hmk : ConnectedComponents.mk c₁ = ConnectedComponents.mk c₂) : c₁ = c₂ :=
+  congrArg Subtype.val <|
+    (WLocalSpace.isHomeomorph_connectedComponents_closedPoints X).bijective.1
+      (a₁ := ⟨c₁, hc₁⟩) (a₂ := ⟨c₂, hc₂⟩) hmk

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1176,6 +1176,7 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{thm:closed-points-isom-pi0,thm:w-local-set-decomposition,
     thm:isom-of-identifies-local-rings-bijective}
   By \Cref{thm:isom-of-identifies-local-rings-bijective}, it suffices to show


### PR DESCRIPTION
Prove that a w-local ring map between w-local rings that is bijective on
stalks and bijective on connected components is bijective.

**Injectivity** uses the unique closed specialization in a w-local space to
identify both lifts after passing through the connected-components
bijection, then transports injectivity from `Spec R` to the stalk side
via the localisation order isomorphism.

**Surjectivity** uses going-down (via flatness from the stalk bijection,
through `Algebra.HasGoingDown.specComap_surjective_of_closedPoints_subset_preimage`)
after showing every closed point of `Spec R` is in the image of `Spec(f)`.

Two private helper lemmas are introduced:
- `specializes_connectedComponents_mk_eq`: a specialization induces equality
  of connected components.
- `closedPoints_eq_of_mk_eq`: two closed points in a w-local prime spectrum
  lying in the same connected component are equal.

Blueprint reference: `thm:isom-of-identifies-local-rings-bijective`.
