### PR TITLE
feat(Algebra/WLocalization): fill sorries for `Generalization` API

### DIFF
--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -70,7 +70,7 @@ def locClosedSubset (f : A) (I : Ideal A) : Set (PrimeSpectrum A) :=
 
 /-- Characterization of `submonoid f I`: an element `a : A` lies in `submonoid f I` if and only
 if `a` lies outside every prime in `locClosedSubset f I = D(f) ∩ V(I)`. -/
-private lemma mem_submonoid_iff (f : A) (I : Ideal A) (a : A) :
+lemma mem_submonoid_iff (f : A) (I : Ideal A) (a : A) :
     a ∈ submonoid f I ↔ ∀ p ∈ locClosedSubset f I, a ∉ p.asIdeal := by
   rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff,
     IsScalarTower.algebraMap_apply A (A ⧸ I),
@@ -91,8 +91,8 @@ private lemma mem_submonoid_iff (f : A) (I : Ideal A) (a : A) :
     · simpa [PrimeSpectrum.mem_basicOpen] using hp_bar
     · rw [PrimeSpectrum.mem_zeroLocus]
       intro b hb
-      change Ideal.Quotient.mk I b ∈ p_bar.asIdeal
-      rw [Ideal.Quotient.eq_zero_iff_mem.mpr hb]
+      rw [comap_asIdeal, SetLike.mem_coe, Ideal.mem_comap,
+        Ideal.Quotient.eq_zero_iff_mem.mpr hb]
       exact p_bar.asIdeal.zero_mem
 
 theorem submonoid_le {f f' : A} {I I' : Ideal A} (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -127,10 +127,8 @@ lemma range_algebraMap_generalization (f : A) (I : Ideal A) :
         rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff,
           IsScalarTower.algebraMap_apply A (A ⧸ I)]
         have h_eq : (algebraMap A (A ⧸ I)) a = (algebraMap A (A ⧸ I)) (f ^ n) := by
-          have hmem : a - f ^ n ∈ I := by
-            have : a - f ^ n = -b := by linear_combination hab
-            rw [this]; exact I.neg_mem hb
-          rwa [← Ideal.Quotient.eq] at hmem
+          simp only [Ideal.Quotient.algebraMap_eq, ← hab, map_add,
+            Ideal.Quotient.eq_zero_iff_mem.mpr hb, add_zero]
         rw [h_eq]
         have hmem : (Ideal.Quotient.mk I f) ^ n ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
           ⟨n, rfl⟩
@@ -183,9 +181,7 @@ private lemma exists_mem_zeroLocus_ideal_specComap_eq {f : A} {I : Ideal A}
         Ideal.Quotient.eq_zero_iff_mem.mp (by rw [map_mul, map_pow]; exact hc)
       exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left
         (mt (q.isPrime.mem_of_pow_mem n) hfq)
-    change IsLocalization.mk' (Generalization f I) a s ∈
-      Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
-    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
+    rw [SetLike.mem_coe, IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
     exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
   · exact PrimeSpectrum.ext (IsLocalization.under_map_of_isPrime_disjoint (submonoid f I)
       (Generalization f I) q.isPrime hq_disj)
@@ -193,9 +189,8 @@ private lemma exists_mem_zeroLocus_ideal_specComap_eq {f : A} {I : Ideal A}
 lemma bijOn_algebraMap_generalization_specComap_zeroLocus_ideal (f : A) (I : Ideal A) :
     Set.BijOn (PrimeSpectrum.comap <| algebraMap A (Generalization f I)) (zeroLocus (ideal f I))
       (locClosedSubset f I) := by
-  refine ⟨?mapsTo, ?injOn, ?surjOn⟩
-  case mapsTo =>
-    intro y hy
+  refine ⟨?_, ?_, ?_⟩
+  · intro y hy
     rw [PrimeSpectrum.mem_zeroLocus] at hy
     have hdisj := ((IsLocalization.isPrime_iff_isPrime_disjoint (submonoid f I)
       (Generalization f I) y.asIdeal).mp y.isPrime).2
@@ -209,14 +204,12 @@ lemma bijOn_algebraMap_generalization_specComap_zeroLocus_ideal (f : A) (I : Ide
     rw [PrimeSpectrum.mem_zeroLocus]
     intro a ha
     refine hy ?_
-    change toLocQuotient f I (algebraMap A (Generalization f I) a) = 0
+    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker]
     rw [(toLocQuotient f I).commutes, IsScalarTower.algebraMap_apply A (A ⧸ I)]
     simp [Ideal.Quotient.eq_zero_iff_mem.mpr ha]
-  case injOn =>
-    exact (PrimeSpectrum.localization_comap_isEmbedding (Generalization f I)
+  · exact (PrimeSpectrum.localization_comap_isEmbedding (Generalization f I)
       (submonoid f I)).injective.injOn
-  case surjOn =>
-    intro q hq
+  · intro q hq
     exact exists_mem_zeroLocus_ideal_specComap_eq hq
 
 lemma exists_specializes_zeroLocus_ideal {f : A} (I : Ideal A)

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -64,49 +64,49 @@ instance indZariski : Algebra.IndZariski A (Generalization f I) := by
   dsimp [Generalization]
   infer_instance
 
+/-- The locally closed subset `D(f) ∩ V(I)` of `Spec A`. -/
 def locClosedSubset (f : A) (I : Ideal A) : Set (PrimeSpectrum A) :=
   basicOpen f ∩ zeroLocus I
 
+/-- Characterization of `submonoid f I`: an element `a : A` lies in `submonoid f I` if and only
+if `a` lies outside every prime in `locClosedSubset f I = D(f) ∩ V(I)`. -/
+private lemma mem_submonoid_iff (f : A) (I : Ideal A) (a : A) :
+    a ∈ submonoid f I ↔ ∀ p ∈ locClosedSubset f I, a ∉ p.asIdeal := by
+  rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff,
+    IsScalarTower.algebraMap_apply A (A ⧸ I),
+    ← PrimeSpectrum.basicOpen_le_basicOpen_iff_algebraMap_isUnit
+      (f := Ideal.Quotient.mk I f) (S := Localization.Away (Ideal.Quotient.mk I f))]
+  refine ⟨fun hle p ⟨hpf, hpI⟩ hap ↦ ?_, fun h p_bar hp_bar hmka ↦ ?_⟩
+  · simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen] at hpf
+    rw [PrimeSpectrum.mem_zeroLocus] at hpI
+    obtain ⟨p_bar, rfl⟩ : p ∈ Set.range (PrimeSpectrum.comap (Ideal.Quotient.mk I)) := by
+      rw [range_comap_of_surjective _ _ Ideal.Quotient.mk_surjective,
+        PrimeSpectrum.mem_zeroLocus, Ideal.mk_ker]
+      exact hpI
+    have hpb_f : p_bar ∈ basicOpen (Ideal.Quotient.mk I f) :=
+      (PrimeSpectrum.mem_basicOpen _ _).mpr fun h ↦ hpf (Ideal.mem_comap.mpr h)
+    exact (PrimeSpectrum.mem_basicOpen _ _).mp (hle hpb_f) (Ideal.mem_comap.mp hap)
+  · simp only [PrimeSpectrum.mem_basicOpen] at hp_bar ⊢
+    refine h (PrimeSpectrum.comap (Ideal.Quotient.mk I) p_bar) ⟨?_, ?_⟩ hmka
+    · simpa [PrimeSpectrum.mem_basicOpen] using hp_bar
+    · rw [PrimeSpectrum.mem_zeroLocus]
+      intro b hb
+      change Ideal.Quotient.mk I b ∈ p_bar.asIdeal
+      rw [Ideal.Quotient.eq_zero_iff_mem.mpr hb]
+      exact p_bar.asIdeal.zero_mem
 
