### PR TITLE
feat(Mathlib/RingTheory/Etale/Prod): binary product of formally étale algebras

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -69,6 +69,7 @@ import Proetale.Mathlib.CategoryTheory.Sites.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.Sites.Precoverage
 import Proetale.Mathlib.CategoryTheory.Sites.Sieves
 import Proetale.Mathlib.Order.BooleanAlgebra.Set
+import Proetale.Mathlib.RingTheory.Etale.Prod
 import Proetale.Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 import Proetale.Mathlib.RingTheory.Henselian
 import Proetale.Mathlib.RingTheory.Ideal.GoingDown

--- a/Proetale/Mathlib/RingTheory/Etale/Prod.lean
+++ b/Proetale/Mathlib/RingTheory/Etale/Prod.lean
@@ -53,21 +53,21 @@ private instance fin2Fam_algebra :
 
 instance FormallyUnramified.prod [FormallyUnramified R A] [FormallyUnramified R B] :
     FormallyUnramified R (A × B) :=
-  haveI : ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
+  letI : ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallyUnramified R A›
     | ⟨1, _⟩ => ‹FormallyUnramified R B›
   FormallyUnramified.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallySmooth.prod [FormallySmooth R A] [FormallySmooth R B] :
     FormallySmooth R (A × B) :=
-  haveI : ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
+  letI : ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallySmooth R A›
     | ⟨1, _⟩ => ‹FormallySmooth R B›
   FormallySmooth.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
     FormallyEtale R (A × B) :=
-  haveI : ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
+  letI : ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallyEtale R A›
     | ⟨1, _⟩ => ‹FormallyEtale R B›
   FormallyEtale.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
@@ -75,10 +75,10 @@ instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
 /-- `A × B` is finitely presented as an `R`-algebra when both factors are. -/
 instance FinitePresentation.prod [FinitePresentation R A] [FinitePresentation R B] :
     FinitePresentation R (A × B) :=
-  haveI : ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
+  letI : ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FinitePresentation R A›
     | ⟨1, _⟩ => ‹FinitePresentation R B›
-  haveI : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
+  letI : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
     Algebra.FinitePresentation.pi (fin2Fam A B)
   Algebra.FinitePresentation.equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 

--- a/Proetale/Mathlib/RingTheory/Etale/Prod.lean
+++ b/Proetale/Mathlib/RingTheory/Etale/Prod.lean
@@ -53,21 +53,21 @@ private instance fin2Fam_algebra :
 
 instance FormallyUnramified.prod [FormallyUnramified R A] [FormallyUnramified R B] :
     FormallyUnramified R (A × B) :=
-  letI : ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
+  have : ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallyUnramified R A›
     | ⟨1, _⟩ => ‹FormallyUnramified R B›
   FormallyUnramified.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallySmooth.prod [FormallySmooth R A] [FormallySmooth R B] :
     FormallySmooth R (A × B) :=
-  letI : ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
+  have : ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallySmooth R A›
     | ⟨1, _⟩ => ‹FormallySmooth R B›
   FormallySmooth.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
     FormallyEtale R (A × B) :=
-  letI : ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
+  have : ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FormallyEtale R A›
     | ⟨1, _⟩ => ‹FormallyEtale R B›
   FormallyEtale.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
@@ -75,10 +75,10 @@ instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
 /-- `A × B` is finitely presented as an `R`-algebra when both factors are. -/
 instance FinitePresentation.prod [FinitePresentation R A] [FinitePresentation R B] :
     FinitePresentation R (A × B) :=
-  letI : ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
+  have : ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
     | ⟨0, _⟩ => ‹FinitePresentation R A›
     | ⟨1, _⟩ => ‹FinitePresentation R B›
-  letI : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
+  have : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
     Algebra.FinitePresentation.pi (fin2Fam A B)
   Algebra.FinitePresentation.equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 

