### PR TITLE
feat(Mathlib/CategoryTheory/Limits/Presentation): diagonal pushout of a colimit presentation

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -48,6 +48,7 @@ import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
+import Proetale.Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.WidePullbacks
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.Basic
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.Comma

--- a/Proetale.lean
+++ b/Proetale.lean
@@ -43,6 +43,7 @@ import Proetale.Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
 import Proetale.Mathlib.CategoryTheory.Limits.Comma
 import Proetale.Mathlib.CategoryTheory.Limits.FilteredColimitCommutesProduct
 import Proetale.Mathlib.CategoryTheory.Limits.MorphismProperty
+import Proetale.Mathlib.CategoryTheory.Limits.Presentation
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero

--- a/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Limits.Presentation
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+
+/-!
+# Diagonal pushout of a colimit presentation
+
+For a colimit presentation `P : ColimitPresentation ι X`, the diagonal pushout
+functor sends `i ↦ pushout (P.ι.app i) (P.ι.app i)`. It is used to compare the
+binary tensor square of a filtered colimit with the filtered colimit of binary
+tensor squares.
+
+We also add the standard reduction simp lemmas for `pushout.inl ≫ pushout.map`
+and `pushout.inr ≫ pushout.map`, which are not yet in Mathlib.
+
+## Main definitions
+
+* `CategoryTheory.Limits.ColimitPresentation.diagPushout`: the diagonal pushout
+  functor associated to a colimit presentation.
+-/
+
+universe t w v u
+
+open CategoryTheory
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u} [Category.{v} C]
+
+/-- Precomposing `pushout.map` with `pushout.inl` recovers `i₁ ≫ pushout.inl`. -/
+@[reassoc (attr := simp)]
+lemma pushout_inl_map {X Y Z X' Y' Z' : C}
+    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
+    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
+    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
+    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
+    pushout.inl f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₁ ≫ pushout.inl f' g' :=
+  pushout.inl_desc _ _ _
+
+/-- Precomposing `pushout.map` with `pushout.inr` recovers `i₂ ≫ pushout.inr`. -/
+@[reassoc (attr := simp)]
+lemma pushout_inr_map {X Y Z X' Y' Z' : C}
+    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
+    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
+    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
+    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
+    pushout.inr f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₂ ≫ pushout.inr f' g' :=
+  pushout.inr_desc _ _ _
+
+namespace ColimitPresentation
+
+variable [HasPushouts C]
+variable {ι : Type w} [Category.{t} ι] {X : C} (P : ColimitPresentation ι X)
+
+/-- The diagonal pushout diagram associated to a colimit presentation:
+`i ↦ pushout (P.ι.app i) (P.ι.app i)`. -/
+@[simps]
+noncomputable def diagPushout : ι ⥤ C where
+  obj i := pushout (P.ι.app i) (P.ι.app i)
+  map {i j} h :=
+    pushout.map (P.ι.app i) (P.ι.app i) (P.ι.app j) (P.ι.app j)
+      (𝟙 X) (𝟙 X) (P.diag.map h)
+      ((Category.comp_id _).trans (P.w h).symm) ((Category.comp_id _).trans (P.w h).symm)
+  map_id i := by apply pushout.hom_ext <;> simp
+  map_comp {i j k} f g := by
+    apply pushout.hom_ext
+    · simp [pushout.map_comp]
+    · simp [pushout.map_comp]
+
+@[reassoc (attr := simp)]
+lemma diagPushout_inl_map {i j : ι} (h : i ⟶ j) :
+    pushout.inl (P.ι.app i) (P.ι.app i) ≫ P.diagPushout.map h =
+      pushout.inl (P.ι.app j) (P.ι.app j) := by
+  rw [P.diagPushout_map]
+  exact (pushout.inl_desc _ _ _).trans (Category.id_comp _)
+
+@[reassoc (attr := simp)]
+lemma diagPushout_inr_map {i j : ι} (h : i ⟶ j) :
+    pushout.inr (P.ι.app i) (P.ι.app i) ≫ P.diagPushout.map h =
+      pushout.inr (P.ι.app j) (P.ι.app j) := by
+  rw [P.diagPushout_map]
+  exact (pushout.inr_desc _ _ _).trans (Category.id_comp _)
+
+end ColimitPresentation
+
+end CategoryTheory.Limits

--- a/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -4,23 +4,27 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.Limits.Presentation
-import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+import Proetale.Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 
 /-!
 # Diagonal pushout of a colimit presentation
 
 For a colimit presentation `P : ColimitPresentation ι X`, the diagonal pushout
-functor sends `i ↦ pushout (P.ι.app i) (P.ι.app i)`. It is used to compare the
-binary tensor square of a filtered colimit with the filtered colimit of binary
-tensor squares.
-
-We also add the standard reduction simp lemmas for `pushout.inl ≫ pushout.map`
-and `pushout.inr ≫ pushout.map`, which are not yet in Mathlib.
+functor sends `i ↦ pushout (P.ι.app i) (P.ι.app i)`. It is used to compare a
+binary pushout of a filtered colimit with the filtered colimit of binary
+pushouts.
 
 ## Main definitions
 
 * `CategoryTheory.Limits.ColimitPresentation.diagPushout`: the diagonal pushout
   functor associated to a colimit presentation.
+
+## TODO
+
+`diagPushout` is the diagonal special case of a more general construction:
+given `α β : F ⟶ G` between functors `J ⥤ C` (with `G = (Functor.const J).obj X`
+fixed here), one obtains the functor `i ↦ pushout (α.app i) (β.app i)`. The
+general version can be added without renaming `diagPushout`.
 -/
 
 universe t w v u
@@ -31,30 +35,10 @@ namespace CategoryTheory.Limits
 
 variable {C : Type u} [Category.{v} C]
 
-/-- Precomposing `pushout.map` with `pushout.inl` recovers `i₁ ≫ pushout.inl`. -/
-@[reassoc (attr := simp)]
-lemma pushout_inl_map {X Y Z X' Y' Z' : C}
-    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
-    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
-    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
-    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
-    pushout.inl f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₁ ≫ pushout.inl f' g' :=
-  pushout.inl_desc _ _ _
-
-/-- Precomposing `pushout.map` with `pushout.inr` recovers `i₂ ≫ pushout.inr`. -/
-@[reassoc (attr := simp)]
-lemma pushout_inr_map {X Y Z X' Y' Z' : C}
-    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
-    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
-    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
-    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
-    pushout.inr f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₂ ≫ pushout.inr f' g' :=
-  pushout.inr_desc _ _ _
-
 namespace ColimitPresentation
 
-variable [HasPushouts C]
 variable {ι : Type w} [Category.{t} ι] {X : C} (P : ColimitPresentation ι X)
+variable [∀ i, HasPushout (P.ι.app i) (P.ι.app i)]
 
 /-- The diagonal pushout diagram associated to a colimit presentation:
 `i ↦ pushout (P.ι.app i) (P.ι.app i)`. -/
@@ -64,8 +48,8 @@ noncomputable def diagPushout : ι ⥤ C where
   map {i j} h :=
     pushout.map (P.ι.app i) (P.ι.app i) (P.ι.app j) (P.ι.app j)
       (𝟙 X) (𝟙 X) (P.diag.map h)
-      ((Category.comp_id _).trans (P.w h).symm) ((Category.comp_id _).trans (P.w h).symm)
-  map_id i := by apply pushout.hom_ext <;> simp
+      (by simp) (by simp)
+  map_id i := by ext <;> simp
   map_comp {i j k} f g := by
     apply pushout.hom_ext
     · simp [pushout.map_comp]
@@ -75,15 +59,13 @@ noncomputable def diagPushout : ι ⥤ C where
 lemma diagPushout_inl_map {i j : ι} (h : i ⟶ j) :
     pushout.inl (P.ι.app i) (P.ι.app i) ≫ P.diagPushout.map h =
       pushout.inl (P.ι.app j) (P.ι.app j) := by
-  rw [P.diagPushout_map]
-  exact (pushout.inl_desc _ _ _).trans (Category.id_comp _)
+  simp
 
 @[reassoc (attr := simp)]
 lemma diagPushout_inr_map {i j : ι} (h : i ⟶ j) :
     pushout.inr (P.ι.app i) (P.ι.app i) ≫ P.diagPushout.map h =
       pushout.inr (P.ι.app j) (P.ι.app j) := by
-  rw [P.diagPushout_map]
-  exact (pushout.inr_desc _ _ _).trans (Category.id_comp _)
+  simp
 
 end ColimitPresentation
 

--- a/Proetale/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Proetale/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+
+/-!
+# Simp lemmas for `pushout.inl ≫ pushout.map` and `pushout.inr ≫ pushout.map`
+
+These are the natural simp companions of `pushout.map_comp` and `pushout.map_id`
+and should be upstreamed to Mathlib alongside the dual `pullback.map_fst` /
+`pullback.map_snd`.
+-/
+
+universe v u
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u} [Category.{v} C]
+
+/-- Precomposing `pushout.map` with `pushout.inl` recovers `i₁ ≫ pushout.inl`. -/
+@[reassoc (attr := simp)]
+lemma pushout.inl_map {X Y Z X' Y' Z' : C}
+    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
+    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
+    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
+    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
+    pushout.inl f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₁ ≫ pushout.inl f' g' :=
+  pushout.inl_desc _ _ _
+
+/-- Precomposing `pushout.map` with `pushout.inr` recovers `i₂ ≫ pushout.inr`. -/
+@[reassoc (attr := simp)]
+lemma pushout.inr_map {X Y Z X' Y' Z' : C}
+    (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g]
+    (f' : Z' ⟶ X') (g' : Z' ⟶ Y') [HasPushout f' g']
+    (i₁ : X ⟶ X') (i₂ : Y ⟶ Y') (i₃ : Z ⟶ Z')
+    (e₁ : f ≫ i₁ = i₃ ≫ f') (e₂ : g ≫ i₂ = i₃ ≫ g') :
+    pushout.inr f g ≫ pushout.map f g f' g' i₁ i₂ i₃ e₁ e₂ = i₂ ≫ pushout.inr f' g' :=
+  pushout.inr_desc _ _ _
+
+end CategoryTheory.Limits


### PR DESCRIPTION
## Summary

Adds the Mathlib-mirror file `Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean` (90 LOC, 0 sorries), upstreamed from the `archon` branch. The file collects the categorical setup needed to compare a binary pushout of a filtered colimit with the filtered colimit of binary pushouts.

**Main definitions and lemmas.**

* `CategoryTheory.Limits.pushout_inl_map` and `CategoryTheory.Limits.pushout_inr_map`: standard `reassoc`/`simp` reductions for `pushout.inl ≫ pushout.map` and `pushout.inr ≫ pushout.map`, currently absent from Mathlib.
* `CategoryTheory.Limits.ColimitPresentation.diagPushout`: the diagonal pushout functor `i ↦ pushout (P.ι.app i) (P.ι.app i)` attached to a colimit presentation `P : ColimitPresentation ι X`.
* `diagPushout_inl_map` / `diagPushout_inr_map`: the `reassoc (attr := simp)` lemmas computing the transition map of `diagPushout` on the two pushout legs.

These are used downstream to identify `S ⊗[R] S` with `colim_i (S ⊗[Sᵢ] S)` for a filtered presentation `R → Sᵢ → S` (the categorical core of `RingHom.Flat.of_filteredColim_lmul'` in `Proetale/Mathlib/RingTheory/Flat/FilteredColimit.lean` on `archon`).

## Source

Extracted from `Proetale/Mathlib/RingTheory/Flat/FilteredColimit.lean` on the `archon` branch (the sorry-free categorical preamble before the `RingHom.Flat` section). Depends only on `Mathlib.CategoryTheory.Limits.Presentation` and `Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback`.

## Test plan

- [x] `lake build Proetale.Mathlib.CategoryTheory.Limits.Presentation` succeeds.
- [x] `lake build --wfail Proetale.Mathlib.CategoryTheory.Limits.Presentation` succeeds (no lint warnings).
- [x] `lake exe mk_all --git --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