--- Helper: if `a ∈ submonoid f I` and `q ∈ locClosedSubset f I`, then `a ∉ q.asIdeal`.
--- This is the forward direction of `mem_submonoid_iff_not_mem_locClosedSubset`, extracted
--- here so it can be used in `range_algebraMap_generalization`.
-private lemma submonoid_disjoint_locClosedSubset_primes (f : A) (I : Ideal A) (a : A)
-    (ha : a ∈ submonoid f I) (q : PrimeSpectrum A) (hq : q ∈ locClosedSubset f I) :
-    a ∉ q.asIdeal := by
-  simp only [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff] at ha
-  simp only [locClosedSubset, Set.mem_inter_iff] at hq
-  obtain ⟨hqf, hqI⟩ := hq
-  simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen] at hqf
-  rw [PrimeSpectrum.mem_zeroLocus] at hqI
-  intro haq
-  -- Build the prime q_bar = image of q in A/I, then lift to (A/I)_f
-  have hker : RingHom.ker (Ideal.Quotient.mk I) ≤ q.asIdeal := by
-    rw [Ideal.mk_ker]; exact hqI
-  set q_bar := Ideal.map (Ideal.Quotient.mk I) q.asIdeal
-  have hq_prime : q_bar.IsPrime :=
-    Ideal.map_isPrime_of_surjective Ideal.Quotient.mk_surjective hker
-  have hmkf : Ideal.Quotient.mk I f ∉ q_bar := by
-    intro hfq
-    have hcomap := Ideal.comap_map_of_surjective (Ideal.Quotient.mk I)
-      Ideal.Quotient.mk_surjective q.asIdeal
-    rw [show Ideal.comap (Ideal.Quotient.mk I) ⊥ = I from
-      RingHom.ker_eq_comap_bot (Ideal.Quotient.mk I) ▸ Ideal.mk_ker] at hcomap
-    have hIq : I ≤ q.asIdeal := hqI
-    exact hqf (sup_eq_left.mpr hIq ▸ (hcomap ▸ Ideal.mem_comap.mpr hfq))
-  have hdisj : Disjoint (Submonoid.powers (Ideal.Quotient.mk I f) : Set (A ⧸ I))
-      (q_bar : Set (A ⧸ I)) :=
-    Set.disjoint_left.mpr fun y hy1 hy2 => by
-      simp only [SetLike.mem_coe, Submonoid.mem_powers_iff] at hy1
-      obtain ⟨n, hn⟩ := hy1
-      rw [← hn] at hy2
-      exact hmkf (hq_prime.mem_of_pow_mem n hy2)
-  have hq_loc : (Ideal.map (algebraMap (A ⧸ I) (Localization.Away (Ideal.Quotient.mk I f)))
-      q_bar).IsPrime :=
-    IsLocalization.isPrime_of_isPrime_disjoint _ _ q_bar hq_prime hdisj
-  apply hq_loc.ne_top
-  exact Ideal.eq_top_of_isUnit_mem _ (Ideal.mem_map_of_mem _ (Ideal.mem_map_of_mem _ haq))
-    (by rw [IsScalarTower.algebraMap_apply A (A ⧸ I)] at ha; exact ha)
+theorem submonoid_le {f f' : A} {I I' : Ideal A} (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
+    submonoid f I ≤ submonoid f' I' := by
+  intro a ha
+  rw [mem_submonoid_iff] at ha ⊢
+  exact fun p hp ↦ ha p (h hp)
+
+noncomputable def map {f f' : A} {I I' : Ideal A}
+    (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
+    Generalization f I →ₐ[A] Generalization f' I' where
+  toRingHom := IsLocalization.map (T := Generalization.submonoid f' I')
+    (Generalization f' I') (RingHom.id A) (submonoid_le h)
+  commutes' r := by simp
 
 /-- The image of `Spec (Generalization f I)` in `Spec A` is equal to
 the generalization hull of `D(f) ∩ V(I)`. -/
@@ -115,350 +115,122 @@ lemma range_algebraMap_generalization (f : A) (I : Ideal A) :
     generalizationHull (locClosedSubset f I) := by
   rw [PrimeSpectrum.localization_comap_range (Generalization f I) (submonoid f I)]
   ext p
-  simp only [Set.mem_setOf_eq]
-  rw [mem_generalizationHull_iff]
-  constructor
-  · -- If Disjoint (submonoid f I) p.asIdeal, find q ∈ locClosedSubset f I with p ⤳ q
-    intro hdisj
-    -- Key claim: f ∉ radical (p.asIdeal ⊔ I)
-    have hf_not_rad : f ∉ Ideal.radical (p.asIdeal ⊔ I) := by
+  simp only [Set.mem_setOf_eq, mem_generalizationHull_iff]
+  refine ⟨fun hdisj ↦ ?_, ?_⟩
+  · have hf_not_rad : f ∉ Ideal.radical (p.asIdeal ⊔ I) := by
       rw [Ideal.mem_radical_iff]
       push Not
       intro n hfn
-      -- f^n ∈ p.asIdeal ⊔ I means f^n = a + b with a ∈ p, b ∈ I
       rw [Submodule.mem_sup] at hfn
       obtain ⟨a, ha, b, hb, hab⟩ := hfn
-      -- In (A/I)_f, image of a equals image of f^n (a unit), so a ∈ submonoid f I
       have ha_sub : a ∈ submonoid f I := by
-        rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff]
-        rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
+        rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff,
+          IsScalarTower.algebraMap_apply A (A ⧸ I)]
         have h_eq : (algebraMap A (A ⧸ I)) a = (algebraMap A (A ⧸ I)) (f ^ n) := by
           have hmem : a - f ^ n ∈ I := by
             have : a - f ^ n = -b := by linear_combination hab
             rw [this]; exact I.neg_mem hb
           rwa [← Ideal.Quotient.eq] at hmem
         rw [h_eq]
-        -- Goal: IsUnit (algebraMap (A ⧸ I) (Localization.Away (mk I f)) (mk I f ^ n))
-        -- mk I f ^ n is in Submonoid.powers (mk I f), so its image is a unit
         have hmem : (Ideal.Quotient.mk I f) ^ n ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
           ⟨n, rfl⟩
         exact IsLocalization.map_units (Localization.Away (Ideal.Quotient.mk I f)) ⟨_, hmem⟩
-      -- But a ∈ p.asIdeal ∩ submonoid f I, contradicting disjointness
       exact Set.disjoint_left.mp hdisj ha_sub ha
-    -- Since f ∉ radical(p ⊔ I), there exists a prime q ⊇ p ⊔ I with f ∉ q
     rw [Ideal.radical_eq_sInf, Ideal.mem_sInf] at hf_not_rad
     push Not at hf_not_rad
     obtain ⟨q, ⟨hle, hq_prime⟩, hfq⟩ := hf_not_rad
-    refine ⟨⟨q, hq_prime⟩, ?_, ?_⟩
-    · -- q ∈ locClosedSubset f I
-      constructor
-      · simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]; exact hfq
-      · rw [PrimeSpectrum.mem_zeroLocus]
-        intro x hx
-        exact hle (Ideal.mem_sup_right hx)
-    · -- p ⤳ q, i.e., p.asIdeal ≤ q
-      rw [← PrimeSpectrum.le_iff_specializes]
-      intro x hx
-      exact hle (Ideal.mem_sup_left hx)
-  · -- If ∃ q ∈ locClosedSubset, p ⤳ q, then Disjoint
-    rintro ⟨q, hq, hpq⟩
+    refine ⟨⟨q, hq_prime⟩, ⟨?_, ?_⟩, ?_⟩
+    · simpa [PrimeSpectrum.mem_basicOpen] using hfq
+    · exact (PrimeSpectrum.mem_zeroLocus _ _).mpr fun x hx ↦ hle (Ideal.mem_sup_right hx)
+    · rw [← PrimeSpectrum.le_iff_specializes]
+      exact fun x hx ↦ hle (Ideal.mem_sup_left hx)
+  · rintro ⟨q, hq, hpq⟩
     rw [← PrimeSpectrum.le_iff_specializes] at hpq
-    refine Set.disjoint_left.mpr fun a ha_sub ha_p => ?_
-    exact submonoid_disjoint_locClosedSubset_primes f I a ha_sub q hq (hpq ha_p)
+    exact Set.disjoint_left.mpr fun a ha_sub ha_p ↦
+      (mem_submonoid_iff f I a).mp ha_sub q hq (hpq ha_p)
+
+/-- Given `q ∈ locClosedSubset f I`, the prime ideal `q · Generalization f I` of
+`Generalization f I` lies in `zeroLocus (ideal f I)` and contracts to `q`. -/
+private lemma exists_mem_zeroLocus_ideal_specComap_eq {f : A} {I : Ideal A}
+    {q : PrimeSpectrum A} (hq : q ∈ locClosedSubset f I) :
+    ∃ y ∈ zeroLocus (ideal f I),
+      PrimeSpectrum.comap (algebraMap A (Generalization f I)) y = q := by
+  have hq_disj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) :=
+    Set.disjoint_left.mpr fun a ha ha_q ↦ (mem_submonoid_iff f I a).mp ha q hq ha_q
+  refine ⟨⟨Ideal.map (algebraMap A (Generalization f I)) q.asIdeal,
+    IsLocalization.isPrime_of_isPrime_disjoint (submonoid f I) (Generalization f I)
+      q.asIdeal q.isPrime hq_disj⟩, ?_, ?_⟩
+  · rw [PrimeSpectrum.mem_zeroLocus]
+    intro z hz
+    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker] at hz
+    obtain ⟨a, s, hzas⟩ := IsLocalization.exists_mk'_eq (submonoid f I) z
+    rw [← hzas] at hz ⊢
+    have hz' : algebraMap A (Localization.Away (Ideal.Quotient.mk I f)) a = 0 := by
+      have h3 := IsLocalization.mk'_spec (M := submonoid f I) (Generalization f I) a s
+      have h4 : toLocQuotient f I (IsLocalization.mk' (Generalization f I) a s *
+          algebraMap A (Generalization f I) (s : A)) =
+        toLocQuotient f I (algebraMap A (Generalization f I) a) := congr_arg _ h3
+      rw [map_mul, hz, zero_mul, (toLocQuotient f I).commutes] at h4
+      exact h4.symm
+    have ha_q : a ∈ q.asIdeal := by
+      have hqI : I ≤ q.asIdeal := (PrimeSpectrum.mem_zeroLocus _ _).mp hq.2
+      have hfq : f ∉ q.asIdeal := hq.1
+      rw [IsScalarTower.algebraMap_apply A (A ⧸ I)] at hz'
+      obtain ⟨⟨_, n, rfl⟩, hc⟩ := (IsLocalization.map_eq_zero_iff
+        (Submonoid.powers (Ideal.Quotient.mk I f))
+        (Localization.Away (Ideal.Quotient.mk I f)) _).mp hz'
+      have hfna : f ^ n * a ∈ I :=
+        Ideal.Quotient.eq_zero_iff_mem.mp (by rw [map_mul, map_pow]; exact hc)
+      exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left
+        (mt (q.isPrime.mem_of_pow_mem n) hfq)
+    change IsLocalization.mk' (Generalization f I) a s ∈
+      Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
+    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
+    exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
+  · exact PrimeSpectrum.ext (IsLocalization.under_map_of_isPrime_disjoint (submonoid f I)
+      (Generalization f I) q.isPrime hq_disj)
 
 lemma bijOn_algebraMap_generalization_specComap_zeroLocus_ideal (f : A) (I : Ideal A) :
     Set.BijOn (PrimeSpectrum.comap <| algebraMap A (Generalization f I)) (zeroLocus (ideal f I))
