### PR TITLE
feat(Mathlib/RingTheory/WeaklyEtale/Pi): finite product of weakly étale algebras

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -77,6 +77,7 @@ import Proetale.Mathlib.RingTheory.RingHom.OpenImmersion
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.RingHom
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.Topology
 import Proetale.Mathlib.RingTheory.TensorProduct.Maps
+import Proetale.Mathlib.RingTheory.WeaklyEtale.Pi
 import Proetale.Mathlib.Topology.Category.TopCat.Limits.Pullbacks
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
 import Proetale.Mathlib.Topology.Constructions

--- a/Proetale.lean
+++ b/Proetale.lean
@@ -70,6 +70,7 @@ import Proetale.Mathlib.CategoryTheory.Sites.Precoverage
 import Proetale.Mathlib.CategoryTheory.Sites.Sieves
 import Proetale.Mathlib.Order.BooleanAlgebra.Set
 import Proetale.Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+import Proetale.Mathlib.RingTheory.Flat.Pi
 import Proetale.Mathlib.RingTheory.Henselian
 import Proetale.Mathlib.RingTheory.Ideal.GoingDown
 import Proetale.Mathlib.RingTheory.RingHom.Flat
@@ -77,6 +78,7 @@ import Proetale.Mathlib.RingTheory.RingHom.OpenImmersion
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.RingHom
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.Topology
 import Proetale.Mathlib.RingTheory.TensorProduct.Maps
+import Proetale.Mathlib.RingTheory.WeaklyEtale.Local
 import Proetale.Mathlib.RingTheory.WeaklyEtale.Pi
 import Proetale.Mathlib.Topology.Category.TopCat.Limits.Pullbacks
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected

--- a/Proetale/Mathlib/RingTheory/Flat/Pi.lean
+++ b/Proetale/Mathlib/RingTheory/Flat/Pi.lean
@@ -17,7 +17,7 @@ from a finite product of commutative rings is flat as a ring map.
 ## Main results
 
 - `Module.Flat.pi`: a finite product of flat modules is flat.
-- `Pi.evalRingHom_flat`: a projection from a finite product of commutative rings is flat.
+- `Pi.flat_evalRingHom`: a projection from a finite product of commutative rings is flat.
 -/
 
 universe u v
@@ -34,7 +34,7 @@ instance Module.Flat.pi {R : Type*} [CommSemiring R] {ι : Type*} [Finite ι]
 
 The projection identifies `B i` with the localization of `∀ j, B j` away from the
 idempotent `Pi.single i 1`. -/
-lemma Pi.evalRingHom_flat {ι : Type*} (B : ι → Type*) [∀ i, CommRing (B i)] (i : ι) :
+lemma Pi.flat_evalRingHom {ι : Type*} (B : ι → Type*) [∀ i, CommRing (B i)] (i : ι) :
     (Pi.evalRingHom B i).Flat := by
   classical
   algebraize [Pi.evalRingHom B i]

