### PR TITLE
feat(Algebra/WeaklyEtale): converse of `ker_pure_of_flat_surjective`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -74,6 +74,7 @@ import Proetale.Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 import Proetale.Mathlib.RingTheory.Flat.Pi
 import Proetale.Mathlib.RingTheory.Henselian
 import Proetale.Mathlib.RingTheory.Ideal.GoingDown
+import Proetale.Mathlib.RingTheory.Ideal.Pure
 import Proetale.Mathlib.RingTheory.RingHom.Flat
 import Proetale.Mathlib.RingTheory.RingHom.OpenImmersion
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.RingHom

--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib
+import Proetale.Mathlib.RingTheory.Ideal.Pure
 import Proetale.Mathlib.RingTheory.RingHom.Flat
 import Proetale.Mathlib.RingTheory.TensorProduct.Maps
 
@@ -199,31 +200,6 @@ end
 
 variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 
-/-- The kernel of a flat surjective ring map is a pure ideal. -/
-lemma _root_.RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B]
-    (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
-    (RingHom.ker f).Pure := by
-  algebraize [f]
-  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
-    (f := Algebra.ofId A B) hsurj).toLinearEquiv
-
-/-- A surjective ring map whose kernel is a pure ideal is flat. This is the converse of
-`RingHom.ker_pure_of_flat_surjective`. -/
-lemma _root_.RingHom.Flat.of_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
-    {f : A →+* B} (hsurj : Function.Surjective f) (h : (RingHom.ker f).Pure) :
-    f.Flat := by
-  algebraize [f]
-  haveI : Module.Flat A (A ⧸ RingHom.ker (Algebra.ofId A B)) := h
-  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
-    (f := Algebra.ofId A B) hsurj).symm.toLinearEquiv
-
-/-- For a surjective ring map, flatness is equivalent to the kernel being a pure ideal. -/
-lemma _root_.RingHom.flat_iff_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
-    {f : A →+* B} (hsurj : Function.Surjective f) :
-    f.Flat ↔ (RingHom.ker f).Pure :=
-  ⟨fun hf ↦ RingHom.ker_pure_of_flat_surjective f hf hsurj,
-    RingHom.Flat.of_ker_pure_of_surjective hsurj⟩
-
 /-- The multiplication map `S ⊗[R] S → S` is flat iff the kernel of the multiplication map
 (i.e. `KaehlerDifferential.ideal R S`) is a pure ideal in `S ⊗[R] S`. -/
 lemma flat_lmul'_iff_kaehlerDifferential_ideal_pure :
@@ -233,8 +209,7 @@ lemma flat_lmul'_iff_kaehlerDifferential_ideal_pure :
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
     FormallyUnramified R S := by
   have hp : (KaehlerDifferential.ideal R S).Pure :=