-    (locClosedSubset f I) := by
+      (locClosedSubset f I) := by
   refine ⟨?mapsTo, ?injOn, ?surjOn⟩
   case mapsTo =>
     intro y hy
-    set q := PrimeSpectrum.comap (algebraMap A (Generalization f I)) y
     rw [PrimeSpectrum.mem_zeroLocus] at hy
-    constructor
-    · -- f ∉ q.asIdeal
-      simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
-      intro hfq
-      have hf_sub : f ∈ submonoid f I := by
-        rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff]
-        rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
-        have hmem : Ideal.Quotient.mk I f ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
-          ⟨1, pow_one _⟩
-        exact IsLocalization.map_units _ ⟨_, hmem⟩
-      have hdisj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) := by
-        have hq_range :
-            q ∈ Set.range (PrimeSpectrum.comap (algebraMap A (Generalization f I))) :=
-          ⟨y, rfl⟩
-        rwa [PrimeSpectrum.localization_comap_range (Generalization f I) (submonoid f I)]
-          at hq_range
-      exact Set.disjoint_left.mp hdisj hf_sub hfq
-    · -- I ⊆ q.asIdeal
-      rw [PrimeSpectrum.mem_zeroLocus]
-      intro a ha
-      change algebraMap A (Generalization f I) a ∈ y.asIdeal
-      apply hy
-      simp only [ideal, SetLike.mem_coe, RingHom.mem_ker]
-      change (toLocQuotient f I) (algebraMap A (Generalization f I) a) = 0
-      rw [(toLocQuotient f I).commutes, IsScalarTower.algebraMap_apply A (A ⧸ I)]
-      simp [Ideal.Quotient.eq_zero_iff_mem.mpr ha]
+    have hdisj := ((IsLocalization.isPrime_iff_isPrime_disjoint (submonoid f I)
+      (Generalization f I) y.asIdeal).mp y.isPrime).2
+    have hf_sub : f ∈ submonoid f I := by
+      rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff,
+        IsScalarTower.algebraMap_apply A (A ⧸ I)]
+      have hmem : Ideal.Quotient.mk I f ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
+        ⟨1, pow_one _⟩
+      exact IsLocalization.map_units (Localization.Away (Ideal.Quotient.mk I f)) ⟨_, hmem⟩
+    refine ⟨fun hfq ↦ Set.disjoint_left.mp hdisj hf_sub hfq, ?_⟩
+    rw [PrimeSpectrum.mem_zeroLocus]
+    intro a ha
+    refine hy ?_
+    change toLocQuotient f I (algebraMap A (Generalization f I) a) = 0
+    rw [(toLocQuotient f I).commutes, IsScalarTower.algebraMap_apply A (A ⧸ I)]
+    simp [Ideal.Quotient.eq_zero_iff_mem.mpr ha]
   case injOn =>
     exact (PrimeSpectrum.localization_comap_isEmbedding (Generalization f I)
       (submonoid f I)).injective.injOn
   case surjOn =>
     intro q hq
