### PR TITLE
feat: formalise statements towards `thm:weakly-etale-over-sh`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -70,6 +70,7 @@ import Proetale.Mathlib.CategoryTheory.Sites.InducedTopology
 import Proetale.Mathlib.CategoryTheory.Sites.IsSheafFor
 import Proetale.Mathlib.CategoryTheory.Sites.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.Sites.Precoverage
+import Proetale.Mathlib.CategoryTheory.Sites.PrecoverageGenerating
 import Proetale.Mathlib.CategoryTheory.Sites.Sieves
 import Proetale.Mathlib.FieldTheory.IsSepClosed
 import Proetale.Mathlib.Order.BooleanAlgebra.Set

--- a/Proetale.lean
+++ b/Proetale.lean
@@ -10,6 +10,7 @@ import Proetale.Algebra.IndBijectiveOnStalks
 import Proetale.Algebra.IndEtale
 import Proetale.Algebra.IndWeaklyEtale
 import Proetale.Algebra.IndZariski
+import Proetale.Algebra.IntegralLocal
 import Proetale.Algebra.LocalIso
 import Proetale.Algebra.Preliminaries.Ideal
 import Proetale.Algebra.ProEtaleContraction

--- a/Proetale/Algebra/Bijective.lean
+++ b/Proetale/Algebra/Bijective.lean
@@ -50,4 +50,17 @@ lemma bijective_of_bijective_residueFieldMap [IsLocalRing R] [IsLocalRing S]
     Function.Bijective (algebraMap R S) :=
   sorry
 
+/-- Let `R → S` be a weakly étale local homomorphism of local rings.  If for every prime
+`p ⊂ R` there is a unique prime `q ⊂ S` lying over `p` and `κ(p) = κ(q)`, then `R → S` is
+an isomorphism. -/
+lemma WeaklyEtale.bijective_of_unique_primes_of_bijective_residueFieldMap
+    [IsLocalRing R] [IsLocalRing S] [IsLocalHom (algebraMap R S)] [Algebra.WeaklyEtale R S]
+    (h : Function.Bijective (PrimeSpectrum.comap <| algebraMap R S))
+    (hres : ∀ (p : Ideal R) [p.IsPrime] (q : Ideal S) [q.IsPrime] [q.LiesOver p],
+      Function.Bijective
+        (IsLocalRing.ResidueField.map (Localization.localRingHom p q (algebraMap R S)
+          ‹q.LiesOver p›.over))) :
+    Function.Bijective (algebraMap R S) :=
+  sorry
+
 end Algebra

--- a/Proetale/Algebra/Bijective.lean
+++ b/Proetale/Algebra/Bijective.lean
@@ -53,7 +53,7 @@ lemma bijective_of_bijective_residueFieldMap [IsLocalRing R] [IsLocalRing S]
 /-- Let `R → S` be a weakly étale local homomorphism of local rings.  If for every prime
 `p ⊂ R` there is a unique prime `q ⊂ S` lying over `p` and `κ(p) = κ(q)`, then `R → S` is
 an isomorphism. -/