--- a/Proetale/Mathlib/RingTheory/Etale/Prod.lean
+++ b/Proetale/Mathlib/RingTheory/Etale/Prod.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RingTheory.Etale.Pi
+import Mathlib.Algebra.Ring.Fin
+import Mathlib.RingTheory.RingHom.FinitePresentation
+
+/-!
+# Formal-étaleness of binary products of rings
+
+We deduce that the binary product of two formally-étale `R`-algebras is formally-étale,
+and likewise for étale, formally unramified, and formally smooth, by transferring the
+finite-Pi case from `Mathlib.RingTheory.Etale.Pi`.
+
+Rather than using `Matrix.vecCons` (whose elaboration does not eagerly reduce
+`![A, B] 0` to `A`), we use an explicit case-based family `fin2Fam A B i`
+defined by `Fin` pattern matching on `Fin 2`, so that `fin2Fam A B 0 = A` and
+`fin2Fam A B 1 = B` reduce definitionally.
+
+## Main results
+
+- `Algebra.FormallyEtale.prod`: `A × B` is `R`-formally-étale when `A` and `B` are.
+- `Algebra.Etale.prod`: `A × B` is `R`-étale when `A` and `B` are.
+- `Algebra.FormallyUnramified.prod`: `A × B` is `R`-formally-unramified when `A` and `B` are.
+- `Algebra.FormallySmooth.prod`: `A × B` is `R`-formally-smooth when `A` and `B` are.
+-/
+
+universe u
+
+namespace Algebra
+
+variable {R A B : Type u}
+variable [CommRing R] [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+
+/-- A binary family `Fin 2 → Type u`. Definitionally `fin2Fam A B 0 = A` and
+`fin2Fam A B 1 = B`. -/
+private def fin2Fam (A B : Type u) : Fin 2 → Type u
+  | ⟨0, _⟩ => A
+  | ⟨1, _⟩ => B
+
+private instance fin2Fam_commRing :
+    ∀ i : Fin 2, CommRing (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹CommRing A›
+  | ⟨1, _⟩ => ‹CommRing B›
+
+private instance fin2Fam_algebra :
+    ∀ i : Fin 2, Algebra R (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹Algebra R A›
+  | ⟨1, _⟩ => ‹Algebra R B›
+
+private instance fin2Fam_formallyUnramified [FormallyUnramified R A] [FormallyUnramified R B] :
+    ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹FormallyUnramified R A›
+  | ⟨1, _⟩ => ‹FormallyUnramified R B›
+
+private instance fin2Fam_formallySmooth [FormallySmooth R A] [FormallySmooth R B] :
+    ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹FormallySmooth R A›
+  | ⟨1, _⟩ => ‹FormallySmooth R B›
+
+private instance fin2Fam_formallyEtale [FormallyEtale R A] [FormallyEtale R B] :
+    ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹FormallyEtale R A›
+  | ⟨1, _⟩ => ‹FormallyEtale R B›
+
+private instance fin2Fam_finitePresentation
+    [FinitePresentation R A] [FinitePresentation R B] :
+    ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
+  | ⟨0, _⟩ => ‹FinitePresentation R A›
+  | ⟨1, _⟩ => ‹FinitePresentation R B›
+
+/-- The natural ring equivalence `((i : Fin 2) → fin2Fam A B i) ≃+* A × B`,
+defined by `(f ↦ (f 0, f 1))`. -/
+@[simps!]
+private def ringEquivProdFin2 (A B : Type u) [CommRing A] [CommRing B] :
+    ((i : Fin 2) → fin2Fam A B i) ≃+* A × B where
+  toFun f := (f 0, f 1)
+  invFun p := fun i => match i with
+    | ⟨0, _⟩ => p.1
+    | ⟨1, _⟩ => p.2
+  left_inv f := by
+    funext i
+    match i with
+    | ⟨0, _⟩ => rfl
+    | ⟨1, _⟩ => rfl
+  right_inv p := rfl
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+
+/-- The natural algebra equivalence between the `Fin 2`-indexed Pi of `fin2Fam A B` and the
+binary product `A × B`. -/
+private noncomputable def algEquivProdFin2 (A B : Type u) [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] :
+    ((i : Fin 2) → fin2Fam A B i) ≃ₐ[R] A × B :=
+  AlgEquiv.ofRingEquiv (f := ringEquivProdFin2 A B) fun _ => rfl
+
+instance FormallyUnramified.prod [FormallyUnramified R A] [FormallyUnramified R B] :
+    FormallyUnramified R (A × B) :=
+  FormallyUnramified.of_equiv (algEquivProdFin2 A B)
+
+instance FormallySmooth.prod [FormallySmooth R A] [FormallySmooth R B] :
+    FormallySmooth R (A × B) :=
+  FormallySmooth.of_equiv (algEquivProdFin2 A B)
+
+instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
+    FormallyEtale R (A × B) :=
+  FormallyEtale.of_equiv (algEquivProdFin2 A B)
+
+/-- `A × B` is finitely presented as an `R`-algebra when both factors are. -/
+instance FinitePresentation.prod [FinitePresentation R A] [FinitePresentation R B] :
+    FinitePresentation R (A × B) :=
+  haveI : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
+    Algebra.FinitePresentation.pi (fin2Fam A B)
+  Algebra.FinitePresentation.equiv (algEquivProdFin2 A B)
+
+instance Etale.prod [Etale R A] [Etale R B] : Etale R (A × B) where
+
+end Algebra

--- a/Proetale/Mathlib/RingTheory/Etale/Prod.lean
+++ b/Proetale/Mathlib/RingTheory/Etale/Prod.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten
 import Mathlib.RingTheory.Etale.Pi
 import Mathlib.Algebra.Ring.Fin
 import Mathlib.RingTheory.RingHom.FinitePresentation
+import Proetale.Mathlib.Algebra.Algebra.Pi
 
 /-!
 # Formal-étaleness of binary products of rings
@@ -50,70 +51,36 @@ private instance fin2Fam_algebra :
   | ⟨0, _⟩ => ‹Algebra R A›
   | ⟨1, _⟩ => ‹Algebra R B›
 
-private instance fin2Fam_formallyUnramified [FormallyUnramified R A] [FormallyUnramified R B] :
-    ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
-  | ⟨0, _⟩ => ‹FormallyUnramified R A›
-  | ⟨1, _⟩ => ‹FormallyUnramified R B›
-
-private instance fin2Fam_formallySmooth [FormallySmooth R A] [FormallySmooth R B] :
-    ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
-  | ⟨0, _⟩ => ‹FormallySmooth R A›
-  | ⟨1, _⟩ => ‹FormallySmooth R B›
-
-private instance fin2Fam_formallyEtale [FormallyEtale R A] [FormallyEtale R B] :
-    ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
-  | ⟨0, _⟩ => ‹FormallyEtale R A›
-  | ⟨1, _⟩ => ‹FormallyEtale R B›
-
-private instance fin2Fam_finitePresentation
-    [FinitePresentation R A] [FinitePresentation R B] :
-    ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
-  | ⟨0, _⟩ => ‹FinitePresentation R A›
-  | ⟨1, _⟩ => ‹FinitePresentation R B›
-
-/-- The natural ring equivalence `((i : Fin 2) → fin2Fam A B i) ≃+* A × B`,
-defined by `(f ↦ (f 0, f 1))`. -/
-@[simps!]
-private def ringEquivProdFin2 (A B : Type u) [CommRing A] [CommRing B] :
-    ((i : Fin 2) → fin2Fam A B i) ≃+* A × B where
-  toFun f := (f 0, f 1)
-  invFun p := fun i => match i with
-    | ⟨0, _⟩ => p.1
-    | ⟨1, _⟩ => p.2
-  left_inv f := by
-    funext i
-    match i with
-    | ⟨0, _⟩ => rfl
-    | ⟨1, _⟩ => rfl
-  right_inv p := rfl
-  map_mul' _ _ := rfl
-  map_add' _ _ := rfl
-
-/-- The natural algebra equivalence between the `Fin 2`-indexed Pi of `fin2Fam A B` and the
-binary product `A × B`. -/
-private noncomputable def algEquivProdFin2 (A B : Type u) [CommRing A] [CommRing B]
-    [Algebra R A] [Algebra R B] :
-    ((i : Fin 2) → fin2Fam A B i) ≃ₐ[R] A × B :=
-  AlgEquiv.ofRingEquiv (f := ringEquivProdFin2 A B) fun _ => rfl
-
 instance FormallyUnramified.prod [FormallyUnramified R A] [FormallyUnramified R B] :
     FormallyUnramified R (A × B) :=
-  FormallyUnramified.of_equiv (algEquivProdFin2 A B)
+  haveI : ∀ i : Fin 2, FormallyUnramified R (fin2Fam A B i)
+    | ⟨0, _⟩ => ‹FormallyUnramified R A›
+    | ⟨1, _⟩ => ‹FormallyUnramified R B›
+  FormallyUnramified.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallySmooth.prod [FormallySmooth R A] [FormallySmooth R B] :
     FormallySmooth R (A × B) :=
-  FormallySmooth.of_equiv (algEquivProdFin2 A B)
+  haveI : ∀ i : Fin 2, FormallySmooth R (fin2Fam A B i)
+    | ⟨0, _⟩ => ‹FormallySmooth R A›
+    | ⟨1, _⟩ => ‹FormallySmooth R B›
+  FormallySmooth.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance FormallyEtale.prod [FormallyEtale R A] [FormallyEtale R B] :
     FormallyEtale R (A × B) :=
-  FormallyEtale.of_equiv (algEquivProdFin2 A B)
+  haveI : ∀ i : Fin 2, FormallyEtale R (fin2Fam A B i)
+    | ⟨0, _⟩ => ‹FormallyEtale R A›
+    | ⟨1, _⟩ => ‹FormallyEtale R B›
+  FormallyEtale.of_equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 /-- `A × B` is finitely presented as an `R`-algebra when both factors are. -/
 instance FinitePresentation.prod [FinitePresentation R A] [FinitePresentation R B] :
     FinitePresentation R (A × B) :=
+  haveI : ∀ i : Fin 2, FinitePresentation R (fin2Fam A B i)
+    | ⟨0, _⟩ => ‹FinitePresentation R A›
+    | ⟨1, _⟩ => ‹FinitePresentation R B›
   haveI : FinitePresentation R ((i : Fin 2) → fin2Fam A B i) :=
     Algebra.FinitePresentation.pi (fin2Fam A B)
-  Algebra.FinitePresentation.equiv (algEquivProdFin2 A B)
+  Algebra.FinitePresentation.equiv (AlgEquiv.piFinTwo R (fin2Fam A B))
 
 instance Etale.prod [Etale R A] [Etale R B] : Etale R (A × B) where
 


### PR DESCRIPTION
## Summary

Adds the binary-product specialisation of the finite-`Pi` étale/finite-presentation
instances from `Mathlib.RingTheory.Etale.Pi`:

- `Algebra.FormallyUnramified.prod`
- `Algebra.FormallySmooth.prod`
- `Algebra.FormallyEtale.prod`
- `Algebra.FinitePresentation.prod`
- `Algebra.Etale.prod`

The derivation is via an algebra equivalence `((i : Fin 2) → fin2Fam A B i) ≃ₐ[R] A × B`,
where `fin2Fam A B : Fin 2 → Type u` is a small case-defined family that reduces
definitionally (`fin2Fam A B 0 = A`, `fin2Fam A B 1 = B`). This avoids `Matrix.vecCons`,
whose elaboration does not eagerly reduce `![A, B] 0` to `A`.

This is the upstream of `Proetale/Mathlib/RingTheory/Etale/Prod.lean` from the
`archon` branch.

## Test plan

- [x] `lake build Proetale.Mathlib.RingTheory.Etale.Prod` succeeds without warnings
- [x] `lake build Proetale` (full project) succeeds
- [x] `lake exe mk_all --git --check` passes
