### PR TITLE
feat(Morphisms/ProAffineEtale): fill `proAffineEtale_Spec_iff` sorry

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Proetale/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -50,10 +50,7 @@ noncomputable def diagPushout : ι ⥤ C where
       (𝟙 X) (𝟙 X) (P.diag.map h)
       (by simp) (by simp)
   map_id i := by ext <;> simp
-  map_comp {i j k} f g := by
-    apply pushout.hom_ext
-    · simp [pushout.map_comp]
-    · simp [pushout.map_comp]
+  map_comp {i j k} f g := by ext <;> simp [pushout.map_comp]
 
 @[reassoc (attr := simp)]
 lemma diagPushout_inl_map {i j : ι} (h : i ⟶ j) :

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -71,18 +71,19 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffineHom f] :
     exact isAffine_of_isAffineHom f'
   infer_instance
 
-/-- A morphism `Spec.map f` between affine schemes is pro-affine étale if and only
-if `f` is ind-étale.
+/-- For any `MorphismProperty Scheme` `P` coming from a ring-hom property `Q` via
+`HasRingHomProperty`, a morphism `Spec.map f` between affine schemes lies in
+`pro (P ⊓ isAffine)` if and only if `f` lies in `ind (RingHom.toMorphismProperty Q)`.
 
-TODO: generalise to a `pro_HasRingHomProperty_Spec_iff` for any
-`MorphismProperty Scheme` coming from a `HasRingHomProperty` instance. That
-statement would simultaneously cover analogues such as pro-affine-flat ↔ ind-flat,
-pro-affine-smooth ↔ ind-smooth, etc. The forward direction below could also be
-shortened by going through `AffineScheme.equivCommRingCat` instead of unfolding
-the `Γ ⊣ Spec` adjunction by hand. -/
-lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
-    proAffineEtale (Spec.map f) ↔ f.hom.IndEtale := by
-  rw [RingHom.IndEtale.iff_ind_etale]
+The forward direction reflects a pro-affine cone of `Spec.map f` along the `Γ ⊣ Spec`
+adjunction (an equivalence on affine objects) to a colimit cocone of ring maps; the
+backward direction applies `Scheme.Spec` to such a colimit and packages the result
+as a pro-cone. -/
+lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
+    {Q : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop}
+    [HasRingHomProperty P Q] {R S : CommRingCat.{u}} (f : R ⟶ S) :
+    (MorphismProperty.pro.{u} (P ⊓ ofObjectProperty (IsAffine ·) ⊤)) (Spec.map f) ↔
+      MorphismProperty.ind.{u} (RingHom.toMorphismProperty @Q) f := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
     haveI hAff : ∀ j, IsAffine (D.obj j) := fun j =>