-    have hq_disj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) :=
-      Set.disjoint_left.mpr fun a ha ha_q =>
-        submonoid_disjoint_locClosedSubset_primes f I a ha q hq ha_q
-    set q_map := Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
-    have hq_map_prime : q_map.IsPrime :=
-      IsLocalization.isPrime_of_isPrime_disjoint (submonoid f I) (Generalization f I)
-        q.asIdeal q.isPrime hq_disj
-    set y : PrimeSpectrum (Generalization f I) := ⟨q_map, hq_map_prime⟩
-    have hy_comap : PrimeSpectrum.comap (algebraMap A (Generalization f I)) y = q :=
-      PrimeSpectrum.ext (IsLocalization.under_map_of_isPrime_disjoint (submonoid f I)
-        (Generalization f I) q.isPrime hq_disj)
-    refine ⟨y, ?_, hy_comap⟩
-    -- y ∈ V(ideal f I): same argument as in exists_specializes_zeroLocus_ideal
-    rw [PrimeSpectrum.mem_zeroLocus]
-    intro z hz_mem
-    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker] at hz_mem
-    obtain ⟨a, s, hzas⟩ := IsLocalization.exists_mk'_eq (submonoid f I) z
-    rw [← hzas] at hz_mem ⊢
-    have hz' : algebraMap A (Localization.Away (Ideal.Quotient.mk I f)) a = 0 := by
-      have h3 := IsLocalization.mk'_spec (M := submonoid f I) (Generalization f I) a s
-      have h4 : (toLocQuotient f I) (IsLocalization.mk' (Generalization f I) a s *
-          algebraMap A (Generalization f I) (s : A)) =
-        (toLocQuotient f I) (algebraMap A (Generalization f I) a) := congr_arg _ h3
-      rw [map_mul, hz_mem, zero_mul, (toLocQuotient f I).commutes] at h4
-      exact h4.symm
-    have ha_q : a ∈ q.asIdeal := by
-      have hqI : I ≤ q.asIdeal := (PrimeSpectrum.mem_zeroLocus _ _).mp hq.2
-      have hfq : f ∉ q.asIdeal := by
-        simp only [locClosedSubset, Set.mem_inter_iff] at hq; exact hq.1
-      set a_bar := Ideal.Quotient.mk I a
-      set f_bar := Ideal.Quotient.mk I f
-      have hz_factor : algebraMap (A ⧸ I) (Localization.Away f_bar) a_bar = 0 := by
-        have := IsScalarTower.algebraMap_apply A (A ⧸ I) (Localization.Away f_bar) a
-        rw [this] at hz'; exact hz'
-      have ⟨c, hc⟩ := (IsLocalization.map_eq_zero_iff (Submonoid.powers f_bar)
-        (Localization.Away f_bar) a_bar).mp hz_factor
-      obtain ⟨c_val, n, hn⟩ := c; subst hn
-      have hfna : f ^ n * a ∈ I := by
-        have : Ideal.Quotient.mk I (f ^ n * a) = 0 := by rw [map_mul, map_pow]; exact hc
-        exact Ideal.Quotient.eq_zero_iff_mem.mp this
-      have hfnq : f ^ n ∉ q.asIdeal := mt (q.isPrime.mem_of_pow_mem n) hfq
-      exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left hfnq
-    change IsLocalization.mk' (Generalization f I) a s ∈ q_map
-    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
-    exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
-
-/-- `a ∈ submonoid f I` iff `a` is not in any prime in `locClosedSubset f I`. -/
-private lemma mem_submonoid_iff_not_mem_locClosedSubset (f : A) (I : Ideal A) (a : A) :
-    a ∈ submonoid f I ↔ ∀ p ∈ locClosedSubset f I, a ∉ p.asIdeal := by
-  simp only [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff, locClosedSubset]
-  constructor
-  · -- If IsUnit (algebraMap A ((A/I)_f) a), then a ∉ p for all p ∈ D(f) ∩ V(I)
-    intro ha p ⟨hpf, hpI⟩ hap
-    simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen] at hpf
-    simp only [PrimeSpectrum.mem_zeroLocus] at hpI
-    have hker : RingHom.ker (Ideal.Quotient.mk I) ≤ p.asIdeal := by
-      have hk : RingHom.ker (Ideal.Quotient.mk I) = I := Ideal.mk_ker
-      rw [hk]; exact hpI
-    set q := Ideal.map (Ideal.Quotient.mk I) p.asIdeal with hq_def
-    have hq_prime : q.IsPrime :=
-      Ideal.map_isPrime_of_surjective Ideal.Quotient.mk_surjective hker
-    have hmkf : Ideal.Quotient.mk I f ∉ q := by
-      rw [hq_def]
-      intro hfq
-      have hcomap := Ideal.comap_map_of_surjective (Ideal.Quotient.mk I)
-        Ideal.Quotient.mk_surjective p.asIdeal
-      rw [show Ideal.comap (Ideal.Quotient.mk I) ⊥ = I from
-        RingHom.ker_eq_comap_bot (Ideal.Quotient.mk I) ▸ Ideal.mk_ker] at hcomap
-      have hfmem : f ∈ p.asIdeal ⊔ I := hcomap ▸ Ideal.mem_comap.mpr hfq
-      have : p.asIdeal ⊔ I = p.asIdeal := sup_eq_left.mpr (by
-        intro x hx; exact hpI hx)
-      exact hpf (this ▸ hfmem)
-    have hdisj : Disjoint (Submonoid.powers (Ideal.Quotient.mk I f) : Set (A ⧸ I))
-        (q : Set (A ⧸ I)) :=
-      Set.disjoint_left.mpr fun y hy1 hy2 => by
-        simp only [SetLike.mem_coe, Submonoid.mem_powers_iff] at hy1
-        obtain ⟨n, hn⟩ := hy1
-        rw [← hn] at hy2
-        exact hmkf (hq_prime.mem_of_pow_mem n hy2)
-    have hq_loc : (Ideal.map (algebraMap (A ⧸ I)
-        (Localization.Away (Ideal.Quotient.mk I f))) q).IsPrime :=
-      IsLocalization.isPrime_of_isPrime_disjoint _ _ q hq_prime hdisj
-    have hmka : Ideal.Quotient.mk I a ∈ q :=
-      Ideal.mem_map_of_mem _ hap
-    apply hq_loc.ne_top
-    exact Ideal.eq_top_of_isUnit_mem _ (Ideal.mem_map_of_mem _ hmka) (by
-      rw [IsScalarTower.algebraMap_apply A (A ⧸ I)] at ha; exact ha)
-  · -- If a ∉ p for all p ∈ D(f) ∩ V(I), then IsUnit (algebraMap A ((A/I)_f) a)
-    intro ha
-    rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
-    have key : basicOpen (Ideal.Quotient.mk I f) ≤ basicOpen (Ideal.Quotient.mk I a) := by
-      intro p_bar hp_bar
-      simp only [PrimeSpectrum.mem_basicOpen] at hp_bar ⊢
-      intro hmka
-      set p := PrimeSpectrum.comap (Ideal.Quotient.mk I) p_bar
-      have hpI : p ∈ zeroLocus (I : Set A) := by
-        rw [PrimeSpectrum.mem_zeroLocus]
-        intro b hb
-        change Ideal.Quotient.mk I b ∈ p_bar.asIdeal
-        rw [Ideal.Quotient.eq_zero_iff_mem.mpr hb]
-        exact p_bar.asIdeal.zero_mem
-      have hpf : p ∈ (basicOpen f : Set _) := by
-        simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
-        intro hfp
-        exact hp_bar (show Ideal.Quotient.mk I f ∈ p_bar.asIdeal from hfp)
-      exact ha p ⟨hpf, hpI⟩ hmka
-    rwa [PrimeSpectrum.basicOpen_le_basicOpen_iff_algebraMap_isUnit (S :=
-      Localization.Away (Ideal.Quotient.mk I f))] at key
-
-theorem submonoid_le {f f' : A} {I I' : Ideal A} (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
-    submonoid f I ≤ submonoid f' I' := by
-  intro a ha
-  rw [mem_submonoid_iff_not_mem_locClosedSubset] at ha ⊢
-  exact fun p hp => ha p (h hp)
-
-noncomputable def map {f f' : A} {I I' : Ideal A}
-    (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
-    Generalization f I →ₐ[A] Generalization f' I' where
-  toRingHom := IsLocalization.map (T := Generalization.submonoid f' I')
-    (Generalization f' I') (RingHom.id A) (submonoid_le h)
-  commutes' := fun r => by simp
+    exact exists_mem_zeroLocus_ideal_specComap_eq hq
 
 lemma exists_specializes_zeroLocus_ideal {f : A} (I : Ideal A)
     (x : PrimeSpectrum (Generalization f I)) : ∃ y ∈ zeroLocus (ideal f I), x ⤳ y := by
-  -- Map x to its image in Spec A
-  set p := PrimeSpectrum.comap (algebraMap A (Generalization f I)) x with hp_def
-  -- p is in generalizationHull(locClosedSubset f I)
-  have hp_range : p ∈ generalizationHull (locClosedSubset f I) := by
-    rw [← range_algebraMap_generalization]; exact ⟨x, rfl⟩
+  have hp_range : PrimeSpectrum.comap (algebraMap A (Generalization f I)) x ∈
+      generalizationHull (locClosedSubset f I) :=
+    range_algebraMap_generalization f I ▸ ⟨x, rfl⟩
   rw [mem_generalizationHull_iff] at hp_range
   obtain ⟨q, hq_loc, hpq⟩ := hp_range
-  rw [← PrimeSpectrum.le_iff_specializes] at hpq
-  -- q is disjoint from submonoid f I
-  have hq_disj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) :=
-    Set.disjoint_left.mpr fun a ha ha_q =>
-      submonoid_disjoint_locClosedSubset_primes f I a ha q hq_loc ha_q
-  -- Lift q to a prime y of Generalization f I
-  set q_map := Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
-  have hq_map_prime : q_map.IsPrime :=
-    IsLocalization.isPrime_of_isPrime_disjoint (submonoid f I) (Generalization f I)
-      q.asIdeal q.isPrime hq_disj
-  set y : PrimeSpectrum (Generalization f I) := ⟨q_map, hq_map_prime⟩
-  have hy_comap : (PrimeSpectrum.comap (algebraMap A (Generalization f I)) y).asIdeal =
-      q.asIdeal :=
-    IsLocalization.under_map_of_isPrime_disjoint (submonoid f I) (Generalization f I)
-      q.isPrime hq_disj
-  refine ⟨y, ?_, ?_⟩
-  · -- y ∈ V(ideal f I): show ideal f I ⊆ y.asIdeal
-    rw [PrimeSpectrum.mem_zeroLocus]
-    intro z hz
-    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker] at hz
-    -- z ∈ ker(toLocQuotient f I), and y.asIdeal = q.asIdeal.map(algebraMap)
-    -- Since toLocQuotient factors through the quotient by ideal and q contains I,
-    -- we need: toLocQuotient z = 0 implies z ∈ y.asIdeal
-    -- toLocQuotient maps z to 0 in (A/I)_f
-    -- y.asIdeal = q.asIdeal.map(algebraMap), and its comap is q.asIdeal
-    -- Since I ⊆ q (from hq_loc), and algebraMap A (Gen f I) is flat...
-    -- Actually, let's use: z ∈ y.asIdeal iff comap z ∈ q, i.e., algebraMap(z) ∈ q_map
-    -- But z is already in Gen f I, not in A.
-    -- Use: y.asIdeal = q_map = IsLocalization.map_comap gives us y = map(comap y)
-    -- and comap y = q. So for z ∈ Gen f I, z ∈ y.asIdeal iff the image of z in
-    -- Gen f I / y.asIdeal is 0.
-    -- Alternative: use IsLocalization.map_comap to show ideal f I ≤ y.asIdeal
-    -- ideal f I = ker(Gen f I → (A/I)_f)
-    -- y.asIdeal corresponds to q = some prime containing I with f ∉ q
-    -- The map Gen f I → (A/I)_f factors as Gen f I → Gen f I / (I·Gen f I) → (A/I)_f
-    -- So ker ⊇ I · Gen f I
-    -- And y.asIdeal ⊇ q.asIdeal.map ⊇ I.map
-    -- So it suffices to show ideal f I ⊆ I.map ... no, that's wrong direction
-    -- Actually: ideal f I = ker(toLocQuotient), and y.asIdeal ⊇ I.map(algebraMap)
-    -- We need: ker(toLocQuotient) ⊆ y.asIdeal
-    -- Use: toLocQuotient z = 0 and z ∈ Gen f I.
-    -- Gen f I = (submonoid f I)⁻¹ A
-    -- write z = a/s with a ∈ A and s ∈ submonoid f I
-    -- toLocQuotient(a/s) = (image of a in (A/I)_f) / (image of s in (A/I)_f) = 0
-    -- So image of a in (A/I)_f = 0
-    -- i.e., algebraMap A ((A/I)_f) a = 0
-    -- i.e., a ∈ ker(A → (A/I)_f)
-    -- ker(A → (A/I)_f) = {a ∈ A | ∃ t ∈ powers(f̄), t · (a mod I) = 0 in A/I}
-    --                   = {a ∈ A | ∃ n, f^n · a ∈ I}
-    -- Since I ⊆ q.asIdeal and f ∉ q.asIdeal, we get f^n ∉ q.asIdeal
-    -- And f^n · a ∈ I ⊆ q.asIdeal, so a ∈ q.asIdeal (since q is prime)
-    -- Then z = a/s ∈ y.asIdeal = q.map(algebraMap) since a ∈ q.asIdeal
-    -- Write z = mk' a s using surjectivity of mk'
-    obtain ⟨a, s, hzas⟩ := IsLocalization.exists_mk'_eq (submonoid f I) z
-    rw [← hzas] at hz ⊢
-    -- toLocQuotient(mk' a s) = 0 means algebraMap A ((A/I)_f) a = 0
-    have hz' : algebraMap A (Localization.Away (Ideal.Quotient.mk I f)) a = 0 := by
-      -- mk' a s * algebraMap s = algebraMap a
-      have h3 := IsLocalization.mk'_spec (M := submonoid f I) (Generalization f I) a s
-      -- Apply toLocQuotient to both sides
-      have h4 : (toLocQuotient f I) (IsLocalization.mk' (Generalization f I) a s *
-          algebraMap A (Generalization f I) (s : A)) =
-        (toLocQuotient f I) (algebraMap A (Generalization f I) a) := congr_arg _ h3
-      rw [map_mul, hz, zero_mul, (toLocQuotient f I).commutes] at h4
-      exact h4.symm
-    -- hz' : algebraMap A ((A/I)_f) a = 0
-    -- Use IsLocalization.eq_iff_exists to extract multiplier
-    -- algebraMap A ((A/I)_f) factors as A → A/I → (A/I)_f
-    -- So algebraMap A ((A/I)_f) a = 0 means ∃ c ∈ powers(mk I f), c * mk I a = 0
-    -- First, get that a maps to zero in A/I localized at f
-    -- By IsLocalization.surj of (A/I) → (A/I)_f, the algebra map is
-    -- algebraMap R S where R = A/I, S = Localization.Away (mk I f), M = powers(mk I f)
-    -- and algebraMap A S = algebraMap (A/I) S ∘ algebraMap A (A/I)
-    -- Use exists_of_eq to get: algebraMap A ((A/I)_f) a = algebraMap A ((A/I)_f) 0
-    -- implies ∃ c ∈ submonoid f I, c * a = c * 0 = 0 in (some sense)
-    -- Actually: use the fact that the composed map A → (A/I)_f has a specific kernel
-    -- Let's work directly: a ∈ q.asIdeal
-    -- Since f ∉ q and I ⊆ q, the image of a in (A/I)_f is zero
-    -- implies ∃ n, f^n * a ∈ I
-    -- Actually let me directly use the characterization:
-    -- algebraMap A ((A/I)_f) a = 0 iff ∃ n, (mk I f)^n * (mk I a) = 0 in A/I
-    -- iff ∃ n, f^n * a ∈ I
-    have ha_q : a ∈ q.asIdeal := by
-      -- q ∈ locClosedSubset f I, so I ⊆ q.asIdeal and f ∉ q.asIdeal
-      have hqI : I ≤ q.asIdeal := (PrimeSpectrum.mem_zeroLocus _ _).mp hq_loc.2
-      have hfq : f ∉ q.asIdeal := by
-        simp only [locClosedSubset, Set.mem_inter_iff] at hq_loc
-        exact hq_loc.1
-      -- From hz': algebraMap A ((A/I)_f) a = 0
-      -- Factor: algebraMap A ((A/I)_f) = algebraMap (A/I) ((A/I)_f) ∘ (mk I)
-      -- So (mk I a) maps to 0 in (A/I)_f
-      -- By localization kernel: ∃ c ∈ powers(mk I f), c * (mk I a) = 0 in A/I
-      set a_bar := Ideal.Quotient.mk I a
-      set f_bar := Ideal.Quotient.mk I f
-      have hz_factor : algebraMap (A ⧸ I) (Localization.Away f_bar) a_bar = 0 := by
-        have := IsScalarTower.algebraMap_apply A (A ⧸ I) (Localization.Away f_bar) a
-        rw [this] at hz'; exact hz'
-      have ⟨c, hc⟩ := (IsLocalization.map_eq_zero_iff (Submonoid.powers f_bar)
-        (Localization.Away f_bar) a_bar).mp hz_factor
-      obtain ⟨c_val, n, hn⟩ := c
-      subst hn
-      -- hc : f_bar ^ n * a_bar = 0 in A/I
-      -- i.e., f^n * a ∈ I
-      have hfna : f ^ n * a ∈ I := by
-        have : Ideal.Quotient.mk I (f ^ n * a) = 0 := by
-          rw [map_mul, map_pow]; exact hc
-        exact Ideal.Quotient.eq_zero_iff_mem.mp this
-      -- f^n ∉ q (since q is prime and f ∉ q)
-      have hfnq : f ^ n ∉ q.asIdeal := mt (q.isPrime.mem_of_pow_mem n) hfq
-      exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left hfnq
-    -- mk' a s ∈ y.asIdeal = Ideal.map (algebraMap A (Gen f I)) q.asIdeal
-    change IsLocalization.mk' (Generalization f I) a s ∈ q_map
-    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
-    exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
-  · -- x ⤳ y using the localization embedding
-    -- For a localization, comap reflects specialization (it's an embedding)
-    have hemb :=
-      PrimeSpectrum.localization_comap_isEmbedding (Generalization f I) (submonoid f I)
-    rw [← hemb.specializes_iff (x := x) (y := y), ← PrimeSpectrum.le_iff_specializes]
-    -- comap y has asIdeal = q.asIdeal (by hy_comap), comap x = p, and p ≤ q
-    change p.asIdeal ≤ (PrimeSpectrum.comap (algebraMap A (Generalization f I)) y).asIdeal
-    rw [hy_comap]
-    exact hpq
+  obtain ⟨y, hy_mem, hy_eq⟩ := exists_mem_zeroLocus_ideal_specComap_eq hq_loc
+  refine ⟨y, hy_mem, ?_⟩
+  rw [← (PrimeSpectrum.localization_comap_isEmbedding (Generalization f I)
+    (submonoid f I)).specializes_iff, hy_eq]
+  exact hpq
 
 end Generalization
 

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -67,32 +67,398 @@ instance indZariski : Algebra.IndZariski A (Generalization f I) := by
 def locClosedSubset (f : A) (I : Ideal A) : Set (PrimeSpectrum A) :=
   basicOpen f ∩ zeroLocus I
 
+
+-- Helper: if `a ∈ submonoid f I` and `q ∈ locClosedSubset f I`, then `a ∉ q.asIdeal`.
+-- This is the forward direction of `mem_submonoid_iff_not_mem_locClosedSubset`, extracted
+-- here so it can be used in `range_algebraMap_generalization`.
+private lemma submonoid_disjoint_locClosedSubset_primes (f : A) (I : Ideal A) (a : A)
+    (ha : a ∈ submonoid f I) (q : PrimeSpectrum A) (hq : q ∈ locClosedSubset f I) :
+    a ∉ q.asIdeal := by
+  simp only [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff] at ha
+  simp only [locClosedSubset, Set.mem_inter_iff] at hq
+  obtain ⟨hqf, hqI⟩ := hq
+  simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen] at hqf
+  rw [PrimeSpectrum.mem_zeroLocus] at hqI
+  intro haq
+  -- Build the prime q_bar = image of q in A/I, then lift to (A/I)_f
+  have hker : RingHom.ker (Ideal.Quotient.mk I) ≤ q.asIdeal := by
+    rw [Ideal.mk_ker]; exact hqI
+  set q_bar := Ideal.map (Ideal.Quotient.mk I) q.asIdeal
+  have hq_prime : q_bar.IsPrime :=
+    Ideal.map_isPrime_of_surjective Ideal.Quotient.mk_surjective hker
+  have hmkf : Ideal.Quotient.mk I f ∉ q_bar := by
+    intro hfq
+    have hcomap := Ideal.comap_map_of_surjective (Ideal.Quotient.mk I)
+      Ideal.Quotient.mk_surjective q.asIdeal
+    rw [show Ideal.comap (Ideal.Quotient.mk I) ⊥ = I from
+      RingHom.ker_eq_comap_bot (Ideal.Quotient.mk I) ▸ Ideal.mk_ker] at hcomap
+    have hIq : I ≤ q.asIdeal := hqI
+    exact hqf (sup_eq_left.mpr hIq ▸ (hcomap ▸ Ideal.mem_comap.mpr hfq))
+  have hdisj : Disjoint (Submonoid.powers (Ideal.Quotient.mk I f) : Set (A ⧸ I))
+      (q_bar : Set (A ⧸ I)) :=
+    Set.disjoint_left.mpr fun y hy1 hy2 => by
+      simp only [SetLike.mem_coe, Submonoid.mem_powers_iff] at hy1
+      obtain ⟨n, hn⟩ := hy1
+      rw [← hn] at hy2
+      exact hmkf (hq_prime.mem_of_pow_mem n hy2)
+  have hq_loc : (Ideal.map (algebraMap (A ⧸ I) (Localization.Away (Ideal.Quotient.mk I f)))
+      q_bar).IsPrime :=
+    IsLocalization.isPrime_of_isPrime_disjoint _ _ q_bar hq_prime hdisj
+  apply hq_loc.ne_top
+  exact Ideal.eq_top_of_isUnit_mem _ (Ideal.mem_map_of_mem _ (Ideal.mem_map_of_mem _ haq))
+    (by rw [IsScalarTower.algebraMap_apply A (A ⧸ I)] at ha; exact ha)
+
 /-- The image of `Spec (Generalization f I)` in `Spec A` is equal to
 the generalization hull of `D(f) ∩ V(I)`. -/
 lemma range_algebraMap_generalization (f : A) (I : Ideal A) :
     Set.range (PrimeSpectrum.comap <| algebraMap A (Generalization f I)) =
-    generalizationHull (locClosedSubset f I) :=
-  sorry
+    generalizationHull (locClosedSubset f I) := by
+  rw [PrimeSpectrum.localization_comap_range (Generalization f I) (submonoid f I)]
+  ext p
+  simp only [Set.mem_setOf_eq]
+  rw [mem_generalizationHull_iff]
+  constructor
+  · -- If Disjoint (submonoid f I) p.asIdeal, find q ∈ locClosedSubset f I with p ⤳ q
+    intro hdisj
+    -- Key claim: f ∉ radical (p.asIdeal ⊔ I)
+    have hf_not_rad : f ∉ Ideal.radical (p.asIdeal ⊔ I) := by
+      rw [Ideal.mem_radical_iff]
+      push Not
+      intro n hfn
+      -- f^n ∈ p.asIdeal ⊔ I means f^n = a + b with a ∈ p, b ∈ I
+      rw [Submodule.mem_sup] at hfn
+      obtain ⟨a, ha, b, hb, hab⟩ := hfn
+      -- In (A/I)_f, image of a equals image of f^n (a unit), so a ∈ submonoid f I
+      have ha_sub : a ∈ submonoid f I := by
+        rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff]
+        rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
+        have h_eq : (algebraMap A (A ⧸ I)) a = (algebraMap A (A ⧸ I)) (f ^ n) := by
+          have hmem : a - f ^ n ∈ I := by
+            have : a - f ^ n = -b := by linear_combination hab
+            rw [this]; exact I.neg_mem hb
+          rwa [← Ideal.Quotient.eq] at hmem
+        rw [h_eq]
+        -- Goal: IsUnit (algebraMap (A ⧸ I) (Localization.Away (mk I f)) (mk I f ^ n))
+        -- mk I f ^ n is in Submonoid.powers (mk I f), so its image is a unit
+        have hmem : (Ideal.Quotient.mk I f) ^ n ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
+          ⟨n, rfl⟩
+        exact IsLocalization.map_units (Localization.Away (Ideal.Quotient.mk I f)) ⟨_, hmem⟩
+      -- But a ∈ p.asIdeal ∩ submonoid f I, contradicting disjointness
+      exact Set.disjoint_left.mp hdisj ha_sub ha
+    -- Since f ∉ radical(p ⊔ I), there exists a prime q ⊇ p ⊔ I with f ∉ q
+    rw [Ideal.radical_eq_sInf, Ideal.mem_sInf] at hf_not_rad
+    push Not at hf_not_rad
+    obtain ⟨q, ⟨hle, hq_prime⟩, hfq⟩ := hf_not_rad
+    refine ⟨⟨q, hq_prime⟩, ?_, ?_⟩
+    · -- q ∈ locClosedSubset f I
+      constructor
+      · simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]; exact hfq
+      · rw [PrimeSpectrum.mem_zeroLocus]
+        intro x hx
+        exact hle (Ideal.mem_sup_right hx)
+    · -- p ⤳ q, i.e., p.asIdeal ≤ q
+      rw [← PrimeSpectrum.le_iff_specializes]
+      intro x hx
+      exact hle (Ideal.mem_sup_left hx)
+  · -- If ∃ q ∈ locClosedSubset, p ⤳ q, then Disjoint
+    rintro ⟨q, hq, hpq⟩
+    rw [← PrimeSpectrum.le_iff_specializes] at hpq
+    refine Set.disjoint_left.mpr fun a ha_sub ha_p => ?_
+    exact submonoid_disjoint_locClosedSubset_primes f I a ha_sub q hq (hpq ha_p)
 
 lemma bijOn_algebraMap_generalization_specComap_zeroLocus_ideal (f : A) (I : Ideal A) :
     Set.BijOn (PrimeSpectrum.comap <| algebraMap A (Generalization f I)) (zeroLocus (ideal f I))