-    RingHom.ker_pure_of_flat_surjective (TensorProduct.lmul' (S := S) R).toRingHom h
-      (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
+    flat_lmul'_iff_kaehlerDifferential_ideal_pure.mp h
   rw [formallyUnramified_iff]
   exact (Ideal.cotangent_subsingleton_iff _).mpr (Ideal.isIdempotentElem_of_pure _)
 

--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -207,6 +207,29 @@ lemma _root_.RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [Com
   exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
     (f := Algebra.ofId A B) hsurj).toLinearEquiv
 
+/-- A surjective ring map whose kernel is a pure ideal is flat. This is the converse of
+`RingHom.ker_pure_of_flat_surjective`. -/
+lemma _root_.RingHom.Flat.of_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+    {f : A →+* B} (hsurj : Function.Surjective f) (h : (RingHom.ker f).Pure) :
+    f.Flat := by
+  algebraize [f]
+  haveI : Module.Flat A (A ⧸ RingHom.ker (Algebra.ofId A B)) := h
+  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
+    (f := Algebra.ofId A B) hsurj).symm.toLinearEquiv
+
+/-- For a surjective ring map, flatness is equivalent to the kernel being a pure ideal. -/
+lemma _root_.RingHom.flat_iff_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+    {f : A →+* B} (hsurj : Function.Surjective f) :
+    f.Flat ↔ (RingHom.ker f).Pure :=
+  ⟨fun hf ↦ RingHom.ker_pure_of_flat_surjective f hf hsurj,
+    RingHom.Flat.of_ker_pure_of_surjective hsurj⟩
+
+/-- The multiplication map `S ⊗[R] S → S` is flat iff the kernel of the multiplication map
+(i.e. `KaehlerDifferential.ideal R S`) is a pure ideal in `S ⊗[R] S`. -/
+lemma flat_lmul'_iff_kaehlerDifferential_ideal_pure :
+    (TensorProduct.lmul' (S := S) R).toRingHom.Flat ↔ (KaehlerDifferential.ideal R S).Pure :=
+  RingHom.flat_iff_ker_pure_of_surjective (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
+
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
     FormallyUnramified R S := by
   have hp : (KaehlerDifferential.ideal R S).Pure :=

--- a/Proetale/Algebra/WeaklyEtale.lean
+++ b/Proetale/Algebra/WeaklyEtale.lean
@@ -204,7 +204,7 @@ variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 (i.e. `KaehlerDifferential.ideal R S`) is a pure ideal in `S ⊗[R] S`. -/
 lemma flat_lmul'_iff_kaehlerDifferential_ideal_pure :
     (TensorProduct.lmul' (S := S) R).toRingHom.Flat ↔ (KaehlerDifferential.ideal R S).Pure :=
-  RingHom.flat_iff_ker_pure_of_surjective (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
+  RingHom.flat_iff_pure_ker_of_surjective (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)
 
 lemma FormallyUnramified.of_flat_lmul' (h : (TensorProduct.lmul' (S := S) R).Flat) :
     FormallyUnramified R S := by

--- a/Proetale/Mathlib/RingTheory/Ideal/Pure.lean
+++ b/Proetale/Mathlib/RingTheory/Ideal/Pure.lean
@@ -14,7 +14,7 @@ being a pure ideal in `A`.
 -/
 
 /-- The kernel of a flat surjective ring map is a pure ideal. -/
-lemma RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B]
+lemma RingHom.pure_ker_of_flat_of_surjective {A B : Type*} [CommRing A] [CommRing B]
     (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
     (RingHom.ker f).Pure := by
   algebraize [f]
@@ -22,8 +22,8 @@ lemma RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B
     (f := Algebra.ofId A B) hsurj).toLinearEquiv
 
 /-- A surjective ring map whose kernel is a pure ideal is flat. This is the converse of
-`RingHom.ker_pure_of_flat_surjective`. -/
-lemma RingHom.Flat.of_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+`RingHom.pure_ker_of_flat_of_surjective`. -/
+lemma RingHom.Flat.of_pure_ker_of_surjective {A B : Type*} [CommRing A] [CommRing B]
     {f : A →+* B} (hsurj : Function.Surjective f) (h : (RingHom.ker f).Pure) :
     f.Flat := by
   algebraize [f]
@@ -32,8 +32,8 @@ lemma RingHom.Flat.of_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRin
     (f := Algebra.ofId A B) hsurj).symm.toLinearEquiv
 
 /-- For a surjective ring map, flatness is equivalent to the kernel being a pure ideal. -/
-lemma RingHom.flat_iff_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+lemma RingHom.flat_iff_pure_ker_of_surjective {A B : Type*} [CommRing A] [CommRing B]
     {f : A →+* B} (hsurj : Function.Surjective f) :
     f.Flat ↔ (RingHom.ker f).Pure :=
-  ⟨fun hf ↦ RingHom.ker_pure_of_flat_surjective f hf hsurj,
-    RingHom.Flat.of_ker_pure_of_surjective hsurj⟩
+  ⟨fun hf ↦ RingHom.pure_ker_of_flat_of_surjective f hf hsurj,
+    RingHom.Flat.of_pure_ker_of_surjective hsurj⟩

--- a/Proetale/Mathlib/RingTheory/Ideal/Pure.lean
+++ b/Proetale/Mathlib/RingTheory/Ideal/Pure.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RingTheory.Ideal.Pure
+import Mathlib.RingTheory.RingHom.Flat
+
+/-!
+# Flat surjective ring maps and pure kernels
+
+For a surjective ring map `f : A →+* B`, flatness of `f` is equivalent to the kernel of `f`
+being a pure ideal in `A`.
+-/
+
+/-- The kernel of a flat surjective ring map is a pure ideal. -/
+lemma RingHom.ker_pure_of_flat_surjective {A B : Type*} [CommRing A] [CommRing B]
+    (f : A →+* B) (hf : f.Flat) (hsurj : Function.Surjective f) :
+    (RingHom.ker f).Pure := by
+  algebraize [f]
+  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
+    (f := Algebra.ofId A B) hsurj).toLinearEquiv
+
+/-- A surjective ring map whose kernel is a pure ideal is flat. This is the converse of
+`RingHom.ker_pure_of_flat_surjective`. -/
+lemma RingHom.Flat.of_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+    {f : A →+* B} (hsurj : Function.Surjective f) (h : (RingHom.ker f).Pure) :
+    f.Flat := by
+  algebraize [f]
+  haveI : Module.Flat A (A ⧸ RingHom.ker (Algebra.ofId A B)) := h
+  exact .of_linearEquiv (Ideal.quotientKerAlgEquivOfSurjective
+    (f := Algebra.ofId A B) hsurj).symm.toLinearEquiv
+
+/-- For a surjective ring map, flatness is equivalent to the kernel being a pure ideal. -/
+lemma RingHom.flat_iff_ker_pure_of_surjective {A B : Type*} [CommRing A] [CommRing B]
+    {f : A →+* B} (hsurj : Function.Surjective f) :
+    f.Flat ↔ (RingHom.ker f).Pure :=
+  ⟨fun hf ↦ RingHom.ker_pure_of_flat_surjective f hf hsurj,
+    RingHom.Flat.of_ker_pure_of_surjective hsurj⟩


### PR DESCRIPTION
## Summary

Adds the converse direction of the existing `RingHom.ker_pure_of_flat_surjective`:

- `RingHom.Flat.of_ker_pure_of_surjective`: a surjective ring map whose kernel is a pure ideal is flat.
- `RingHom.flat_iff_ker_pure_of_surjective`: the iff form combining both directions.
- `Algebra.flat_lmul'_iff_kaehlerDifferential_ideal_pure`: specialisation to the multiplication map `lmul' : S ⊗[R] S → S`, whose kernel is `KaehlerDifferential.ideal R S`.

The proof of the converse is a direct transport of flatness along the algebra isomorphism `A ⧸ ker f ≃ₐ[A] B` provided by `Ideal.quotientKerAlgEquivOfSurjective`, mirroring the forward direction.

These lemmas are extracted from `Proetale/Mathlib/RingTheory/WeaklyEtale/Subalgebra.lean` on the `archon` branch, where they are used (as `flat_lmul'_of_pure_ker`) to derive flatness of `lmul'` from purity of `KaehlerDifferential.ideal`, the bridge that converts the idempotency input of Stacks [092K] into the `WeaklyEtale` conclusion.

## Test plan

- [x] `lake build` succeeds (validation script passes)
- [x] No `sorry` introduced
- [x] All new lemmas have docstrings