-lemma WeaklyEtale.bijective_of_unique_primes_of_bijective_residueFieldMap
+lemma WeaklyEtale.bijective_algebraMap_of_bijective_residueFieldMap
     [IsLocalRing R] [IsLocalRing S] [IsLocalHom (algebraMap R S)] [Algebra.WeaklyEtale R S]
     (h : Function.Bijective (PrimeSpectrum.comap <| algebraMap R S))
     (hres : ∀ (p : Ideal R) [p.IsPrime] (q : Ideal S) [q.IsPrime] [q.LiesOver p],

--- a/Proetale/Algebra/HenselianLocalRing.lean
+++ b/Proetale/Algebra/HenselianLocalRing.lean
@@ -1,4 +1,5 @@
 import Proetale.Algebra.WeaklyEtale
+import Proetale.Mathlib.RingTheory.Henselian
 
 universe u
 
@@ -27,5 +28,12 @@ lemma WeaklyEtale.bijective_of_henselianLocalRing [HenselianLocalRing R]
     [IsSepClosed (IsLocalRing.ResidueField R)] [Algebra.WeaklyEtale R S] :
     Function.Bijective (algebraMap R S) :=
   sorry
+
+/-- If `R → S` is a local homomorphism of local rings, `R` is strictly henselian and `S` is
+weakly étale over `R`, then `R → S` is an isomorphism. -/
+lemma WeaklyEtale.bijective_of_isStrictlyHenselianLocalRing [IsStrictlyHenselianLocalRing R]
+    [Algebra.WeaklyEtale R S] :
+    Function.Bijective (algebraMap R S) :=
+  WeaklyEtale.bijective_of_henselianLocalRing
 
 end Algebra

--- a/Proetale/Algebra/IndEtale.lean
+++ b/Proetale/Algebra/IndEtale.lean
@@ -17,7 +17,7 @@ In this file we define ind-étale algebras and ring homomorphisms.
 
 universe u
 
-open CategoryTheory Limits
+open CategoryTheory Limits TensorProduct
 
 variable (R : Type u) {S : Type u} [CommRing R] [CommRing S] [Algebra R S]
 
@@ -83,6 +83,24 @@ instance isSeparable_residueField [Algebra.IndEtale R S] (p : Ideal R) (q : Idea
     [Algebra (Localization.AtPrime p) (Localization.AtPrime q)]
     [Localization.AtPrime.IsLiesOverAlgebra p q] :
     Algebra.IsSeparable p.ResidueField q.ResidueField :=
+  sorry
+
+/-- If `B` is an ind-étale algebra over a field `K` and `B` has at least two distinct prime
+ideals, then `B` has a nontrivial idempotent element. -/
+theorem exists_isIdempotentElem_of_two_primes {K B : Type u} [Field K] [CommRing B]
+    [Algebra K B] [Algebra.IndEtale K B] {q₁ q₂ : Ideal B} [q₁.IsPrime] [q₂.IsPrime]
+    (h : q₁ ≠ q₂) :
+    ∃ e : B, IsIdempotentElem e ∧ e ≠ 0 ∧ e ≠ 1 :=
+  sorry
+
+/-- If `B` is an ind-étale algebra over a field `K` and `q` is a prime ideal of `B` whose
+residue field is strictly larger than `K`, then the tensor product
+`κ(q) ⊗[K] B` has a nontrivial idempotent element. -/
+theorem exists_isIdempotentElem_tensorProduct_of_residueField_ne {K B : Type u}
+    [Field K] [CommRing B] [Algebra K B] [Algebra.IndEtale K B]
+    (q : Ideal B) [q.IsPrime]
+    (h : ¬ Function.Bijective (algebraMap K q.ResidueField)) :
+    ∃ e : q.ResidueField ⊗[K] B, IsIdempotentElem e ∧ e ≠ 0 ∧ e ≠ 1 :=
   sorry
 
 end Algebra.IndEtale

--- a/Proetale/Algebra/IntegralLocal.lean
+++ b/Proetale/Algebra/IntegralLocal.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+import Proetale.Mathlib.RingTheory.Henselian
+
+/-!
+# Local rings and integral algebras
+
+This file collects miscellaneous lemmas relating local rings, integral ring
+homomorphisms, and Henselian local rings.  These are used in the proof of
+[Stacks 097Z](https://stacks.math.columbia.edu/tag/097Z) (over a strictly
+Henselian local ring, a weakly étale local algebra is the ring itself).
+
+## Main statements
+
+* `HenselianLocalRing.exists_pi_of_finite` ([Stacks 04GH (1)]
+  (https://stacks.math.columbia.edu/tag/04GH)):
+  A finite algebra over a Henselian local ring decomposes as a finite product
+  of Henselian local rings, each finite over the base.
+* `IsLocalRing.of_henselianLocalRing_of_isIntegral_of_isDomain`:
+  An integral algebra over a Henselian local ring that is an integral domain is local.
+* `Algebra.IsAlgebraic.residueField_of_isIntegral`:
+  The residue field extension induced by a local integral homomorphism of local rings
+  is algebraic.
+* `Algebra.IsLocalRing.tensorProduct_of_isPurelyInseparable_residueField`
+  ([Stacks 092Y](https://stacks.math.columbia.edu/tag/092Y)):
+  If `R → S` is local and integral and either `κ(S)/κ(R)` or `κ(T)/κ(R)` is purely
+  inseparable, the tensor product `S ⊗[R] T` is a local ring.
+-/
+
+universe u
+
+open TensorProduct
+
+namespace HenselianLocalRing
+
+variable (R : Type u) [CommRing R] [HenselianLocalRing R]
+variable (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S]
+
+/-- A finite algebra over a Henselian local ring is, as a ring, a finite product of
+Henselian local rings, each finite over the base.
+
+[Stacks 04GH (1)](https://stacks.math.columbia.edu/tag/04GH). -/
+theorem exists_pi_of_finite :
+    ∃ (ι : Type u) (_ : Fintype ι) (B : ι → Type u) (_ : ∀ i, CommRing (B i))
+      (_ : ∀ i, IsLocalRing (B i)) (_ : ∀ i, HenselianLocalRing (B i))
+      (_ : ∀ i, Algebra R (B i)) (_ : ∀ i, Module.Finite R (B i)),
+        Nonempty (S ≃ₐ[R] (Π i, B i)) :=
+  sorry
+
+end HenselianLocalRing
+
+namespace IsLocalRing
+
+/-- An integral algebra over a Henselian local ring that is an integral domain is local. -/
+theorem of_henselianLocalRing_of_isIntegral_of_isDomain
+    {R S : Type u} [CommRing R] [CommRing S] [HenselianLocalRing R]
+    [Algebra R S] [Algebra.IsIntegral R S] [IsDomain S] :
+    IsLocalRing S :=
+  sorry
+
+end IsLocalRing
+
+namespace Algebra
+
+variable {R S : Type u} [CommRing R] [CommRing S] [Algebra R S]
+  [IsLocalRing R] [IsLocalRing S] [IsLocalHom (algebraMap R S)]
+
+/-- The residue field extension induced by a local integral homomorphism of local rings is
+algebraic. -/
+theorem IsAlgebraic.residueField_of_isIntegral [Algebra.IsIntegral R S] :
+    letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
+      (IsLocalRing.ResidueField.map (algebraMap R S)).toAlgebra
+    Algebra.IsAlgebraic (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
+  sorry
+
+variable (R S) in
+/-- Let `R → S` and `R → T` be local ring homomorphisms of local rings, with `R → S`
+integral.  If `κ(S)/κ(R)` or `κ(T)/κ(R)` is purely inseparable, the tensor product
+`S ⊗[R] T` is a local ring.
+
+[Stacks 092Y](https://stacks.math.columbia.edu/tag/092Y). -/
+theorem isLocalRing_tensorProduct_of_isPurelyInseparable_residueField
+    (T : Type u) [CommRing T] [Algebra R T] [IsLocalRing T] [IsLocalHom (algebraMap R T)]
+    [Algebra.IsIntegral R S]
+    (h :
+      letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
+        (IsLocalRing.ResidueField.map (algebraMap R S)).toAlgebra
+      letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField T) :=
+        (IsLocalRing.ResidueField.map (algebraMap R T)).toAlgebra
+      IsPurelyInseparable (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) ∨
+        IsPurelyInseparable (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField T)) :
+    IsLocalRing (S ⊗[R] T) :=
+  sorry
+
+end Algebra

--- a/Proetale/Algebra/IntegralLocal.lean
+++ b/Proetale/Algebra/IntegralLocal.lean
@@ -43,7 +43,9 @@ variable (S : Type u) [CommRing S] [Algebra R S] [Module.Finite R S]
 /-- A finite algebra over a Henselian local ring is, as a ring, a finite product of
 Henselian local rings, each finite over the base.
 
-[Stacks 04GH (1)](https://stacks.math.columbia.edu/tag/04GH). -/
+[Stacks 04GH (1)](https://stacks.math.columbia.edu/tag/04GH).
+
+This is destined to go directly to Mathlib, so it should not be worked on here. -/
 theorem exists_pi_of_finite :
     ∃ (ι : Type u) (_ : Fintype ι) (B : ι → Type u) (_ : ∀ i, CommRing (B i))
       (_ : ∀ i, IsLocalRing (B i)) (_ : ∀ i, HenselianLocalRing (B i))
@@ -72,8 +74,6 @@ variable {R S : Type u} [CommRing R] [CommRing S] [Algebra R S]
 /-- The residue field extension induced by a local integral homomorphism of local rings is
 algebraic. -/
 theorem IsAlgebraic.residueField_of_isIntegral [Algebra.IsIntegral R S] :
-    letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
-      (IsLocalRing.ResidueField.map (algebraMap R S)).toAlgebra
     Algebra.IsAlgebraic (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
   sorry
 
@@ -86,12 +86,7 @@ integral.  If `κ(S)/κ(R)` or `κ(T)/κ(R)` is purely inseparable, the tensor p
 theorem isLocalRing_tensorProduct_of_isPurelyInseparable_residueField
     (T : Type u) [CommRing T] [Algebra R T] [IsLocalRing T] [IsLocalHom (algebraMap R T)]
     [Algebra.IsIntegral R S]
-    (h :
-      letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) :=
-        (IsLocalRing.ResidueField.map (algebraMap R S)).toAlgebra
-      letI : Algebra (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField T) :=
-        (IsLocalRing.ResidueField.map (algebraMap R T)).toAlgebra
-      IsPurelyInseparable (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) ∨
+    (h : IsPurelyInseparable (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField S) ∨
         IsPurelyInseparable (IsLocalRing.ResidueField R) (IsLocalRing.ResidueField T)) :
     IsLocalRing (S ⊗[R] T) :=
   sorry

--- a/Proetale/Mathlib/RingTheory/Henselian.lean
+++ b/Proetale/Mathlib/RingTheory/Henselian.lean
@@ -11,6 +11,15 @@ instance (R : Type*) [CommRing R] [IsStrictlyHenselianLocalRing R] :
     IsSepClosed (IsLocalRing.ResidueField R) :=
   IsStrictlyHenselianLocalRing.isSepClosed_residueField
 
+/-- A local ring is strictly Henselian if and only if it is Henselian and its residue
+field is separably closed. -/
+theorem isStrictlyHenselianLocalRing_iff_henselianLocalRing_and_isSepClosed
+    (R : Type*) [CommRing R] [IsLocalRing R] :
+    IsStrictlyHenselianLocalRing R ↔
+      HenselianLocalRing R ∧ IsSepClosed (IsLocalRing.ResidueField R) :=
+  ⟨fun _ ↦ ⟨inferInstance, inferInstance⟩,
+    fun h ↦ have := h.1; ⟨h.2⟩⟩
+
 /-- `HenselianLocalRing` transfers along a ring isomorphism. -/
 theorem HenselianLocalRing.of_ringEquiv {R S : Type*} [CommRing R] [CommRing S]
     [HenselianLocalRing R] (e : R ≃+* S) : HenselianLocalRing S := by

--- a/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
+++ b/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
@@ -1,3 +1,4 @@
+import Mathlib.Topology.Category.TopCat.Limits.Basic
 import Mathlib.Topology.Connected.TotallyDisconnected
 import Mathlib.Topology.Homeomorph.Lemmas
 import Mathlib.Topology.Inseparable
@@ -138,3 +139,16 @@ def ConnectedComponents.mkHomeomorph [TotallyDisconnectedSpace S] : S ≃ₜ Con
   right_inv := ConnectedComponents.surjective_coe.forall.2 fun _ => rfl
   continuous_toFun := continuous_coe
   continuous_invFun := continuous_id.connectedComponentsLift_continuous
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+/-- The inverse limit of a system of totally disconnected topological spaces is
+totally disconnected. -/
+instance TopCat.limitCone_pt_totallyDisconnectedSpace
+    {J : Type v} [SmallCategory J] (F : J ⥤ TopCat.{max v u})
+    [∀ j, TotallyDisconnectedSpace (F.obj j)] :
+    TotallyDisconnectedSpace (TopCat.limitCone.{v, u} F).pt := by
+  change TotallyDisconnectedSpace ({ u : ∀ j : J, F.obj j | _ } : Type _)
+  exact Subtype.totallyDisconnectedSpace

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -676,6 +676,8 @@ The following example shows that our definition agrees with the one in
     \label{lem:sh-iff-henselian-and-sep-closed}
     A local ring $(R, \mathfrak{m}, \kappa)$ is strictly Henselian if and only if it is Henselian and $\kappa$ is separably closed.
     \uses{def:strictly-henselian-local-ring}
+    \lean{isStrictlyHenselianLocalRing_iff_henselianLocalRing_and_isSepClosed}
+    \leanok
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -11,6 +11,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     a finite product of Henselian local rings, each finite over $R$.
     \label{lemma:finite-over-henselian-local}
     \lean{HenselianLocalRing.exists_pi_of_finite}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -707,7 +708,7 @@ suffices for our purposes.
     Let $A \to B$ be a weakly étale local homomorphism of local rings. For all $\mathfrak{p} \subset A$,
     there is a unique prime $\mathfrak{q} \subset B$ lying over $\mathfrak{p}$ and
     $\kappa(\mathfrak{p}) = \kappa(\mathfrak{q})$. Then $A \to B$ is an isomorphism.
-    \lean{Algebra.WeaklyEtale.bijective_of_unique_primes_of_bijective_residueFieldMap}
+    \lean{Algebra.WeaklyEtale.bijective_algebraMap_of_bijective_residueFieldMap}
 \end{lemma}
 
 \begin{proof}
@@ -734,6 +735,7 @@ suffices for our purposes.
 \end{lemma}
 
 \begin{proof}
+    \leanok
     Suppose $x, y$ are two distinct points that lives in the same connected component. Then the
     projection of $x, y$ will be always fall in the same connected components, thus equal. This
     is a contradiction.

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -49,6 +49,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     Then $S$ is a local ring.
     \label{lemma:henselian-local-integral-local}
     \lean{IsLocalRing.of_henselianLocalRing_of_isIntegral_of_isDomain}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -74,6 +75,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     the extension of residue fields $\kappa(S) / \kappa(R)$ is algebraic.
     \label{lemma:integral-local-algebraic-residue-field}
     \lean{Algebra.IsAlgebraic.residueField_of_isIntegral}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -88,6 +90,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     is purely inseparable, then $T \otimes_{R} S$ is a local ring.
     \label{lemma:tensorprod-local-purely-inseparable}
     \lean{Algebra.isLocalRing_tensorProduct_of_isPurelyInseparable_residueField}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -709,6 +712,7 @@ suffices for our purposes.
     there is a unique prime $\mathfrak{q} \subset B$ lying over $\mathfrak{p}$ and
     $\kappa(\mathfrak{p}) = \kappa(\mathfrak{q})$. Then $A \to B$ is an isomorphism.
     \lean{Algebra.WeaklyEtale.bijective_algebraMap_of_bijective_residueFieldMap}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -748,6 +752,7 @@ suffices for our purposes.
     two different prime ideals $q_1$ and $q_2$ in $B$, then $B$ has a nontrivial
     idempotent element $e$ (i.i. $e^2 = e$).
     \lean{Algebra.IndEtale.exists_isIdempotentElem_of_two_primes}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -767,6 +772,7 @@ suffices for our purposes.
     $\kappa(q) \otimes_A B$ has a nontrivial idempotent element.
     \uses{def:ind-etale}
     \lean{Algebra.IndEtale.exists_isIdempotentElem_tensorProduct_of_residueField_ne}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -845,6 +851,7 @@ suffices for our purposes.
     \uses{def:weakly-etale-algebra,
     def:strictly-henselian-local-ring}
     \lean{Algebra.WeaklyEtale.bijective_of_isStrictlyHenselianLocalRing}
+    \leanok
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -10,6 +10,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     Let $R$ be a Henselian local ring and $S$ a finite $R$-algebra. Then $S$ is
     a finite product of Henselian local rings, each finite over $R$.
     \label{lemma:finite-over-henselian-local}
+    \lean{HenselianLocalRing.exists_pi_of_finite}
 \end{lemma}
 
 \begin{proof}
@@ -46,6 +47,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     Let $R$ be a Henselian local ring and $S$ be an integral $R$-algebra and an integral domain.
     Then $S$ is a local ring.
     \label{lemma:henselian-local-integral-local}
+    \lean{IsLocalRing.of_henselianLocalRing_of_isIntegral_of_isDomain}
 \end{lemma}
 
 \begin{proof}
@@ -70,6 +72,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     Let $R \to S$ be a local ring homomorphism of local rings. If $R \to S$ is integral,
     the extension of residue fields $\kappa(S) / \kappa(R)$ is algebraic.
     \label{lemma:integral-local-algebraic-residue-field}
+    \lean{Algebra.IsAlgebraic.residueField_of_isIntegral}
 \end{lemma}
 
 \begin{proof}
@@ -83,6 +86,7 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
     $R \to S$ is integral and $\kappa(S) / \kappa(R)$ or $\kappa(T) / \kappa(S)$
     is purely inseparable, then $T \otimes_{R} S$ is a local ring.
     \label{lemma:tensorprod-local-purely-inseparable}
+    \lean{Algebra.isLocalRing_tensorProduct_of_isPurelyInseparable_residueField}
 \end{lemma}
 
 \begin{proof}
@@ -700,9 +704,10 @@ suffices for our purposes.
 
 \begin{lemma}
     \label{lem:isom-of-unique-lying-over-and-residue-field-eq}
-    Let $A \to B$ be a local homomorphism of local rings. For all $\mathfrak{p} \subset A$,
+    Let $A \to B$ be a weakly étale local homomorphism of local rings. For all $\mathfrak{p} \subset A$,
     there is a unique prime $\mathfrak{q} \subset B$ lying over $\mathfrak{p}$ and
     $\kappa(\mathfrak{p}) = \kappa(\mathfrak{q})$. Then $A \to B$ is an isomorphism.
+    \lean{Algebra.WeaklyEtale.bijective_of_unique_primes_of_bijective_residueFieldMap}
 \end{lemma}
 
 \begin{proof}
@@ -724,6 +729,8 @@ suffices for our purposes.
     Let $I$ be a directed set. Let $T_i, \, i \in I$ be a series of totally disconnected
     topological spaces. Then
     $$T = \varprojlim_{i \in I} T_i $$ is also totally disconnected.
+    \lean{TopCat.limitCone_pt_totallyDisconnectedSpace}
+    \leanok
 \end{lemma}
 
 \begin{proof}
@@ -738,6 +745,7 @@ suffices for our purposes.
     Let $B$ be a ind-\'etale algebra over some field $K$. If there are
     two different prime ideals $q_1$ and $q_2$ in $B$, then $B$ has a nontrivial
     idempotent element $e$ (i.i. $e^2 = e$).
+    \lean{Algebra.IndEtale.exists_isIdempotentElem_of_two_primes}
 \end{lemma}
 
 \begin{proof}
@@ -754,8 +762,9 @@ suffices for our purposes.
     % It is unclear whether this lemma is in the most general form.
     Let $B$ be a ind-\'etale algebra over some field $K$. If there exists
     a prime ideal $q$ of $B$, such that the residue field of $q$ is not $K$, then
-    $\kappa(q) \otimes_A B$ has a nontrivial element.
+    $\kappa(q) \otimes_A B$ has a nontrivial idempotent element.
     \uses{def:ind-etale}
+    \lean{Algebra.IndEtale.exists_isIdempotentElem_tensorProduct_of_residueField_ne}
 \end{lemma}
 
 \begin{proof}
@@ -833,6 +842,7 @@ suffices for our purposes.
     and $A \to B$ is weakly étale, then $A = B$.
     \uses{def:weakly-etale-algebra,
     def:strictly-henselian-local-ring}
+    \lean{Algebra.WeaklyEtale.bijective_of_isStrictlyHenselianLocalRing}
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
Closes #110.

This PR adds Lean statements (with `sorry` proofs) for the lemmas appearing in the dependency chain of `thm:weakly-etale-over-sh` (Stacks [097Z](https://stacks.math.columbia.edu/tag/097Z)) in the blueprint, and adds the corresponding `\lean` tags so the blueprint connects them to the formalisation.

## New declarations

In `Proetale/Algebra/IntegralLocal.lean` (new file):
- `HenselianLocalRing.exists_pi_of_finite` — a finite algebra over a Henselian local ring decomposes as a finite product of Henselian local rings, each finite over the base ([Stacks 04GH (1)](https://stacks.math.columbia.edu/tag/04GH))
- `IsLocalRing.of_henselianLocalRing_of_isIntegral_of_isDomain` — an integral algebra over a Henselian local ring that is an integral domain is local
- `Algebra.IsAlgebraic.residueField_of_isIntegral` — the residue field extension induced by a local integral homomorphism is algebraic
- `Algebra.isLocalRing_tensorProduct_of_isPurelyInseparable_residueField` — Stacks [092Y](https://stacks.math.columbia.edu/tag/092Y)

In `Proetale/Algebra/Bijective.lean`:
- `Algebra.WeaklyEtale.bijective_of_unique_primes_of_bijective_residueFieldMap`

In `Proetale/Algebra/IndEtale.lean`:
- `Algebra.IndEtale.exists_isIdempotentElem_of_two_primes`
- `Algebra.IndEtale.exists_isIdempotentElem_tensorProduct_of_residueField_ne`

In `Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean`:
- `TopCat.limitCone_pt_totallyDisconnectedSpace` — inverse limit of totally disconnected spaces is totally disconnected (proof provided)

In `Proetale/Mathlib/RingTheory/Henselian.lean`:
- `isStrictlyHenselianLocalRing_iff_henselianLocalRing_and_isSepClosed` (proof provided)

In `Proetale/Algebra/HenselianLocalRing.lean`:
- `Algebra.WeaklyEtale.bijective_of_isStrictlyHenselianLocalRing` (the final statement)

The blueprint chapters have been updated with `\lean` tags pointing to these declarations.

## Test plan
- [x] `lake build` succeeds.