--- a/Proetale/Mathlib/RingTheory/Flat/Pi.lean
+++ b/Proetale/Mathlib/RingTheory/Flat/Pi.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.Algebra.DirectSum.Module
+import Mathlib.RingTheory.Flat.Localization
+import Mathlib.RingTheory.Localization.Away.Basic
+import Mathlib.RingTheory.RingHom.Flat
+
+/-!
+# Flatness of finite products
+
+We show that a finite product of flat modules is flat, and that a projection
+from a finite product of commutative rings is flat as a ring map.
+
+## Main results
+
+- `Module.Flat.pi`: a finite product of flat modules is flat.
+- `Pi.evalRingHom_flat`: a projection from a finite product of commutative rings is flat.
+-/
+
+universe u v
+
+/-- A finite product of flat modules is flat. -/
+instance Module.Flat.pi {R : Type*} [CommSemiring R] {ι : Type*} [Finite ι]
+    {M : ι → Type*} [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
+    [∀ i, Module.Flat R (M i)] : Module.Flat R (∀ i, M i) := by
+  classical
+  cases nonempty_fintype ι
+  exact .of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm
+
+/-- A projection from a finite product of commutative rings is flat as a ring map.
+
+The projection identifies `B i` with the localization of `∀ j, B j` away from the
+idempotent `Pi.single i 1`. -/
+lemma Pi.evalRingHom_flat {ι : Type*} (B : ι → Type*) [∀ i, CommRing (B i)] (i : ι) :
+    (Pi.evalRingHom B i).Flat := by
+  classical
+  algebraize [Pi.evalRingHom B i]
+  have he : IsIdempotentElem (Pi.single i 1 : ∀ j, B j) := by
+    rw [IsIdempotentElem, ← Pi.single_mul, mul_one]
+  haveI : IsLocalization.Away (Pi.single i 1 : ∀ j, B j) (B i) :=
+    IsLocalization.away_of_isIdempotentElem he (RingHom.ker_evalRingHom B i)
+      (Function.surjective_eval i)
+  exact IsLocalization.flat (B i) (Submonoid.powers (Pi.single i 1 : ∀ j, B j))

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Local.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Local.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RingTheory.Etale.Weakly
+import Mathlib.RingTheory.Flat.Localization
+import Mathlib.RingTheory.Localization.Away.Basic
+import Mathlib.RingTheory.RingHom.Flat
+
+/-!
+# Weakly étale is local on the target
+
+We show that being a weakly étale algebra can be checked on a standard cover of the target.
+
+## Main results
+
+- `Algebra.WeaklyEtale.of_span_eq_top_target_of_isLocalizationAway`: weak étaleness can be
+  checked on a standard cover of the target.
+-/
+
+universe u v
+
+open TensorProduct
+
+namespace Algebra.WeaklyEtale
+
+/-- Being a weakly étale algebra can be checked on a standard cover of the target. -/
+lemma of_span_eq_top_target_of_isLocalizationAway
+    {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    {ι : Type*} (s : ι → S) (hs : Ideal.span (Set.range s) = ⊤)
+    (T : ι → Type*) [∀ i, CommRing (T i)] [∀ i, Algebra R (T i)]
+    [∀ i, Algebra S (T i)] [∀ i, IsScalarTower R S (T i)]
+    [∀ i, IsLocalization.Away (s i) (T i)]
+    [∀ i, Algebra.WeaklyEtale R (T i)] :
+    Algebra.WeaklyEtale R S := by
+  classical
+  let idx : Set.range s → ι := fun r ↦ r.2.choose
+  have hidx (r : Set.range s) : s (idx r) = r.1 := r.2.choose_spec
+  haveI hloc : ∀ r : Set.range s, IsLocalization.Away r.1 (T (idx r)) := fun r =>
+    hidx r ▸ (inferInstance : IsLocalization.Away (s (idx r)) (T (idx r)))
+  refine ⟨?_, ?_⟩
+  · exact Module.flat_of_isLocalized_span S S (Set.range s) hs
+      (fun r ↦ T (idx r)) (fun r ↦ Algebra.linearMap S (T (idx r)))
+      (fun _ ↦ inferInstance)
+  · algebraize [(Algebra.TensorProduct.lmul' R (S := S)).toRingHom]
+    haveI : IsScalarTower (S ⊗[R] S) S S := .right
+    letI alg (r : Set.range s) : Algebra (S ⊗[R] S) (T (idx r)) :=
+      ((algebraMap S (T (idx r))).comp (algebraMap (S ⊗[R] S) S)).toAlgebra
+    haveI tower (r : Set.range s) : IsScalarTower (S ⊗[R] S) S (T (idx r)) :=
+      IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+    have flat_T (r : Set.range s) : Module.Flat (S ⊗[R] S) (T (idx r)) := by
+      let i := idx r
+      let α : S →ₐ[R] T i := IsScalarTower.toAlgHom R S (T i)
+      have hα : α.toRingHom.Flat :=
+        RingHom.flat_algebraMap_iff.mpr (IsLocalization.flat (T i) (.powers (s i)))
+      have hαα : (Algebra.TensorProduct.map α α).toRingHom.Flat :=
+        RingHom.Flat.tensorProductMap hα hα
+      have hlmul : (Algebra.TensorProduct.lmul' R (S := T i)).toRingHom.Flat :=
+        Algebra.WeaklyEtale.flat_lmul' R (T i)
+      have hcomp : ((Algebra.TensorProduct.lmul' R (S := T i)).toRingHom.comp
+          (Algebra.TensorProduct.map α α).toRingHom).Flat :=
+        RingHom.Flat.comp hαα hlmul
+      have hα_eq : α.toRingHom.comp (Algebra.TensorProduct.lmul' R (S := S)).toRingHom =
+          (Algebra.TensorProduct.lmul' R (S := T i)).toRingHom.comp
+            (Algebra.TensorProduct.map α α).toRingHom := by
+        ext x
+        all_goals
+          simp [Algebra.TensorProduct.lmul'_apply_tmul, Algebra.TensorProduct.map_tmul]
+      have heq : algebraMap (S ⊗[R] S) (T i) =
+          (Algebra.TensorProduct.lmul' R (S := T i)).toRingHom.comp
+            (Algebra.TensorProduct.map α α).toRingHom :=
+        hα_eq
+      rw [← RingHom.flat_algebraMap_iff, heq]
+      exact hcomp
+    exact Module.flat_of_isLocalized_span (R := S ⊗[R] S) S S (Set.range s) hs
+      (fun r ↦ T (idx r)) (fun r ↦ Algebra.linearMap S (T (idx r))) flat_T
+
+end Algebra.WeaklyEtale

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Local.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Local.lean
@@ -17,6 +17,7 @@ We show that being a weakly étale algebra can be checked on a standard cover of
 
 - `Algebra.WeaklyEtale.of_span_eq_top_target_of_isLocalizationAway`: weak étaleness can be
   checked on a standard cover of the target.
+- `Algebra.WeaklyEtale.of_span_eq_top_target`: `Localization.Away` variant of the above.
 -/
 
 universe u v
@@ -37,17 +38,17 @@ lemma of_span_eq_top_target_of_isLocalizationAway
   classical
   let idx : Set.range s → ι := fun r ↦ r.2.choose
   have hidx (r : Set.range s) : s (idx r) = r.1 := r.2.choose_spec
-  haveI hloc : ∀ r : Set.range s, IsLocalization.Away r.1 (T (idx r)) := fun r =>
+  have hloc : ∀ r : Set.range s, IsLocalization.Away r.1 (T (idx r)) := fun r =>
     hidx r ▸ (inferInstance : IsLocalization.Away (s (idx r)) (T (idx r)))
   refine ⟨?_, ?_⟩
   · exact Module.flat_of_isLocalized_span S S (Set.range s) hs
       (fun r ↦ T (idx r)) (fun r ↦ Algebra.linearMap S (T (idx r)))
       (fun _ ↦ inferInstance)
   · algebraize [(Algebra.TensorProduct.lmul' R (S := S)).toRingHom]
-    haveI : IsScalarTower (S ⊗[R] S) S S := .right
-    letI alg (r : Set.range s) : Algebra (S ⊗[R] S) (T (idx r)) :=
+    have : IsScalarTower (S ⊗[R] S) S S := .right
+    let alg (r : Set.range s) : Algebra (S ⊗[R] S) (T (idx r)) :=
       ((algebraMap S (T (idx r))).comp (algebraMap (S ⊗[R] S) S)).toAlgebra
-    haveI tower (r : Set.range s) : IsScalarTower (S ⊗[R] S) S (T (idx r)) :=
+    have tower (r : Set.range s) : IsScalarTower (S ⊗[R] S) S (T (idx r)) :=
       IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
     have flat_T (r : Set.range s) : Module.Flat (S ⊗[R] S) (T (idx r)) := by
       let i := idx r
@@ -75,5 +76,14 @@ lemma of_span_eq_top_target_of_isLocalizationAway
       exact hcomp
     exact Module.flat_of_isLocalized_span (R := S ⊗[R] S) S S (Set.range s) hs
       (fun r ↦ T (idx r)) (fun r ↦ Algebra.linearMap S (T (idx r))) flat_T
+
+/-- Being a weakly étale algebra can be checked on a standard cover of the target,
+applied to the canonical `Localization.Away`. -/
+lemma of_span_eq_top_target
+    {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    {ι : Type*} (s : ι → S) (hs : Ideal.span (Set.range s) = ⊤)
+    [∀ i, Algebra.WeaklyEtale R (Localization.Away (s i))] :
+    Algebra.WeaklyEtale R S :=
+  of_span_eq_top_target_of_isLocalizationAway s hs (fun i ↦ Localization.Away (s i))
 
 end Algebra.WeaklyEtale

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Pi.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Pi.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.RingTheory.Etale.Pi
-import Mathlib.RingTheory.Localization.Away.Basic
-import Mathlib.RingTheory.Flat.Localization
-import Mathlib.RingTheory.Flat.Stability
-import Proetale.Algebra.WeaklyEtale
+import Proetale.Mathlib.RingTheory.WeaklyEtale.Local
 
 /-!
 # Finite product of weakly étale algebras
@@ -22,37 +19,6 @@ then `∀ i, B i` is a weakly étale `A`-algebra.
 
 universe u v
 
-open scoped TensorProduct
-
-/-- A finite product of flat modules is flat. -/
-private lemma Module.Flat.finitePi
-    {R : Type*} [CommSemiring R] {ι : Type*} [Finite ι]
-    {M : ι → Type*} [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
-    [∀ i, Module.Flat R (M i)] : Module.Flat R (∀ i, M i) := by
-  classical
-  cases nonempty_fintype ι
-  exact .of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm
-
-/-- A projection from a finite product of commutative rings is flat as a ring map.
-
-The projection identifies `B i` with the localization of `∀ j, B j` away from the
-idempotent `Pi.single i 1`. -/
-private lemma _root_.Pi.evalRingHom_flat
-    {ι : Type*} (B : ι → Type*) [∀ i, CommRing (B i)] (i : ι) :
-    (Pi.evalRingHom B i).Flat := by
-  classical
-  letI : Algebra (∀ j, B j) (B i) := (Pi.evalRingHom B i).toAlgebra
-  have he : IsIdempotentElem (Pi.single i 1 : ∀ j, B j) := by
-    rw [IsIdempotentElem, ← Pi.single_mul, mul_one]
-  have hker : RingHom.ker (algebraMap (∀ j, B j) (B i)) =
-      Ideal.span {1 - Pi.single i 1} := RingHom.ker_evalRingHom B i
-  have hsurj : Function.Surjective (algebraMap (∀ j, B j) (B i)) :=
-    Function.surjective_eval i
-  haveI : IsLocalization.Away (Pi.single i 1 : ∀ j, B j) (B i) :=
-    IsLocalization.away_of_isIdempotentElem he hker hsurj
-  change Module.Flat (∀ j, B j) (B i)
-  exact IsLocalization.flat (B i) (Submonoid.powers (Pi.single i 1 : ∀ j, B j))
-
 namespace Algebra
 
 /-- A finite product of weakly étale algebras over `A` is weakly étale. -/
@@ -62,52 +28,12 @@ instance WeaklyEtale.pi {A : Type u} [CommRing A]
     [∀ i, Algebra.WeaklyEtale A (B i)] :
     Algebra.WeaklyEtale A (∀ i, B i) := by
   classical
-  cases nonempty_fintype ι
-  refine ⟨Module.Flat.finitePi, ?_⟩
-  let S := ∀ i, B i
-  -- For each `k`, install the `(S ⊗[A] S)`-algebra structure on `B k` given by
-  -- `proj_k ∘ lmul'`. By naturality of `lmul'`, this map factors as
-  -- `lmul' A (B k) ∘ TensorProduct.map proj_k proj_k`, so flatness reduces to
-  -- `proj_k`-flatness and `Algebra.WeaklyEtale.flat_lmul'` for each `B k`.
-  letI : ∀ k, Algebra (S ⊗[A] S) (B k) := fun k =>
-    ((Pi.evalAlgHom A B k).toRingHom.comp
-      (Algebra.TensorProduct.lmul' A (S := S)).toRingHom).toAlgebra
-  haveI : ∀ k, Module.Flat (S ⊗[A] S) (B k) := fun k => by
-    have hf : (Pi.evalAlgHom A B k).toRingHom.Flat := Pi.evalRingHom_flat B k
-    have h1 : (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
-        (Pi.evalAlgHom A B k)).toRingHom.Flat :=
-      Algebra.TensorProduct.flat_map hf hf
-    have h2 : (Algebra.TensorProduct.lmul' A (S := B k)).toRingHom.Flat :=
-      Algebra.WeaklyEtale.flat_lmul' A (B k)
-    have hnat : (Pi.evalAlgHom A B k).comp (Algebra.TensorProduct.lmul' A (S := S)) =
-        (Algebra.TensorProduct.lmul' A (S := B k)).comp
-          (Algebra.TensorProduct.map (Pi.evalAlgHom A B k) (Pi.evalAlgHom A B k)) := by
-      apply Algebra.TensorProduct.ext
-      · ext x
-        change (Pi.evalAlgHom A B k) (Algebra.TensorProduct.lmul' A (x ⊗ₜ[A] 1)) =
-            Algebra.TensorProduct.lmul' A (S := B k)
-              (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
-                (Pi.evalAlgHom A B k) (x ⊗ₜ[A] 1))
-        rw [Algebra.TensorProduct.lmul'_apply_tmul, Algebra.TensorProduct.map_tmul,
-          Algebra.TensorProduct.lmul'_apply_tmul, map_one, mul_one, mul_one]
-      · ext x
-        change (Pi.evalAlgHom A B k) (Algebra.TensorProduct.lmul' A (1 ⊗ₜ[A] x)) =
-            Algebra.TensorProduct.lmul' A (S := B k)
-              (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
-                (Pi.evalAlgHom A B k) (1 ⊗ₜ[A] x))
-        rw [Algebra.TensorProduct.lmul'_apply_tmul, Algebra.TensorProduct.map_tmul,
-          Algebra.TensorProduct.lmul'_apply_tmul, map_one, one_mul, one_mul]
-    have heq : ((Pi.evalAlgHom A B k).toRingHom.comp
-          (Algebra.TensorProduct.lmul' A (S := S)).toRingHom) =
-        ((Algebra.TensorProduct.lmul' A (S := B k)).toRingHom.comp
-          (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
-            (Pi.evalAlgHom A B k)).toRingHom) := by
-      simpa using congr_arg AlgHom.toRingHom hnat
-    change RingHom.Flat ((Pi.evalAlgHom A B k).toRingHom.comp
-      (Algebra.TensorProduct.lmul' A (S := S)).toRingHom)
-    rw [heq]
-    exact RingHom.Flat.comp h1 h2
-  change Module.Flat (S ⊗[A] S) S
-  exact Module.Flat.finitePi
+  letI (i : ι) : Algebra (∀ j, B j) (B i) := (Pi.evalAlgHom A B i).toAlgebra
+  have (i : ι) : IsLocalization.Away (Pi.single i 1 : ∀ j, B j) (B i) := by
+    refine IsLocalization.away_of_isIdempotentElem ?_ (RingHom.ker_evalRingHom _ _)
+      ((Pi.evalRingHom B i).surjective)
+    rw [IsIdempotentElem, ← Pi.single_mul, mul_one]
+  exact Algebra.WeaklyEtale.of_span_eq_top_target_of_isLocalizationAway
+    _ (Ideal.span_single_eq_top B) (fun i ↦ B i)
 
 end Algebra

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Pi.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Pi.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RingTheory.Etale.Pi
+import Mathlib.RingTheory.Localization.Away.Basic
+import Mathlib.RingTheory.Flat.Localization
+import Mathlib.RingTheory.Flat.Stability
+import Proetale.Algebra.WeaklyEtale
+
+/-!
+# Finite product of weakly étale algebras
+
+If `B i` is a weakly étale `A`-algebra for each `i` in a finite indexing type,
+then `∀ i, B i` is a weakly étale `A`-algebra.
+
+## Main results
+
+- `Algebra.WeaklyEtale.pi`: a finite product of weakly étale algebras is weakly étale.
+-/
+
+universe u v
+
+open scoped TensorProduct
+
+/-- A finite product of flat modules is flat. -/
+private lemma Module.Flat.finitePi
+    {R : Type*} [CommSemiring R] {ι : Type*} [Finite ι]
+    {M : ι → Type*} [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
+    [∀ i, Module.Flat R (M i)] : Module.Flat R (∀ i, M i) := by
+  classical
+  cases nonempty_fintype ι
+  exact .of_linearEquiv (DirectSum.linearEquivFunOnFintype R ι M).symm
+
+/-- A projection from a finite product of commutative rings is flat as a ring map.
+
+The projection identifies `B i` with the localization of `∀ j, B j` away from the
+idempotent `Pi.single i 1`. -/
+private lemma _root_.Pi.evalRingHom_flat
+    {ι : Type*} (B : ι → Type*) [∀ i, CommRing (B i)] (i : ι) :
+    (Pi.evalRingHom B i).Flat := by
+  classical
+  letI : Algebra (∀ j, B j) (B i) := (Pi.evalRingHom B i).toAlgebra
+  have he : IsIdempotentElem (Pi.single i 1 : ∀ j, B j) := by
+    rw [IsIdempotentElem, ← Pi.single_mul, mul_one]
+  have hker : RingHom.ker (algebraMap (∀ j, B j) (B i)) =
+      Ideal.span {1 - Pi.single i 1} := RingHom.ker_evalRingHom B i
+  have hsurj : Function.Surjective (algebraMap (∀ j, B j) (B i)) :=
+    Function.surjective_eval i
+  haveI : IsLocalization.Away (Pi.single i 1 : ∀ j, B j) (B i) :=
+    IsLocalization.away_of_isIdempotentElem he hker hsurj
+  change Module.Flat (∀ j, B j) (B i)
+  exact IsLocalization.flat (B i) (Submonoid.powers (Pi.single i 1 : ∀ j, B j))
+
+namespace Algebra
+
+/-- A finite product of weakly étale algebras over `A` is weakly étale. -/
+instance WeaklyEtale.pi {A : Type u} [CommRing A]
+    {ι : Type v} [Finite ι] {B : ι → Type*}
+    [∀ i, CommRing (B i)] [∀ i, Algebra A (B i)]
+    [∀ i, Algebra.WeaklyEtale A (B i)] :
+    Algebra.WeaklyEtale A (∀ i, B i) := by
+  classical
+  cases nonempty_fintype ι
+  refine ⟨Module.Flat.finitePi, ?_⟩
+  let S := ∀ i, B i
+  -- For each `k`, install the `(S ⊗[A] S)`-algebra structure on `B k` given by
+  -- `proj_k ∘ lmul'`. By naturality of `lmul'`, this map factors as
+  -- `lmul' A (B k) ∘ TensorProduct.map proj_k proj_k`, so flatness reduces to
+  -- `proj_k`-flatness and `Algebra.WeaklyEtale.flat_lmul'` for each `B k`.
+  letI : ∀ k, Algebra (S ⊗[A] S) (B k) := fun k =>
+    ((Pi.evalAlgHom A B k).toRingHom.comp
+      (Algebra.TensorProduct.lmul' A (S := S)).toRingHom).toAlgebra
+  haveI : ∀ k, Module.Flat (S ⊗[A] S) (B k) := fun k => by
+    have hf : (Pi.evalAlgHom A B k).toRingHom.Flat := Pi.evalRingHom_flat B k
+    have h1 : (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
+        (Pi.evalAlgHom A B k)).toRingHom.Flat :=
+      Algebra.TensorProduct.flat_map hf hf
+    have h2 : (Algebra.TensorProduct.lmul' A (S := B k)).toRingHom.Flat :=
+      Algebra.WeaklyEtale.flat_lmul' A (B k)
+    have hnat : (Pi.evalAlgHom A B k).comp (Algebra.TensorProduct.lmul' A (S := S)) =
+        (Algebra.TensorProduct.lmul' A (S := B k)).comp
+          (Algebra.TensorProduct.map (Pi.evalAlgHom A B k) (Pi.evalAlgHom A B k)) := by
+      apply Algebra.TensorProduct.ext
+      · ext x
+        change (Pi.evalAlgHom A B k) (Algebra.TensorProduct.lmul' A (x ⊗ₜ[A] 1)) =
+            Algebra.TensorProduct.lmul' A (S := B k)
+              (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
+                (Pi.evalAlgHom A B k) (x ⊗ₜ[A] 1))
+        rw [Algebra.TensorProduct.lmul'_apply_tmul, Algebra.TensorProduct.map_tmul,
+          Algebra.TensorProduct.lmul'_apply_tmul, map_one, mul_one, mul_one]
+      · ext x
+        change (Pi.evalAlgHom A B k) (Algebra.TensorProduct.lmul' A (1 ⊗ₜ[A] x)) =
+            Algebra.TensorProduct.lmul' A (S := B k)
+              (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
+                (Pi.evalAlgHom A B k) (1 ⊗ₜ[A] x))
+        rw [Algebra.TensorProduct.lmul'_apply_tmul, Algebra.TensorProduct.map_tmul,
+          Algebra.TensorProduct.lmul'_apply_tmul, map_one, one_mul, one_mul]
+    have heq : ((Pi.evalAlgHom A B k).toRingHom.comp
+          (Algebra.TensorProduct.lmul' A (S := S)).toRingHom) =
+        ((Algebra.TensorProduct.lmul' A (S := B k)).toRingHom.comp
+          (Algebra.TensorProduct.map (Pi.evalAlgHom A B k)
+            (Pi.evalAlgHom A B k)).toRingHom) := by
+      simpa using congr_arg AlgHom.toRingHom hnat
+    change RingHom.Flat ((Pi.evalAlgHom A B k).toRingHom.comp
+      (Algebra.TensorProduct.lmul' A (S := S)).toRingHom)
+    rw [heq]
+    exact RingHom.Flat.comp h1 h2
+  change Module.Flat (S ⊗[A] S) S
+  exact Module.Flat.finitePi
+
+end Algebra


### PR DESCRIPTION
## Summary

Upstreams `Algebra.WeaklyEtale.pi` from the `archon` branch: a finite product of weakly étale `A`-algebras is weakly étale.

Two auxiliary results are added as `private`:
- `Module.Flat.finitePi`: a finite product of flat modules is flat.
- `Pi.evalRingHom_flat`: a projection out of a finite product of commutative rings is a flat ring map (via the localization-away-from-an-idempotent characterization).

The proof of the main instance reduces flatness of `lmul' A S` for `S = ∀ i, B i` to per-factor flatness of `lmul' A (B k)` (which holds by `Algebra.WeaklyEtale.flat_lmul'`) using the naturality square `proj_k ∘ lmul' A S = lmul' A (B k) ∘ map proj_k proj_k`.

## Test plan

- [x] `lake build Proetale/Mathlib/RingTheory/WeaklyEtale/Pi.lean` succeeds with no errors or warnings.
- [x] Full `lake build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