@@ -173,9 +174,9 @@ lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
         rw [show (mkScheme c').π.app i =
             Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, this,
           Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
-    · change (τNat.app j').hom.Etale
-      rw [← HasRingHomProperty.Spec_iff (P := @Etale), hSpec_τ]
-      exact MorphismProperty.comp_mem _ _ _ inferInstance (hts j'.unop).1.1
+    · change Q (τNat.app j').hom
+      rw [← HasRingHomProperty.Spec_iff (P := P), hSpec_τ]
+      exact MorphismProperty.RespectsIso.precomp _ _ _ (hts j'.unop).1.1
     · apply Spec.map_injective
       rw [Spec.map_comp, hSpec_σ, hSpec_τ, Category.assoc, ← Category.assoc _ _ (t.app _),
         Iso.hom_inv_id, Category.id_comp]
@@ -203,8 +204,8 @@ lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
       intro j'
       dsimp [c]
       simp
-    · change Etale (Spec.map (t.app j'.unop))
-      rw [HasRingHomProperty.Spec_iff (P := @Etale)]
+    · change P (Spec.map (t.app j'.unop))
+      rw [HasRingHomProperty.Spec_iff (P := P)]
       exact (hts j'.unop).1
     · change ofObjectProperty (IsAffine ·) ⊤ (Spec.map (t.app j'.unop))
       rw [ofObjectProperty_top_right_iff]
@@ -212,5 +213,12 @@ lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
     · change Spec.map (s.app j'.unop) ≫ Spec.map (t.app j'.unop) = Spec.map f
       rw [← Spec.map_comp]
       exact congrArg Spec.map (hts j'.unop).2
+
+/-- A morphism `Spec.map f` between affine schemes is pro-affine étale if and only
+if `f` is ind-étale. -/
+lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
+    proAffineEtale (Spec.map f) ↔ f.hom.IndEtale := by
+  rw [proAffineEtale, pro_inf_isAffine_Spec_iff (P := @Etale) f, RingHom.IndEtale.iff_ind_etale]
+  rfl
 
 end AlgebraicGeometry

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -71,8 +71,152 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffineHom f] :
     exact isAffine_of_isAffineHom f'
   infer_instance
 
+/-- Backward direction of `proAffineEtale_Spec_iff`: an ind-étale ring map between
+commutative rings gives rise to a pro-affine étale morphism via `Spec`. -/
+lemma proAffineEtale_Spec_of_indEtale {R S : CommRingCat.{u}} {f : R ⟶ S}
+    (h : f.hom.IndEtale) : proAffineEtale (Spec.map f) := by
+  rw [RingHom.IndEtale.iff_ind_etale] at h
+  obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
+  refine ⟨Jᵒᵖ, inferInstance, inferInstance, D.op ⋙ Scheme.Spec,
+    { app j' := Spec.map (t.app j'.unop)
+      naturality := fun j' k' α => by
+        dsimp
+        have := t.naturality α.unop
+        simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
+        rw [Category.comp_id, ← Spec.map_comp, ← this] },
+    { app j' := Spec.map (s.app j'.unop)
+      naturality := fun j' k' α => by
+        dsimp
+        have := s.naturality α.unop
+        simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
+        rw [Category.id_comp, ← Spec.map_comp, this] },
+    ?_, fun j' => ⟨⟨?_, ?_⟩, ?_⟩⟩
+  · let c : Cocone D := Cocone.mk _ s
+    have hcop : IsLimit c.op := IsColimit.op hs
+    have hSpecLimit : IsLimit (Scheme.Spec.mapCone c.op) :=
+      isLimitOfPreserves Scheme.Spec hcop
+    refine IsLimit.ofIsoLimit hSpecLimit (Cone.ext (Iso.refl _) ?_)
+    intro j'
+    dsimp [c]
+    simp
+  · change Etale (Spec.map (t.app j'.unop))
+    rw [HasRingHomProperty.Spec_iff (P := @Etale)]
+    exact (hts j'.unop).1
+  · change ofObjectProperty (IsAffine ·) ⊤ (Spec.map (t.app j'.unop))
+    rw [ofObjectProperty_top_right_iff]
+    exact AlgebraicGeometry.isAffine_Spec _
+  · change Spec.map (s.app j'.unop) ≫ Spec.map (t.app j'.unop) = Spec.map f
+    rw [← Spec.map_comp]
+    exact congrArg Spec.map (hts j'.unop).2
+
+/-- Forward direction of `proAffineEtale_Spec_iff`: a pro-affine étale morphism between
+affine schemes lifts to an ind-étale ring map.
+
+The diagram in `Scheme` is replaced by `D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec` via the
+unit of the `Γ ⊣ Spec` adjunction (iso on affine objects); reflecting the limit along
+`Scheme.Spec` then produces the desired colimit data in `CommRingCat`. -/
+lemma proAffineEtale_Spec_to_indEtale {R S : CommRingCat.{u}} {f : R ⟶ S}
+    (h : proAffineEtale (Spec.map f)) : f.hom.IndEtale := by
+  rw [RingHom.IndEtale.iff_ind_etale]
+  obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
+  haveI hAff : ∀ j, IsAffine (D.obj j) := fun j =>
+    ofObjectProperty_top_right_iff.mp (hts j).1.2
+  let Φ : Jᵒᵖ ⥤ CommRingCat.{u} := D.op ⋙ Scheme.Γ
+  let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' =>
+    Spec.preimage (s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom)
+  let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' =>
+    Spec.preimage ((D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop)
+  have hSpec_σ : ∀ j' : Jᵒᵖ,
+      Spec.map (σ j') = s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom :=
+    fun j' => Spec.map_preimage _
+  have hSpec_τ : ∀ j' : Jᵒᵖ,
+      Spec.map (τ j') = (D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop :=
+    fun j' => Spec.map_preimage _
+  let τNat : (Functor.const Jᵒᵖ).obj R ⟶ Φ :=
+    { app := τ
+      naturality := fun j' k' α => by
+        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+        haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+        dsimp
+        rw [Category.id_comp]
+        apply Spec.map_injective
+        rw [Spec.map_comp, hSpec_τ k', hSpec_τ j']
+        have htn : t.app k'.unop = D.map α.unop ≫ t.app j'.unop := by
+          have := t.naturality α.unop
+          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
+          exact this.symm
+        rw [htn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop)]
+        exact (Scheme.isoSpec_inv_naturality_assoc (D.map α.unop) (t.app j'.unop)).symm }
+  let σNat : Φ ⟶ (Functor.const Jᵒᵖ).obj S :=
+    { app := σ
+      naturality := fun j' k' α => by
+        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+        haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+        dsimp
+        rw [Category.comp_id]
+        apply Spec.map_injective
+        rw [Spec.map_comp, hSpec_σ k', hSpec_σ j']
+        have hsn : s.app j'.unop = s.app k'.unop ≫ D.map α.unop := by
+          have := s.naturality α.unop
+          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
+          exact this
+        rw [hsn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop),
+          Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
+  let legSpec : (c' : Cocone Φ) → (i : J) → (Spec c'.pt ⟶ D.obj i) :=
+    fun c' i => Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
+  let mkScheme : Cocone Φ → Cone D := fun c' =>
+    { pt := Spec c'.pt
+      π :=
+        { app := legSpec c'
+          naturality := fun i i' α => by
+            haveI : IsAffine (D.obj i) := hAff i
+            haveI : IsAffine (D.obj i') := hAff i'
+            dsimp only [legSpec, Functor.const_obj_obj, Functor.const_obj_map]
+            rw [Category.id_comp]
+            have hcnat : Φ.map α.op ≫ c'.ι.app (Opposite.op i) =
+                c'.ι.app (Opposite.op i') := by
+              have := c'.ι.naturality α.op
+              simp only [Functor.const_obj_obj, Functor.const_obj_map,
+                Category.comp_id] at this
+              exact this
+            rw [show Φ.map α.op = (D.map α).appTop from Scheme.Γ_map_op (D.map α)] at hcnat
+            rw [← hcnat, Spec.map_comp, Category.assoc,
+              Scheme.isoSpec_inv_naturality, ← Category.assoc] } }
+  refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' => ⟨?_, ?_⟩⟩
+  · refine
+      { desc := fun c' => Spec.preimage (hs.lift (mkScheme c'))
+        fac := fun c' j' => ?_
+        uniq := fun c' m hm => ?_ }
+    · apply Spec.map_injective
+      haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+      have hliftFac : hs.lift (mkScheme c') ≫ s.app j'.unop =
+          Spec.map (c'.ι.app (Opposite.op j'.unop)) ≫
+            (D.obj j'.unop).isoSpec.inv := hs.fac (mkScheme c') j'.unop
+      rw [Spec.map_comp, Spec.map_preimage, hSpec_σ, ← Category.assoc, hliftFac,
+        Category.assoc, Iso.inv_hom_id, Category.comp_id]
+    · apply Spec.map_injective
+      refine (hs.uniq (mkScheme c') (Spec.map m) ?_).trans
+        (Spec.map_preimage (hs.lift (mkScheme c'))).symm
+      intro i
+      haveI : IsAffine (D.obj i) := hAff i
+      have hmi : σNat.app (Opposite.op i) ≫ m = c'.ι.app (Opposite.op i) :=
+        hm (Opposite.op i)
+      have : Spec.map (c'.ι.app (Opposite.op i)) =
+          Spec.map m ≫ s.app i ≫ (D.obj i).isoSpec.hom := by
+        rw [← hSpec_σ (Opposite.op i), ← Spec.map_comp, hmi]
+      rw [show (mkScheme c').π.app i =
+          Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, this,
+        Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
+  · change (τNat.app j').hom.Etale
+    rw [← HasRingHomProperty.Spec_iff (P := @Etale), hSpec_τ]
+    exact MorphismProperty.comp_mem _ _ _ inferInstance (hts j'.unop).1.1
+  · apply Spec.map_injective
+    rw [Spec.map_comp, hSpec_σ, hSpec_τ, Category.assoc, ← Category.assoc _ _ (t.app _),
+      Iso.hom_inv_id, Category.id_comp]
+    exact (hts j'.unop).2
+
 lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
     proAffineEtale (Spec.map f) ↔ f.hom.IndEtale :=
-  sorry
+  ⟨proAffineEtale_Spec_to_indEtale, proAffineEtale_Spec_of_indEtale⟩
 
 end AlgebraicGeometry

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -71,152 +71,146 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffineHom f] :
     exact isAffine_of_isAffineHom f'
   infer_instance
 
-/-- Backward direction of `proAffineEtale_Spec_iff`: an ind-étale ring map between
-commutative rings gives rise to a pro-affine étale morphism via `Spec`. -/
-lemma proAffineEtale_Spec_of_indEtale {R S : CommRingCat.{u}} {f : R ⟶ S}
-    (h : f.hom.IndEtale) : proAffineEtale (Spec.map f) := by
-  rw [RingHom.IndEtale.iff_ind_etale] at h
-  obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
-  refine ⟨Jᵒᵖ, inferInstance, inferInstance, D.op ⋙ Scheme.Spec,
-    { app j' := Spec.map (t.app j'.unop)
-      naturality := fun j' k' α => by
-        dsimp
-        have := t.naturality α.unop
-        simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
-        rw [Category.comp_id, ← Spec.map_comp, ← this] },
-    { app j' := Spec.map (s.app j'.unop)
-      naturality := fun j' k' α => by
-        dsimp
-        have := s.naturality α.unop
-        simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
-        rw [Category.id_comp, ← Spec.map_comp, this] },
-    ?_, fun j' => ⟨⟨?_, ?_⟩, ?_⟩⟩
-  · let c : Cocone D := Cocone.mk _ s
-    have hcop : IsLimit c.op := IsColimit.op hs
-    have hSpecLimit : IsLimit (Scheme.Spec.mapCone c.op) :=
-      isLimitOfPreserves Scheme.Spec hcop
-    refine IsLimit.ofIsoLimit hSpecLimit (Cone.ext (Iso.refl _) ?_)
-    intro j'
-    dsimp [c]
-    simp
-  · change Etale (Spec.map (t.app j'.unop))
-    rw [HasRingHomProperty.Spec_iff (P := @Etale)]
-    exact (hts j'.unop).1
-  · change ofObjectProperty (IsAffine ·) ⊤ (Spec.map (t.app j'.unop))
-    rw [ofObjectProperty_top_right_iff]
-    exact AlgebraicGeometry.isAffine_Spec _
-  · change Spec.map (s.app j'.unop) ≫ Spec.map (t.app j'.unop) = Spec.map f
-    rw [← Spec.map_comp]
-    exact congrArg Spec.map (hts j'.unop).2
+/-- A morphism `Spec.map f` between affine schemes is pro-affine étale if and only
+if `f` is ind-étale.
 
-/-- Forward direction of `proAffineEtale_Spec_iff`: a pro-affine étale morphism between
-affine schemes lifts to an ind-étale ring map.
-
-The diagram in `Scheme` is replaced by `D ⋙ Scheme.Γ.rightOp ⋙ Scheme.Spec` via the
-unit of the `Γ ⊣ Spec` adjunction (iso on affine objects); reflecting the limit along
-`Scheme.Spec` then produces the desired colimit data in `CommRingCat`. -/
-lemma proAffineEtale_Spec_to_indEtale {R S : CommRingCat.{u}} {f : R ⟶ S}
-    (h : proAffineEtale (Spec.map f)) : f.hom.IndEtale := by
-  rw [RingHom.IndEtale.iff_ind_etale]
-  obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
-  haveI hAff : ∀ j, IsAffine (D.obj j) := fun j =>
-    ofObjectProperty_top_right_iff.mp (hts j).1.2
-  let Φ : Jᵒᵖ ⥤ CommRingCat.{u} := D.op ⋙ Scheme.Γ
-  let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' =>
-    Spec.preimage (s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom)
-  let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' =>
-    Spec.preimage ((D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop)
-  have hSpec_σ : ∀ j' : Jᵒᵖ,
-      Spec.map (σ j') = s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom :=
-    fun j' => Spec.map_preimage _
-  have hSpec_τ : ∀ j' : Jᵒᵖ,
-      Spec.map (τ j') = (D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop :=
-    fun j' => Spec.map_preimage _
-  let τNat : (Functor.const Jᵒᵖ).obj R ⟶ Φ :=
-    { app := τ
-      naturality := fun j' k' α => by
-        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
-        haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
-        dsimp
-        rw [Category.id_comp]
-        apply Spec.map_injective
-        rw [Spec.map_comp, hSpec_τ k', hSpec_τ j']
-        have htn : t.app k'.unop = D.map α.unop ≫ t.app j'.unop := by
-          have := t.naturality α.unop
-          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
-          exact this.symm
-        rw [htn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop)]
-        exact (Scheme.isoSpec_inv_naturality_assoc (D.map α.unop) (t.app j'.unop)).symm }
-  let σNat : Φ ⟶ (Functor.const Jᵒᵖ).obj S :=
-    { app := σ
-      naturality := fun j' k' α => by
-        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
-        haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
-        dsimp
-        rw [Category.comp_id]
-        apply Spec.map_injective
-        rw [Spec.map_comp, hSpec_σ k', hSpec_σ j']
-        have hsn : s.app j'.unop = s.app k'.unop ≫ D.map α.unop := by
-          have := s.naturality α.unop
-          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
-          exact this
-        rw [hsn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop),
-          Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
-  let legSpec : (c' : Cocone Φ) → (i : J) → (Spec c'.pt ⟶ D.obj i) :=
-    fun c' i => Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
-  let mkScheme : Cocone Φ → Cone D := fun c' =>
-    { pt := Spec c'.pt
-      π :=
-        { app := legSpec c'
-          naturality := fun i i' α => by
-            haveI : IsAffine (D.obj i) := hAff i
-            haveI : IsAffine (D.obj i') := hAff i'
-            dsimp only [legSpec, Functor.const_obj_obj, Functor.const_obj_map]
-            rw [Category.id_comp]
-            have hcnat : Φ.map α.op ≫ c'.ι.app (Opposite.op i) =
-                c'.ι.app (Opposite.op i') := by
-              have := c'.ι.naturality α.op
-              simp only [Functor.const_obj_obj, Functor.const_obj_map,
-                Category.comp_id] at this
-              exact this
-            rw [show Φ.map α.op = (D.map α).appTop from Scheme.Γ_map_op (D.map α)] at hcnat
-            rw [← hcnat, Spec.map_comp, Category.assoc,
-              Scheme.isoSpec_inv_naturality, ← Category.assoc] } }
-  refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' => ⟨?_, ?_⟩⟩
-  · refine
-      { desc := fun c' => Spec.preimage (hs.lift (mkScheme c'))
-        fac := fun c' j' => ?_
-        uniq := fun c' m hm => ?_ }
-    · apply Spec.map_injective
-      haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
-      have hliftFac : hs.lift (mkScheme c') ≫ s.app j'.unop =
-          Spec.map (c'.ι.app (Opposite.op j'.unop)) ≫
-            (D.obj j'.unop).isoSpec.inv := hs.fac (mkScheme c') j'.unop
-      rw [Spec.map_comp, Spec.map_preimage, hSpec_σ, ← Category.assoc, hliftFac,
-        Category.assoc, Iso.inv_hom_id, Category.comp_id]
-    · apply Spec.map_injective
-      refine (hs.uniq (mkScheme c') (Spec.map m) ?_).trans
-        (Spec.map_preimage (hs.lift (mkScheme c'))).symm
-      intro i
-      haveI : IsAffine (D.obj i) := hAff i
-      have hmi : σNat.app (Opposite.op i) ≫ m = c'.ι.app (Opposite.op i) :=
-        hm (Opposite.op i)
-      have : Spec.map (c'.ι.app (Opposite.op i)) =
-          Spec.map m ≫ s.app i ≫ (D.obj i).isoSpec.hom := by
-        rw [← hSpec_σ (Opposite.op i), ← Spec.map_comp, hmi]
-      rw [show (mkScheme c').π.app i =
-          Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, this,
-        Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
-  · change (τNat.app j').hom.Etale
-    rw [← HasRingHomProperty.Spec_iff (P := @Etale), hSpec_τ]
-    exact MorphismProperty.comp_mem _ _ _ inferInstance (hts j'.unop).1.1
-  · apply Spec.map_injective
-    rw [Spec.map_comp, hSpec_σ, hSpec_τ, Category.assoc, ← Category.assoc _ _ (t.app _),
-      Iso.hom_inv_id, Category.id_comp]
-    exact (hts j'.unop).2
-
+TODO: generalise to a `pro_HasRingHomProperty_Spec_iff` for any
+`MorphismProperty Scheme` coming from a `HasRingHomProperty` instance. That
+statement would simultaneously cover analogues such as pro-affine-flat ↔ ind-flat,
+pro-affine-smooth ↔ ind-smooth, etc. The forward direction below could also be
+shortened by going through `AffineScheme.equivCommRingCat` instead of unfolding
+the `Γ ⊣ Spec` adjunction by hand. -/
 lemma proAffineEtale_Spec_iff {R S : CommRingCat.{u}} {f : R ⟶ S} :
-    proAffineEtale (Spec.map f) ↔ f.hom.IndEtale :=
-  ⟨proAffineEtale_Spec_to_indEtale, proAffineEtale_Spec_of_indEtale⟩
+    proAffineEtale (Spec.map f) ↔ f.hom.IndEtale := by
+  rw [RingHom.IndEtale.iff_ind_etale]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
+    haveI hAff : ∀ j, IsAffine (D.obj j) := fun j =>
+      ofObjectProperty_top_right_iff.mp (hts j).1.2
+    let Φ : Jᵒᵖ ⥤ CommRingCat.{u} := D.op ⋙ Scheme.Γ
+    let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' =>
+      Spec.preimage (s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom)
+    let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' =>
+      Spec.preimage ((D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop)
+    have hSpec_σ : ∀ j' : Jᵒᵖ,
+        Spec.map (σ j') = s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom :=
+      fun j' => Spec.map_preimage _
+    have hSpec_τ : ∀ j' : Jᵒᵖ,
+        Spec.map (τ j') = (D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop :=
+      fun j' => Spec.map_preimage _
+    let τNat : (Functor.const Jᵒᵖ).obj R ⟶ Φ :=
+      { app := τ
+        naturality := fun j' k' α => by
+          haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+          haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+          dsimp
+          rw [Category.id_comp]
+          apply Spec.map_injective
+          rw [Spec.map_comp, hSpec_τ k', hSpec_τ j']
+          have htn : t.app k'.unop = D.map α.unop ≫ t.app j'.unop := by
+            have := t.naturality α.unop
+            simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
+            exact this.symm
+          rw [htn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop)]
+          exact (Scheme.isoSpec_inv_naturality_assoc (D.map α.unop) (t.app j'.unop)).symm }
+    let σNat : Φ ⟶ (Functor.const Jᵒᵖ).obj S :=
+      { app := σ
+        naturality := fun j' k' α => by
+          haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+          haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+          dsimp
+          rw [Category.comp_id]
+          apply Spec.map_injective
+          rw [Spec.map_comp, hSpec_σ k', hSpec_σ j']
+          have hsn : s.app j'.unop = s.app k'.unop ≫ D.map α.unop := by
+            have := s.naturality α.unop
+            simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
+            exact this
+          rw [hsn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop),
+            Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
+    let legSpec : (c' : Cocone Φ) → (i : J) → (Spec c'.pt ⟶ D.obj i) :=
+      fun c' i => Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
+    let mkScheme : Cocone Φ → Cone D := fun c' =>
+      { pt := Spec c'.pt
+        π :=
+          { app := legSpec c'
+            naturality := fun i i' α => by
+              haveI : IsAffine (D.obj i) := hAff i
+              haveI : IsAffine (D.obj i') := hAff i'
+              dsimp only [legSpec, Functor.const_obj_obj, Functor.const_obj_map]
+              rw [Category.id_comp]
+              have hcnat : Φ.map α.op ≫ c'.ι.app (Opposite.op i) =
+                  c'.ι.app (Opposite.op i') := by
+                have := c'.ι.naturality α.op
+                simp only [Functor.const_obj_obj, Functor.const_obj_map,
+                  Category.comp_id] at this
+                exact this
+              rw [show Φ.map α.op = (D.map α).appTop from Scheme.Γ_map_op (D.map α)] at hcnat
+              rw [← hcnat, Spec.map_comp, Category.assoc,
+                Scheme.isoSpec_inv_naturality, ← Category.assoc] } }
+    refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' => ⟨?_, ?_⟩⟩
+    · refine
+        { desc := fun c' => Spec.preimage (hs.lift (mkScheme c'))
+          fac := fun c' j' => ?_
+          uniq := fun c' m hm => ?_ }
+      · apply Spec.map_injective
+        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+        have hliftFac : hs.lift (mkScheme c') ≫ s.app j'.unop =
+            Spec.map (c'.ι.app (Opposite.op j'.unop)) ≫
+              (D.obj j'.unop).isoSpec.inv := hs.fac (mkScheme c') j'.unop
+        rw [Spec.map_comp, Spec.map_preimage, hSpec_σ, ← Category.assoc, hliftFac,
+          Category.assoc, Iso.inv_hom_id, Category.comp_id]
+      · apply Spec.map_injective
+        refine (hs.uniq (mkScheme c') (Spec.map m) ?_).trans
+          (Spec.map_preimage (hs.lift (mkScheme c'))).symm
+        intro i
+        haveI : IsAffine (D.obj i) := hAff i
+        have hmi : σNat.app (Opposite.op i) ≫ m = c'.ι.app (Opposite.op i) :=
+          hm (Opposite.op i)
+        have : Spec.map (c'.ι.app (Opposite.op i)) =
+            Spec.map m ≫ s.app i ≫ (D.obj i).isoSpec.hom := by
+          rw [← hSpec_σ (Opposite.op i), ← Spec.map_comp, hmi]
+        rw [show (mkScheme c').π.app i =
+            Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, this,
+          Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
+    · change (τNat.app j').hom.Etale
+      rw [← HasRingHomProperty.Spec_iff (P := @Etale), hSpec_τ]
+      exact MorphismProperty.comp_mem _ _ _ inferInstance (hts j'.unop).1.1
+    · apply Spec.map_injective
+      rw [Spec.map_comp, hSpec_σ, hSpec_τ, Category.assoc, ← Category.assoc _ _ (t.app _),
+        Iso.hom_inv_id, Category.id_comp]
+      exact (hts j'.unop).2
+  · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
+    refine ⟨Jᵒᵖ, inferInstance, inferInstance, D.op ⋙ Scheme.Spec,
+      { app j' := Spec.map (t.app j'.unop)
+        naturality := fun j' k' α => by
+          dsimp
+          have := t.naturality α.unop
+          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
+          rw [Category.comp_id, ← Spec.map_comp, ← this] },
+      { app j' := Spec.map (s.app j'.unop)
+        naturality := fun j' k' α => by
+          dsimp
+          have := s.naturality α.unop
+          simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
+          rw [Category.id_comp, ← Spec.map_comp, this] },
+      ?_, fun j' => ⟨⟨?_, ?_⟩, ?_⟩⟩
+    · let c : Cocone D := Cocone.mk _ s
+      have hcop : IsLimit c.op := IsColimit.op hs
+      have hSpecLimit : IsLimit (Scheme.Spec.mapCone c.op) :=
+        isLimitOfPreserves Scheme.Spec hcop
+      refine IsLimit.ofIsoLimit hSpecLimit (Cone.ext (Iso.refl _) ?_)
+      intro j'
+      dsimp [c]
+      simp
+    · change Etale (Spec.map (t.app j'.unop))
+      rw [HasRingHomProperty.Spec_iff (P := @Etale)]
+      exact (hts j'.unop).1
+    · change ofObjectProperty (IsAffine ·) ⊤ (Spec.map (t.app j'.unop))
+      rw [ofObjectProperty_top_right_iff]
+      exact AlgebraicGeometry.isAffine_Spec _
+    · change Spec.map (s.app j'.unop) ≫ Spec.map (t.app j'.unop) = Spec.map f
+      rw [← Spec.map_comp]
+      exact congrArg Spec.map (hts j'.unop).2
 
 end AlgebraicGeometry

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -84,24 +84,24 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
     [HasRingHomProperty P Q] {R S : CommRingCat.{u}} (f : R ⟶ S) :
     (MorphismProperty.pro.{u} (P ⊓ ofObjectProperty (IsAffine ·) ⊤)) (Spec.map f) ↔
       MorphismProperty.ind.{u} (RingHom.toMorphismProperty @Q) f := by
-  refine ⟨fun h => ?_, fun h => ?_⟩
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
-    haveI hAff : ∀ j, IsAffine (D.obj j) := fun j =>
+    haveI hAff : ∀ j, IsAffine (D.obj j) := fun j ↦
       ofObjectProperty_top_right_iff.mp (hts j).1.2
     let Φ : Jᵒᵖ ⥤ CommRingCat.{u} := D.op ⋙ Scheme.Γ
-    let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' =>
+    let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' ↦
       Spec.preimage (s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom)
-    let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' =>
+    let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' ↦
       Spec.preimage ((D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop)
     have hSpec_σ : ∀ j' : Jᵒᵖ,
         Spec.map (σ j') = s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom :=
-      fun j' => Spec.map_preimage _
+      fun j' ↦ Spec.map_preimage _
     have hSpec_τ : ∀ j' : Jᵒᵖ,
         Spec.map (τ j') = (D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop :=
-      fun j' => Spec.map_preimage _
+      fun j' ↦ Spec.map_preimage _
     let τNat : (Functor.const Jᵒᵖ).obj R ⟶ Φ :=
       { app := τ
-        naturality := fun j' k' α => by
+        naturality := fun j' k' α ↦ by
           haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
           haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
           dsimp
@@ -116,7 +116,7 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
           exact (Scheme.isoSpec_inv_naturality_assoc (D.map α.unop) (t.app j'.unop)).symm }
     let σNat : Φ ⟶ (Functor.const Jᵒᵖ).obj S :=
       { app := σ
-        naturality := fun j' k' α => by
+        naturality := fun j' k' α ↦ by
           haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
           haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
           dsimp
@@ -130,12 +130,12 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
           rw [hsn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop),
             Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
     let legSpec : (c' : Cocone Φ) → (i : J) → (Spec c'.pt ⟶ D.obj i) :=
-      fun c' i => Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
-    let mkScheme : Cocone Φ → Cone D := fun c' =>
+      fun c' i ↦ Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
+    let mkScheme : Cocone Φ → Cone D := fun c' ↦
       { pt := Spec c'.pt
         π :=
           { app := legSpec c'
-            naturality := fun i i' α => by
+            naturality := fun i i' α ↦ by
               haveI : IsAffine (D.obj i) := hAff i
               haveI : IsAffine (D.obj i') := hAff i'
               dsimp only [legSpec, Functor.const_obj_obj, Functor.const_obj_map]
@@ -149,11 +149,11 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
               rw [show Φ.map α.op = (D.map α).appTop from Scheme.Γ_map_op (D.map α)] at hcnat
               rw [← hcnat, Spec.map_comp, Category.assoc,
                 Scheme.isoSpec_inv_naturality, ← Category.assoc] } }
-    refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' => ⟨?_, ?_⟩⟩
+    refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' ↦ ⟨?_, ?_⟩⟩
     · refine
-        { desc := fun c' => Spec.preimage (hs.lift (mkScheme c'))
-          fac := fun c' j' => ?_
-          uniq := fun c' m hm => ?_ }
+        { desc := fun c' ↦ Spec.preimage (hs.lift (mkScheme c'))
+          fac := fun c' j' ↦ ?_
+          uniq := fun c' m hm ↦ ?_ }
       · apply Spec.map_injective
         haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
         have hliftFac : hs.lift (mkScheme c') ≫ s.app j'.unop =
@@ -168,11 +168,11 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
         haveI : IsAffine (D.obj i) := hAff i
         have hmi : σNat.app (Opposite.op i) ≫ m = c'.ι.app (Opposite.op i) :=
           hm (Opposite.op i)
-        have : Spec.map (c'.ι.app (Opposite.op i)) =
+        have hcπ : Spec.map (c'.ι.app (Opposite.op i)) =
             Spec.map m ≫ s.app i ≫ (D.obj i).isoSpec.hom := by
           rw [← hSpec_σ (Opposite.op i), ← Spec.map_comp, hmi]
         rw [show (mkScheme c').π.app i =
-            Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, this,
+            Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, hcπ,
           Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
     · change Q (τNat.app j').hom
       rw [← HasRingHomProperty.Spec_iff (P := P), hSpec_τ]
@@ -184,22 +184,21 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
   · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
     refine ⟨Jᵒᵖ, inferInstance, inferInstance, D.op ⋙ Scheme.Spec,
       { app j' := Spec.map (t.app j'.unop)
-        naturality := fun j' k' α => by
+        naturality := fun j' k' α ↦ by
           dsimp
           have := t.naturality α.unop
           simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
           rw [Category.comp_id, ← Spec.map_comp, ← this] },
       { app j' := Spec.map (s.app j'.unop)
-        naturality := fun j' k' α => by
+        naturality := fun j' k' α ↦ by
           dsimp
           have := s.naturality α.unop
           simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
           rw [Category.id_comp, ← Spec.map_comp, this] },
-      ?_, fun j' => ⟨⟨?_, ?_⟩, ?_⟩⟩
+      ?_, fun j' ↦ ⟨⟨?_, ?_⟩, ?_⟩⟩
     · let c : Cocone D := Cocone.mk _ s
-      have hcop : IsLimit c.op := IsColimit.op hs
       have hSpecLimit : IsLimit (Scheme.Spec.mapCone c.op) :=
-        isLimitOfPreserves Scheme.Spec hcop
+        isLimitOfPreserves Scheme.Spec hs.op
       refine IsLimit.ofIsoLimit hSpecLimit (Cone.ext (Iso.refl _) ?_)
       intro j'
       dsimp [c]

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -86,24 +86,24 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
       MorphismProperty.ind.{u} (RingHom.toMorphismProperty @Q) f := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨J, _, _, D, t, s, hs, hts⟩ := h
-    haveI hAff : ∀ j, IsAffine (D.obj j) := fun j ↦
+    have hAff (j : J) : IsAffine (D.obj j) :=
       ofObjectProperty_top_right_iff.mp (hts j).1.2
     let Φ : Jᵒᵖ ⥤ CommRingCat.{u} := D.op ⋙ Scheme.Γ
-    let σ : ∀ j' : Jᵒᵖ, Φ.obj j' ⟶ S := fun j' ↦
+    let σ (j' : Jᵒᵖ) : Φ.obj j' ⟶ S :=
       Spec.preimage (s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom)
-    let τ : ∀ j' : Jᵒᵖ, R ⟶ Φ.obj j' := fun j' ↦
+    let τ (j' : Jᵒᵖ) : R ⟶ Φ.obj j' :=
       Spec.preimage ((D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop)
-    have hSpec_σ : ∀ j' : Jᵒᵖ,
+    have hSpec_σ (j' : Jᵒᵖ) :
         Spec.map (σ j') = s.app j'.unop ≫ (D.obj j'.unop).isoSpec.hom :=
-      fun j' ↦ Spec.map_preimage _
-    have hSpec_τ : ∀ j' : Jᵒᵖ,
+      Spec.map_preimage _
+    have hSpec_τ (j' : Jᵒᵖ) :
         Spec.map (τ j') = (D.obj j'.unop).isoSpec.inv ≫ t.app j'.unop :=
-      fun j' ↦ Spec.map_preimage _
+      Spec.map_preimage _
     let τNat : (Functor.const Jᵒᵖ).obj R ⟶ Φ :=
       { app := τ
         naturality := fun j' k' α ↦ by
-          haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
-          haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+          have : IsAffine (D.obj j'.unop) := hAff j'.unop
+          have : IsAffine (D.obj k'.unop) := hAff k'.unop
           dsimp
           rw [Category.id_comp]
           apply Spec.map_injective
@@ -112,13 +112,14 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
             have := t.naturality α.unop
             simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id] at this
             exact this.symm
-          rw [htn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop)]
+          have hΦmap : Φ.map α = (D.map α.unop).appTop := Scheme.Γ_map_op (D.map α.unop)
+          rw [htn, hΦmap]
           exact (Scheme.isoSpec_inv_naturality_assoc (D.map α.unop) (t.app j'.unop)).symm }
     let σNat : Φ ⟶ (Functor.const Jᵒᵖ).obj S :=
       { app := σ
         naturality := fun j' k' α ↦ by
-          haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
-          haveI : IsAffine (D.obj k'.unop) := hAff k'.unop
+          have : IsAffine (D.obj j'.unop) := hAff j'.unop
+          have : IsAffine (D.obj k'.unop) := hAff k'.unop
           dsimp
           rw [Category.comp_id]
           apply Spec.map_injective
@@ -127,17 +128,17 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
             have := s.naturality α.unop
             simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp] at this
             exact this
-          rw [hsn, show Φ.map α = (D.map α.unop).appTop from Scheme.Γ_map_op (D.map α.unop),
-            Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
-    let legSpec : (c' : Cocone Φ) → (i : J) → (Spec c'.pt ⟶ D.obj i) :=
-      fun c' i ↦ Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
-    let mkScheme : Cocone Φ → Cone D := fun c' ↦
+          have hΦmap : Φ.map α = (D.map α.unop).appTop := Scheme.Γ_map_op (D.map α.unop)
+          rw [hsn, hΦmap, Category.assoc, Scheme.isoSpec_hom_naturality, ← Category.assoc] }
+    let legSpec (c' : Cocone Φ) (i : J) : Spec c'.pt ⟶ D.obj i :=
+      Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv
+    let mkScheme (c' : Cocone Φ) : Cone D :=
       { pt := Spec c'.pt
         π :=
           { app := legSpec c'
             naturality := fun i i' α ↦ by
-              haveI : IsAffine (D.obj i) := hAff i
-              haveI : IsAffine (D.obj i') := hAff i'
+              have : IsAffine (D.obj i) := hAff i
+              have : IsAffine (D.obj i') := hAff i'
               dsimp only [legSpec, Functor.const_obj_obj, Functor.const_obj_map]
               rw [Category.id_comp]
               have hcnat : Φ.map α.op ≫ c'.ι.app (Opposite.op i) =
@@ -146,7 +147,8 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
                 simp only [Functor.const_obj_obj, Functor.const_obj_map,
                   Category.comp_id] at this
                 exact this
-              rw [show Φ.map α.op = (D.map α).appTop from Scheme.Γ_map_op (D.map α)] at hcnat
+              have hΦmap : Φ.map α.op = (D.map α).appTop := Scheme.Γ_map_op (D.map α)
+              rw [hΦmap] at hcnat
               rw [← hcnat, Spec.map_comp, Category.assoc,
                 Scheme.isoSpec_inv_naturality, ← Category.assoc] } }
     refine ⟨Jᵒᵖ, inferInstance, inferInstance, Φ, τNat, σNat, ?_, fun j' ↦ ⟨?_, ?_⟩⟩
@@ -155,7 +157,7 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
           fac := fun c' j' ↦ ?_
           uniq := fun c' m hm ↦ ?_ }
       · apply Spec.map_injective
-        haveI : IsAffine (D.obj j'.unop) := hAff j'.unop
+        have : IsAffine (D.obj j'.unop) := hAff j'.unop
         have hliftFac : hs.lift (mkScheme c') ≫ s.app j'.unop =
             Spec.map (c'.ι.app (Opposite.op j'.unop)) ≫
               (D.obj j'.unop).isoSpec.inv := hs.fac (mkScheme c') j'.unop
@@ -165,18 +167,18 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
         refine (hs.uniq (mkScheme c') (Spec.map m) ?_).trans
           (Spec.map_preimage (hs.lift (mkScheme c'))).symm
         intro i
-        haveI : IsAffine (D.obj i) := hAff i
+        have : IsAffine (D.obj i) := hAff i
         have hmi : σNat.app (Opposite.op i) ≫ m = c'.ι.app (Opposite.op i) :=
           hm (Opposite.op i)
         have hcπ : Spec.map (c'.ι.app (Opposite.op i)) =
             Spec.map m ≫ s.app i ≫ (D.obj i).isoSpec.hom := by
           rw [← hSpec_σ (Opposite.op i), ← Spec.map_comp, hmi]
-        rw [show (mkScheme c').π.app i =
-            Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv from rfl, hcπ,
-          Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
-    · change Q (τNat.app j').hom
-      rw [← HasRingHomProperty.Spec_iff (P := P), hSpec_τ]
-      exact MorphismProperty.RespectsIso.precomp _ _ _ (hts j'.unop).1.1
+        have hmkπ : (mkScheme c').π.app i =
+            Spec.map (c'.ι.app (Opposite.op i)) ≫ (D.obj i).isoSpec.inv := rfl
+        rw [hmkπ, hcπ, Category.assoc, Category.assoc, Iso.hom_inv_id, Category.comp_id]
+    · exact (HasRingHomProperty.Spec_iff (P := P)).mp <| by
+        rw [hSpec_τ]
+        exact MorphismProperty.RespectsIso.precomp _ _ _ (hts j'.unop).1.1
     · apply Spec.map_injective
       rw [Spec.map_comp, hSpec_σ, hSpec_τ, Category.assoc, ← Category.assoc _ _ (t.app _),
         Iso.hom_inv_id, Category.id_comp]
@@ -203,14 +205,9 @@ lemma pro_inf_isAffine_Spec_iff (P : MorphismProperty Scheme.{u})
       intro j'
       dsimp [c]
       simp
-    · change P (Spec.map (t.app j'.unop))
-      rw [HasRingHomProperty.Spec_iff (P := P)]
-      exact (hts j'.unop).1
-    · change ofObjectProperty (IsAffine ·) ⊤ (Spec.map (t.app j'.unop))
-      rw [ofObjectProperty_top_right_iff]
-      exact AlgebraicGeometry.isAffine_Spec _
-    · change Spec.map (s.app j'.unop) ≫ Spec.map (t.app j'.unop) = Spec.map f
-      rw [← Spec.map_comp]
+    · exact (HasRingHomProperty.Spec_iff (P := P)).mpr (hts j'.unop).1
+    · exact ofObjectProperty_top_right_iff.mpr (AlgebraicGeometry.isAffine_Spec _)
+    · rw [← Spec.map_comp]
       exact congrArg Spec.map (hts j'.unop).2
 
 /-- A morphism `Spec.map f` between affine schemes is pro-affine étale if and only


### PR DESCRIPTION
## Summary

Fills the `proAffineEtale_Spec_iff` sorry in `Proetale/Morphisms/ProAffineEtale.lean`:
for a ring homomorphism `f : R ⟶ S` in `CommRingCat`, the scheme morphism
`Spec.map f` is pro-affine étale iff `f` is ind-étale.

The proof is split into two helpers:

- `proAffineEtale_Spec_of_indEtale` (backward direction): given an ind-étale ring
  map `f = colim_J (tⱼ ≫ sⱼ)`, apply `Scheme.Spec` to the colimit-presentation to
  obtain a cofiltered limit of affine étale `Spec` maps, then package it as a
  `MorphismProperty.pro` witness.
- `proAffineEtale_Spec_to_indEtale` (forward direction): given a pro-affine étale
  cone `(D, t, s)` of `Spec.map f`, transport `D` along `Scheme.Γ` to a diagram
  `Φ = D.op ⋙ Scheme.Γ` in `CommRingCat`, lift `t`, `s` through the `Γ ⊣ Spec`
  adjunction (which is iso on affine objects, via `Scheme.isoSpec`), and verify
  the colimit by transporting cones back through `Spec` and using
  `Spec.map_injective` / `Spec.map_preimage`.

Combining them gives the `iff`. The other three sorries in this file
(`proAffineEtale_le_weaklyEtale`, `HasOfPostcompProperty`, `PreProSpreads`) are
left untouched and remain as the next chunks to upstream.

Source: ported from the `archon` branch.

## Test plan

- [x] `lake build` succeeds on the full project (8600 jobs).
- [x] `lake build --wfail Proetale.Morphisms.ProAffineEtale` succeeds (no lint warnings).
- [x] `lake exe mk_all --git --check` reports no update necessary.
- [x] No new `sorry` introduced; only the `proAffineEtale_Spec_iff` sorry is closed.