-    (locClosedSubset f I) :=
-  sorry
+    (locClosedSubset f I) := by
+  refine ⟨?mapsTo, ?injOn, ?surjOn⟩
+  case mapsTo =>
+    intro y hy
+    set q := PrimeSpectrum.comap (algebraMap A (Generalization f I)) y
+    rw [PrimeSpectrum.mem_zeroLocus] at hy
+    constructor
+    · -- f ∉ q.asIdeal
+      simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
+      intro hfq
+      have hf_sub : f ∈ submonoid f I := by
+        rw [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff]
+        rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
+        have hmem : Ideal.Quotient.mk I f ∈ Submonoid.powers (Ideal.Quotient.mk I f) :=
+          ⟨1, pow_one _⟩
+        exact IsLocalization.map_units _ ⟨_, hmem⟩
+      have hdisj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) := by
+        have hq_range :
+            q ∈ Set.range (PrimeSpectrum.comap (algebraMap A (Generalization f I))) :=
+          ⟨y, rfl⟩
+        rwa [PrimeSpectrum.localization_comap_range (Generalization f I) (submonoid f I)]
+          at hq_range
+      exact Set.disjoint_left.mp hdisj hf_sub hfq
+    · -- I ⊆ q.asIdeal
+      rw [PrimeSpectrum.mem_zeroLocus]
+      intro a ha
+      change algebraMap A (Generalization f I) a ∈ y.asIdeal
+      apply hy
+      simp only [ideal, SetLike.mem_coe, RingHom.mem_ker]
+      change (toLocQuotient f I) (algebraMap A (Generalization f I) a) = 0
+      rw [(toLocQuotient f I).commutes, IsScalarTower.algebraMap_apply A (A ⧸ I)]
+      simp [Ideal.Quotient.eq_zero_iff_mem.mpr ha]
+  case injOn =>
+    exact (PrimeSpectrum.localization_comap_isEmbedding (Generalization f I)
+      (submonoid f I)).injective.injOn
+  case surjOn =>
+    intro q hq
+    have hq_disj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) :=
+      Set.disjoint_left.mpr fun a ha ha_q =>
+        submonoid_disjoint_locClosedSubset_primes f I a ha q hq ha_q
+    set q_map := Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
+    have hq_map_prime : q_map.IsPrime :=
+      IsLocalization.isPrime_of_isPrime_disjoint (submonoid f I) (Generalization f I)
+        q.asIdeal q.isPrime hq_disj
+    set y : PrimeSpectrum (Generalization f I) := ⟨q_map, hq_map_prime⟩
+    have hy_comap : PrimeSpectrum.comap (algebraMap A (Generalization f I)) y = q :=
+      PrimeSpectrum.ext (IsLocalization.under_map_of_isPrime_disjoint (submonoid f I)
+        (Generalization f I) q.isPrime hq_disj)
+    refine ⟨y, ?_, hy_comap⟩
+    -- y ∈ V(ideal f I): same argument as in exists_specializes_zeroLocus_ideal
+    rw [PrimeSpectrum.mem_zeroLocus]
+    intro z hz_mem
+    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker] at hz_mem
+    obtain ⟨a, s, hzas⟩ := IsLocalization.exists_mk'_eq (submonoid f I) z
+    rw [← hzas] at hz_mem ⊢
+    have hz' : algebraMap A (Localization.Away (Ideal.Quotient.mk I f)) a = 0 := by
+      have h3 := IsLocalization.mk'_spec (M := submonoid f I) (Generalization f I) a s
+      have h4 : (toLocQuotient f I) (IsLocalization.mk' (Generalization f I) a s *
+          algebraMap A (Generalization f I) (s : A)) =
+        (toLocQuotient f I) (algebraMap A (Generalization f I) a) := congr_arg _ h3
+      rw [map_mul, hz_mem, zero_mul, (toLocQuotient f I).commutes] at h4
+      exact h4.symm
+    have ha_q : a ∈ q.asIdeal := by
+      have hqI : I ≤ q.asIdeal := (PrimeSpectrum.mem_zeroLocus _ _).mp hq.2
+      have hfq : f ∉ q.asIdeal := by
+        simp only [locClosedSubset, Set.mem_inter_iff] at hq; exact hq.1
+      set a_bar := Ideal.Quotient.mk I a
+      set f_bar := Ideal.Quotient.mk I f
+      have hz_factor : algebraMap (A ⧸ I) (Localization.Away f_bar) a_bar = 0 := by
+        have := IsScalarTower.algebraMap_apply A (A ⧸ I) (Localization.Away f_bar) a
+        rw [this] at hz'; exact hz'
+      have ⟨c, hc⟩ := (IsLocalization.map_eq_zero_iff (Submonoid.powers f_bar)
+        (Localization.Away f_bar) a_bar).mp hz_factor
+      obtain ⟨c_val, n, hn⟩ := c; subst hn
+      have hfna : f ^ n * a ∈ I := by
+        have : Ideal.Quotient.mk I (f ^ n * a) = 0 := by rw [map_mul, map_pow]; exact hc
+        exact Ideal.Quotient.eq_zero_iff_mem.mp this
+      have hfnq : f ^ n ∉ q.asIdeal := mt (q.isPrime.mem_of_pow_mem n) hfq
+      exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left hfnq
+    change IsLocalization.mk' (Generalization f I) a s ∈ q_map
+    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
+    exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
+
+/-- `a ∈ submonoid f I` iff `a` is not in any prime in `locClosedSubset f I`. -/
+private lemma mem_submonoid_iff_not_mem_locClosedSubset (f : A) (I : Ideal A) (a : A) :
+    a ∈ submonoid f I ↔ ∀ p ∈ locClosedSubset f I, a ∉ p.asIdeal := by
+  simp only [submonoid, Submonoid.mem_comap, IsUnit.mem_submonoid_iff, locClosedSubset]
+  constructor
+  · -- If IsUnit (algebraMap A ((A/I)_f) a), then a ∉ p for all p ∈ D(f) ∩ V(I)
+    intro ha p ⟨hpf, hpI⟩ hap
+    simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen] at hpf
+    simp only [PrimeSpectrum.mem_zeroLocus] at hpI
+    have hker : RingHom.ker (Ideal.Quotient.mk I) ≤ p.asIdeal := by
+      have hk : RingHom.ker (Ideal.Quotient.mk I) = I := Ideal.mk_ker
+      rw [hk]; exact hpI
+    set q := Ideal.map (Ideal.Quotient.mk I) p.asIdeal with hq_def
+    have hq_prime : q.IsPrime :=
+      Ideal.map_isPrime_of_surjective Ideal.Quotient.mk_surjective hker
+    have hmkf : Ideal.Quotient.mk I f ∉ q := by
+      rw [hq_def]
+      intro hfq
+      have hcomap := Ideal.comap_map_of_surjective (Ideal.Quotient.mk I)
+        Ideal.Quotient.mk_surjective p.asIdeal
+      rw [show Ideal.comap (Ideal.Quotient.mk I) ⊥ = I from
+        RingHom.ker_eq_comap_bot (Ideal.Quotient.mk I) ▸ Ideal.mk_ker] at hcomap
+      have hfmem : f ∈ p.asIdeal ⊔ I := hcomap ▸ Ideal.mem_comap.mpr hfq
+      have : p.asIdeal ⊔ I = p.asIdeal := sup_eq_left.mpr (by
+        intro x hx; exact hpI hx)
+      exact hpf (this ▸ hfmem)
+    have hdisj : Disjoint (Submonoid.powers (Ideal.Quotient.mk I f) : Set (A ⧸ I))
+        (q : Set (A ⧸ I)) :=
+      Set.disjoint_left.mpr fun y hy1 hy2 => by
+        simp only [SetLike.mem_coe, Submonoid.mem_powers_iff] at hy1
+        obtain ⟨n, hn⟩ := hy1
+        rw [← hn] at hy2
+        exact hmkf (hq_prime.mem_of_pow_mem n hy2)
+    have hq_loc : (Ideal.map (algebraMap (A ⧸ I)
+        (Localization.Away (Ideal.Quotient.mk I f))) q).IsPrime :=
+      IsLocalization.isPrime_of_isPrime_disjoint _ _ q hq_prime hdisj
+    have hmka : Ideal.Quotient.mk I a ∈ q :=
+      Ideal.mem_map_of_mem _ hap
+    apply hq_loc.ne_top
+    exact Ideal.eq_top_of_isUnit_mem _ (Ideal.mem_map_of_mem _ hmka) (by
+      rw [IsScalarTower.algebraMap_apply A (A ⧸ I)] at ha; exact ha)
+  · -- If a ∉ p for all p ∈ D(f) ∩ V(I), then IsUnit (algebraMap A ((A/I)_f) a)
+    intro ha
+    rw [IsScalarTower.algebraMap_apply A (A ⧸ I)]
+    have key : basicOpen (Ideal.Quotient.mk I f) ≤ basicOpen (Ideal.Quotient.mk I a) := by
+      intro p_bar hp_bar
+      simp only [PrimeSpectrum.mem_basicOpen] at hp_bar ⊢
+      intro hmka
+      set p := PrimeSpectrum.comap (Ideal.Quotient.mk I) p_bar
+      have hpI : p ∈ zeroLocus (I : Set A) := by
+        rw [PrimeSpectrum.mem_zeroLocus]
+        intro b hb
+        change Ideal.Quotient.mk I b ∈ p_bar.asIdeal
+        rw [Ideal.Quotient.eq_zero_iff_mem.mpr hb]
+        exact p_bar.asIdeal.zero_mem
+      have hpf : p ∈ (basicOpen f : Set _) := by
+        simp only [SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
+        intro hfp
+        exact hp_bar (show Ideal.Quotient.mk I f ∈ p_bar.asIdeal from hfp)
+      exact ha p ⟨hpf, hpI⟩ hmka
+    rwa [PrimeSpectrum.basicOpen_le_basicOpen_iff_algebraMap_isUnit (S :=
+      Localization.Away (Ideal.Quotient.mk I f))] at key
 
 theorem submonoid_le {f f' : A} {I I' : Ideal A} (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
-    submonoid f I ≤ submonoid f' I' :=
-  sorry
+    submonoid f I ≤ submonoid f' I' := by
+  intro a ha
+  rw [mem_submonoid_iff_not_mem_locClosedSubset] at ha ⊢
+  exact fun p hp => ha p (h hp)
 
 noncomputable def map {f f' : A} {I I' : Ideal A}
     (h : locClosedSubset f' I' ⊆ locClosedSubset f I) :
     Generalization f I →ₐ[A] Generalization f' I' where
   toRingHom := IsLocalization.map (T := Generalization.submonoid f' I')
     (Generalization f' I') (RingHom.id A) (submonoid_le h)
-  commutes' := sorry
+  commutes' := fun r => by simp
 
 lemma exists_specializes_zeroLocus_ideal {f : A} (I : Ideal A)
-    (x : PrimeSpectrum (Generalization f I)) : ∃ y ∈ zeroLocus (ideal f I), x ⤳ y :=
-  sorry
+    (x : PrimeSpectrum (Generalization f I)) : ∃ y ∈ zeroLocus (ideal f I), x ⤳ y := by
+  -- Map x to its image in Spec A
+  set p := PrimeSpectrum.comap (algebraMap A (Generalization f I)) x with hp_def
+  -- p is in generalizationHull(locClosedSubset f I)
+  have hp_range : p ∈ generalizationHull (locClosedSubset f I) := by
+    rw [← range_algebraMap_generalization]; exact ⟨x, rfl⟩
+  rw [mem_generalizationHull_iff] at hp_range
+  obtain ⟨q, hq_loc, hpq⟩ := hp_range
+  rw [← PrimeSpectrum.le_iff_specializes] at hpq
+  -- q is disjoint from submonoid f I
+  have hq_disj : Disjoint (submonoid f I : Set A) (q.asIdeal : Set A) :=
+    Set.disjoint_left.mpr fun a ha ha_q =>
+      submonoid_disjoint_locClosedSubset_primes f I a ha q hq_loc ha_q
+  -- Lift q to a prime y of Generalization f I
+  set q_map := Ideal.map (algebraMap A (Generalization f I)) q.asIdeal
+  have hq_map_prime : q_map.IsPrime :=
+    IsLocalization.isPrime_of_isPrime_disjoint (submonoid f I) (Generalization f I)
+      q.asIdeal q.isPrime hq_disj
+  set y : PrimeSpectrum (Generalization f I) := ⟨q_map, hq_map_prime⟩
+  have hy_comap : (PrimeSpectrum.comap (algebraMap A (Generalization f I)) y).asIdeal =
+      q.asIdeal :=
+    IsLocalization.under_map_of_isPrime_disjoint (submonoid f I) (Generalization f I)
+      q.isPrime hq_disj
+  refine ⟨y, ?_, ?_⟩
+  · -- y ∈ V(ideal f I): show ideal f I ⊆ y.asIdeal
+    rw [PrimeSpectrum.mem_zeroLocus]
+    intro z hz
+    simp only [ideal, SetLike.mem_coe, RingHom.mem_ker] at hz
+    -- z ∈ ker(toLocQuotient f I), and y.asIdeal = q.asIdeal.map(algebraMap)
+    -- Since toLocQuotient factors through the quotient by ideal and q contains I,
+    -- we need: toLocQuotient z = 0 implies z ∈ y.asIdeal
+    -- toLocQuotient maps z to 0 in (A/I)_f
+    -- y.asIdeal = q.asIdeal.map(algebraMap), and its comap is q.asIdeal
+    -- Since I ⊆ q (from hq_loc), and algebraMap A (Gen f I) is flat...
+    -- Actually, let's use: z ∈ y.asIdeal iff comap z ∈ q, i.e., algebraMap(z) ∈ q_map
+    -- But z is already in Gen f I, not in A.
+    -- Use: y.asIdeal = q_map = IsLocalization.map_comap gives us y = map(comap y)
+    -- and comap y = q. So for z ∈ Gen f I, z ∈ y.asIdeal iff the image of z in
+    -- Gen f I / y.asIdeal is 0.
+    -- Alternative: use IsLocalization.map_comap to show ideal f I ≤ y.asIdeal
+    -- ideal f I = ker(Gen f I → (A/I)_f)
+    -- y.asIdeal corresponds to q = some prime containing I with f ∉ q
+    -- The map Gen f I → (A/I)_f factors as Gen f I → Gen f I / (I·Gen f I) → (A/I)_f
+    -- So ker ⊇ I · Gen f I
+    -- And y.asIdeal ⊇ q.asIdeal.map ⊇ I.map
+    -- So it suffices to show ideal f I ⊆ I.map ... no, that's wrong direction
+    -- Actually: ideal f I = ker(toLocQuotient), and y.asIdeal ⊇ I.map(algebraMap)
+    -- We need: ker(toLocQuotient) ⊆ y.asIdeal
+    -- Use: toLocQuotient z = 0 and z ∈ Gen f I.
+    -- Gen f I = (submonoid f I)⁻¹ A
+    -- write z = a/s with a ∈ A and s ∈ submonoid f I
+    -- toLocQuotient(a/s) = (image of a in (A/I)_f) / (image of s in (A/I)_f) = 0
+    -- So image of a in (A/I)_f = 0
+    -- i.e., algebraMap A ((A/I)_f) a = 0
+    -- i.e., a ∈ ker(A → (A/I)_f)
+    -- ker(A → (A/I)_f) = {a ∈ A | ∃ t ∈ powers(f̄), t · (a mod I) = 0 in A/I}
+    --                   = {a ∈ A | ∃ n, f^n · a ∈ I}
+    -- Since I ⊆ q.asIdeal and f ∉ q.asIdeal, we get f^n ∉ q.asIdeal
+    -- And f^n · a ∈ I ⊆ q.asIdeal, so a ∈ q.asIdeal (since q is prime)
+    -- Then z = a/s ∈ y.asIdeal = q.map(algebraMap) since a ∈ q.asIdeal
+    -- Write z = mk' a s using surjectivity of mk'
+    obtain ⟨a, s, hzas⟩ := IsLocalization.exists_mk'_eq (submonoid f I) z
+    rw [← hzas] at hz ⊢
+    -- toLocQuotient(mk' a s) = 0 means algebraMap A ((A/I)_f) a = 0
+    have hz' : algebraMap A (Localization.Away (Ideal.Quotient.mk I f)) a = 0 := by
+      -- mk' a s * algebraMap s = algebraMap a
+      have h3 := IsLocalization.mk'_spec (M := submonoid f I) (Generalization f I) a s
+      -- Apply toLocQuotient to both sides
+      have h4 : (toLocQuotient f I) (IsLocalization.mk' (Generalization f I) a s *
+          algebraMap A (Generalization f I) (s : A)) =
+        (toLocQuotient f I) (algebraMap A (Generalization f I) a) := congr_arg _ h3
+      rw [map_mul, hz, zero_mul, (toLocQuotient f I).commutes] at h4
+      exact h4.symm
+    -- hz' : algebraMap A ((A/I)_f) a = 0
+    -- Use IsLocalization.eq_iff_exists to extract multiplier
+    -- algebraMap A ((A/I)_f) factors as A → A/I → (A/I)_f
+    -- So algebraMap A ((A/I)_f) a = 0 means ∃ c ∈ powers(mk I f), c * mk I a = 0
+    -- First, get that a maps to zero in A/I localized at f
+    -- By IsLocalization.surj of (A/I) → (A/I)_f, the algebra map is
+    -- algebraMap R S where R = A/I, S = Localization.Away (mk I f), M = powers(mk I f)
+    -- and algebraMap A S = algebraMap (A/I) S ∘ algebraMap A (A/I)
+    -- Use exists_of_eq to get: algebraMap A ((A/I)_f) a = algebraMap A ((A/I)_f) 0
+    -- implies ∃ c ∈ submonoid f I, c * a = c * 0 = 0 in (some sense)
+    -- Actually: use the fact that the composed map A → (A/I)_f has a specific kernel
+    -- Let's work directly: a ∈ q.asIdeal
+    -- Since f ∉ q and I ⊆ q, the image of a in (A/I)_f is zero
+    -- implies ∃ n, f^n * a ∈ I
+    -- Actually let me directly use the characterization:
+    -- algebraMap A ((A/I)_f) a = 0 iff ∃ n, (mk I f)^n * (mk I a) = 0 in A/I
+    -- iff ∃ n, f^n * a ∈ I
+    have ha_q : a ∈ q.asIdeal := by
+      -- q ∈ locClosedSubset f I, so I ⊆ q.asIdeal and f ∉ q.asIdeal
+      have hqI : I ≤ q.asIdeal := (PrimeSpectrum.mem_zeroLocus _ _).mp hq_loc.2
+      have hfq : f ∉ q.asIdeal := by
+        simp only [locClosedSubset, Set.mem_inter_iff] at hq_loc
+        exact hq_loc.1
+      -- From hz': algebraMap A ((A/I)_f) a = 0
+      -- Factor: algebraMap A ((A/I)_f) = algebraMap (A/I) ((A/I)_f) ∘ (mk I)
+      -- So (mk I a) maps to 0 in (A/I)_f
+      -- By localization kernel: ∃ c ∈ powers(mk I f), c * (mk I a) = 0 in A/I
+      set a_bar := Ideal.Quotient.mk I a
+      set f_bar := Ideal.Quotient.mk I f
+      have hz_factor : algebraMap (A ⧸ I) (Localization.Away f_bar) a_bar = 0 := by
+        have := IsScalarTower.algebraMap_apply A (A ⧸ I) (Localization.Away f_bar) a
+        rw [this] at hz'; exact hz'
+      have ⟨c, hc⟩ := (IsLocalization.map_eq_zero_iff (Submonoid.powers f_bar)
+        (Localization.Away f_bar) a_bar).mp hz_factor
+      obtain ⟨c_val, n, hn⟩ := c
+      subst hn
+      -- hc : f_bar ^ n * a_bar = 0 in A/I
+      -- i.e., f^n * a ∈ I
+      have hfna : f ^ n * a ∈ I := by
+        have : Ideal.Quotient.mk I (f ^ n * a) = 0 := by
+          rw [map_mul, map_pow]; exact hc
+        exact Ideal.Quotient.eq_zero_iff_mem.mp this
+      -- f^n ∉ q (since q is prime and f ∉ q)
+      have hfnq : f ^ n ∉ q.asIdeal := mt (q.isPrime.mem_of_pow_mem n) hfq
+      exact (q.isPrime.mem_or_mem (hqI hfna)).resolve_left hfnq
+    -- mk' a s ∈ y.asIdeal = Ideal.map (algebraMap A (Gen f I)) q.asIdeal
+    change IsLocalization.mk' (Generalization f I) a s ∈ q_map
+    rw [IsLocalization.mk'_mem_map_algebraMap_iff (submonoid f I)]
+    exact ⟨1, (submonoid f I).one_mem, by simpa using ha_q⟩
+  · -- x ⤳ y using the localization embedding
+    -- For a localization, comap reflects specialization (it's an embedding)
+    have hemb :=
+      PrimeSpectrum.localization_comap_isEmbedding (Generalization f I) (submonoid f I)
+    rw [← hemb.specializes_iff (x := x) (y := y), ← PrimeSpectrum.le_iff_specializes]
+    -- comap y has asIdeal = q.asIdeal (by hy_comap), comap x = p, and p ≤ q
+    change p.asIdeal ≤ (PrimeSpectrum.comap (algebraMap A (Generalization f I)) y).asIdeal
+    rw [hy_comap]
+    exact hpq
 
 end Generalization
 

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1234,6 +1234,7 @@ on the choice of $f$ and $I$ \stacksproject{096V}.
 \end{lemma}
 
 \begin{proof}
+    \leanok
     Let $S = S_{f, I}$, $Z = D(f) \cap V(I)$ and $J = \tildeideal{I}{f}$.
 
     Note that $Z$ is homeomorphic to $\spec{(A/I)_f}$.


### PR DESCRIPTION
Fill the five `sorry` placeholders in the `WLocalization.Generalization` section of `Proetale/Algebra/WLocalization/Basic.lean`:

* `range_algebraMap_generalization`: identifies the image of `Spec (Generalization f I) → Spec A` with the generalization hull of `D(f) ∩ V(I)`.
* `bijOn_algebraMap_generalization_specComap_zeroLocus_ideal`: the closed subscheme `V(ideal f I) ⊂ Spec (Generalization f I)` maps bijectively onto `D(f) ∩ V(I)`.
* `submonoid_le`: monotonicity of `Generalization.submonoid f I` along inclusions of locally closed subsets `D(f') ∩ V(I') ⊆ D(f) ∩ V(I)`.
* `Generalization.map.commutes'`: the `A`-algebra structure of the transition map between generalizations.
* `exists_specializes_zeroLocus_ideal`: every point of `Spec (Generalization f I)` specializes to a point of `V(ideal f I)`.

The proofs use two private helper lemmas: `submonoid_disjoint_locClosedSubset_primes` (forward direction of the membership criterion) and `mem_submonoid_iff_not_mem_locClosedSubset` (characterising `submonoid f I` via primes in `D(f) ∩ V(I)`).

This corresponds to `lemma:locally-closed-specializations` in `blueprint/src/chapters/local-structure.tex`; the informal proof is now annotated with `\leanok`.

## Test plan
- [x] `lake build Proetale.Algebra.WLocalization.Basic` succeeds with no warnings.
- [x] `bash .agent/validation.sh` passes (full project build with `--wfail`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)