### PR TITLE
feat(Algebra/WLocalization): fill `diag.map_id` and `diag.map_comp` sorries

### DIFF
--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -302,6 +302,7 @@ lemma stratum_anti {E F E' F' : Finset A} (hEE' : E ⊆ E') (hFF' : F ⊆ F') :
     exact Ideal.span_mono (Finset.coe_subset.mpr hFF')
 
 /-- The type of disjoint union decompositions of `E` into two finite sets. -/
+@[ext]
 structure Stratification.Index (E : Finset A) where
   left : Finset A
   right : Finset A
@@ -446,9 +447,7 @@ private lemma ProdStrata.map_transport_eq {E : Finset A}
          Generalization.locClosedSubset j.function j.ideal)
     (x : ProdStrata E) :
     Generalization.map h (x j) = x i := by
-  obtain rfl : j = i := by
-    cases i; cases j
-    simpa only [Stratification.Index.mk.injEq] using ⟨hl, hr⟩
+  obtain rfl : j = i := Stratification.Index.ext hl hr
   simp
 
 /-- Two `Generalization.map` calls into the same target, starting from `ProdStrata`-components
@@ -462,9 +461,7 @@ private lemma ProdStrata.map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ide
             Generalization.locClosedSubset j₂.function j₂.ideal)
     (x : ProdStrata E) :
     Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) := by
-  obtain rfl : j₁ = j₂ := by
-    cases j₁; cases j₂
-    simpa only [Stratification.Index.mk.injEq] using ⟨hl, hr⟩
+  obtain rfl : j₁ = j₂ := Stratification.Index.ext hl hr
   rfl
 
 variable (A) in

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -448,34 +448,31 @@ noncomputable def diag : Finset A ⥤ CommAlgCat A where
     ext x i
     simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_id, AlgHom.coe_id, id_eq,
       ProdStrata.map_apply]
-    suffices h : ∀ {j : Stratification.Index E} (_ : j = i)
-        (h : Generalization.locClosedSubset i.function i.ideal ⊆
-             Generalization.locClosedSubset j.function j.ideal),
-        Generalization.map h (x j) = x i by
-      exact h (Stratification.Index.ext
-        (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
-          Set.subset_union_left.trans i.union_eq.le)
-        (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
-          Set.subset_union_right.trans i.union_eq.le)) _
-    rintro j rfl _
-    simp
+    generalize_proofs h pf
+    have hi : i.restrict h = i := Stratification.Index.ext
+      (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+        Set.subset_union_left.trans i.union_eq.le)
+      (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+        Set.subset_union_right.trans i.union_eq.le)
+    revert pf
+    rw [hi]
+    intro pf
+    exact Generalization.map_id pf (x i)
   map_comp {E F G} f g := by
     classical
     ext x i
     simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_comp, AlgHom.coe_comp, Function.comp_apply,
       ProdStrata.map_apply, Generalization.map_map]
-    suffices h : ∀ (j₁ j₂ : Stratification.Index E) (_ : j₁ = j₂) (f' : A) (I' : Ideal A)
-        (h₁ : Generalization.locClosedSubset f' I' ⊆
-                Generalization.locClosedSubset j₁.function j₁.ideal)
-        (h₂ : Generalization.locClosedSubset f' I' ⊆
-                Generalization.locClosedSubset j₂.function j₂.ideal),
-        Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) by
-      exact h _ _ (Stratification.Index.ext
+    generalize_proofs hfg pf pfg pff pf'
+    have hi : (i.restrict pfg).restrict pff = i.restrict hfg :=
+      Stratification.Index.ext
         (by simp only [Stratification.Index.restrict_left,
-            ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)])
+            ← Finset.inter_assoc, Finset.inter_eq_left.mpr pff])
         (by simp only [Stratification.Index.restrict_right,
-            ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)])) _ _ _ _
-    rintro j₁ j₂ rfl f' I' h₁ h₂
+            ← Finset.inter_assoc, Finset.inter_eq_left.mpr pff])
+    revert pf'
+    rw [hi]
+    intro pf'
     rfl
 
 variable (A) in

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -423,13 +423,80 @@ lemma ProdStrata.mapsTo_map_specComap {E F : Finset A} (h : E ⊆ F) :
     ← Ideal.map_le_iff_le_comap] at hp ⊢
   exact (map_ideal_le h).trans hp
 
+/-- Composition of `Generalization.map`s is again a `Generalization.map`. -/
+private lemma Generalization.map_comp_apply {f₁ f₂ f₃ : A} {I₁ I₂ I₃ : Ideal A}
+    (h₁₂ : Generalization.locClosedSubset f₂ I₂ ⊆ Generalization.locClosedSubset f₁ I₁)
+    (h₂₃ : Generalization.locClosedSubset f₃ I₃ ⊆ Generalization.locClosedSubset f₂ I₂)
+    (x : Generalization f₁ I₁) :
+    Generalization.map h₂₃ (Generalization.map h₁₂ x) =
+      Generalization.map (h₂₃.trans h₁₂) x := by
+  obtain ⟨a, s, rfl⟩ := IsLocalization.exists_mk'_eq (Generalization.submonoid f₁ I₁) x
+  simp only [Generalization.map, AlgHom.coe_mk, IsLocalization.map_mk', RingHom.id_apply]
+
+/-- If two indices share `left` and `right`, then transporting a `ProdStrata`-component along
+`Generalization.map` recovers the other component. -/
+private lemma map_transport_eq {E : Finset A}
+    {i j : Stratification.Index E}
+    (hl : j.left = i.left) (hr : j.right = i.right)
+    (h : Generalization.locClosedSubset i.function i.ideal ⊆
+         Generalization.locClosedSubset j.function j.ideal)
+    (x : ProdStrata E) :
+    Generalization.map h (x j) = x i := by
+  have hij : j = i := by
+    cases i; cases j
+    simp only [Stratification.Index.mk.injEq]
+    exact ⟨hl, hr⟩
+  subst hij
+  simp only [Generalization.map, AlgHom.coe_mk]
+  exact IsLocalization.map_id _
+
+/-- Two `Generalization.map` calls into the same target, starting from `ProdStrata`-components
+of indices that share `left` and `right`, give equal results. -/
+private lemma map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ideal A}
+    {j₁ j₂ : Stratification.Index E}
+    (hl : j₁.left = j₂.left) (hr : j₁.right = j₂.right)
+    (h₁ : Generalization.locClosedSubset f' I' ⊆
+            Generalization.locClosedSubset j₁.function j₁.ideal)
+    (h₂ : Generalization.locClosedSubset f' I' ⊆
+            Generalization.locClosedSubset j₂.function j₂.ideal)
+    (x : ProdStrata E) :
+    Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) := by
+  have hij : j₁ = j₂ := by
+    cases j₁; cases j₂
+    simp only [Stratification.Index.mk.injEq]
+    exact ⟨hl, hr⟩
+  subst hij
+  rfl
+
 variable (A) in
 /-- The diagram whose colimit is the w-localization of `A`. -/
 noncomputable def diag : Finset A ⥤ CommAlgCat A where
   obj E := .of A (ProdStrata E)
   map {E F} f := CommAlgCat.ofHom (ProdStrata.map <| leOfHom f)
-  map_id E := sorry
-  map_comp := sorry
+  map_id E := by
+    classical
+    apply CommAlgCat.hom_ext
+    refine AlgHom.ext fun x => ProdStrata.ext _ _ fun i => ?_
+    change ProdStrata.map (leOfHom (𝟙 E)) x i = x i
+    rw [ProdStrata.map_apply]
+    refine map_transport_eq ?_ ?_ _ x
+    · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+        Set.subset_union_left.trans i.union_eq.le
+    · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+        Set.subset_union_right.trans i.union_eq.le
+  map_comp {E F G} f g := by
+    classical
+    apply CommAlgCat.hom_ext
+    refine AlgHom.ext fun x => ProdStrata.ext _ _ fun i => ?_
+    change ProdStrata.map (leOfHom (f ≫ g)) x i =
+      ((ProdStrata.map (leOfHom g)).comp (ProdStrata.map (leOfHom f))) x i
+    rw [ProdStrata.map_apply, AlgHom.comp_apply, ProdStrata.map_apply, ProdStrata.map_apply,
+      Generalization.map_comp_apply]
+    refine map_transport_comp_eq ?_ ?_ _ _ x
+    · simp only [Stratification.Index.restrict_left,
+        ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)]
+    · simp only [Stratification.Index.restrict_right,
+        ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)]
 
 variable (A) in
 /-- The w-localization of a ring as an object of `CommAlgCat A` is the colimit over

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -438,32 +438,6 @@ lemma ProdStrata.mapsTo_map_specComap {E F : Finset A} (h : E ⊆ F) :
     ← Ideal.map_le_iff_le_comap] at hp ⊢
   exact (map_ideal_le h).trans hp
 
-/-- If two indices share `left` and `right`, then transporting a `ProdStrata`-component along
-`Generalization.map` recovers the other component. -/
-private lemma ProdStrata.map_transport_eq {E : Finset A}
-    {i j : Stratification.Index E}
-    (hl : j.left = i.left) (hr : j.right = i.right)
-    (h : Generalization.locClosedSubset i.function i.ideal ⊆
-         Generalization.locClosedSubset j.function j.ideal)
-    (x : ProdStrata E) :
-    Generalization.map h (x j) = x i := by
-  obtain rfl : j = i := Stratification.Index.ext hl hr
-  simp
-
-/-- Two `Generalization.map` calls into the same target, starting from `ProdStrata`-components
-of indices that share `left` and `right`, give equal results. -/
-private lemma ProdStrata.map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ideal A}
-    {j₁ j₂ : Stratification.Index E}
-    (hl : j₁.left = j₂.left) (hr : j₁.right = j₂.right)
-    (h₁ : Generalization.locClosedSubset f' I' ⊆
-            Generalization.locClosedSubset j₁.function j₁.ideal)
-    (h₂ : Generalization.locClosedSubset f' I' ⊆
-            Generalization.locClosedSubset j₂.function j₂.ideal)
-    (x : ProdStrata E) :
-    Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) := by
-  obtain rfl : j₁ = j₂ := Stratification.Index.ext hl hr
-  rfl
-
 variable (A) in
 /-- The diagram whose colimit is the w-localization of `A`. -/
 noncomputable def diag : Finset A ⥤ CommAlgCat A where
@@ -474,21 +448,35 @@ noncomputable def diag : Finset A ⥤ CommAlgCat A where
     ext x i
     simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_id, AlgHom.coe_id, id_eq,
       ProdStrata.map_apply]
-    refine ProdStrata.map_transport_eq ?_ ?_ _ x
-    · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
-        Set.subset_union_left.trans i.union_eq.le
-    · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
-        Set.subset_union_right.trans i.union_eq.le
+    suffices h : ∀ {j : Stratification.Index E} (_ : j = i)
+        (h : Generalization.locClosedSubset i.function i.ideal ⊆
+             Generalization.locClosedSubset j.function j.ideal),
+        Generalization.map h (x j) = x i by
+      exact h (Stratification.Index.ext
+        (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+          Set.subset_union_left.trans i.union_eq.le)
+        (Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
+          Set.subset_union_right.trans i.union_eq.le)) _
+    rintro j rfl _
+    simp
   map_comp {E F G} f g := by
     classical
     ext x i
     simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_comp, AlgHom.coe_comp, Function.comp_apply,
       ProdStrata.map_apply, Generalization.map_map]
-    refine ProdStrata.map_transport_comp_eq ?_ ?_ _ _ x
-    · simp only [Stratification.Index.restrict_left,
-        ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)]
-    · simp only [Stratification.Index.restrict_right,
-        ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)]
+    suffices h : ∀ (j₁ j₂ : Stratification.Index E) (_ : j₁ = j₂) (f' : A) (I' : Ideal A)
+        (h₁ : Generalization.locClosedSubset f' I' ⊆
+                Generalization.locClosedSubset j₁.function j₁.ideal)
+        (h₂ : Generalization.locClosedSubset f' I' ⊆
+                Generalization.locClosedSubset j₂.function j₂.ideal),
+        Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) by
+      exact h _ _ (Stratification.Index.ext
+        (by simp only [Stratification.Index.restrict_left,
+            ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)])
+        (by simp only [Stratification.Index.restrict_right,
+            ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)])) _ _ _ _
+    rintro j₁ j₂ rfl f' I' h₁ h₂
+    rfl
 
 variable (A) in
 /-- The w-localization of a ring as an object of `CommAlgCat A` is the colimit over

--- a/Proetale/Algebra/WLocalization/Basic.lean
+++ b/Proetale/Algebra/WLocalization/Basic.lean
@@ -108,6 +108,20 @@ noncomputable def map {f f' : A} {I I' : Ideal A}
     (Generalization f' I') (RingHom.id A) (submonoid_le h)
   commutes' r := by simp
 
+@[simp]
+lemma map_id {f : A} {I : Ideal A} (h : locClosedSubset f I ⊆ locClosedSubset f I)
+    (x : Generalization f I) : map h x = x := by
+  simp [map]
+
+/-- Composition of `Generalization.map`s is again a `Generalization.map`. -/
+lemma map_map {f₁ f₂ f₃ : A} {I₁ I₂ I₃ : Ideal A}
+    (h₁₂ : locClosedSubset f₂ I₂ ⊆ locClosedSubset f₁ I₁)
+    (h₂₃ : locClosedSubset f₃ I₃ ⊆ locClosedSubset f₂ I₂)
+    (x : Generalization f₁ I₁) :
+    map h₂₃ (map h₁₂ x) = map (h₂₃.trans h₁₂) x := by
+  obtain ⟨a, s, rfl⟩ := IsLocalization.exists_mk'_eq (submonoid f₁ I₁) x
+  simp [map, IsLocalization.map_mk']
+
 /-- The image of `Spec (Generalization f I)` in `Spec A` is equal to
 the generalization hull of `D(f) ∩ V(I)`. -/
 lemma range_algebraMap_generalization (f : A) (I : Ideal A) :
@@ -423,36 +437,23 @@ lemma ProdStrata.mapsTo_map_specComap {E F : Finset A} (h : E ⊆ F) :
     ← Ideal.map_le_iff_le_comap] at hp ⊢
   exact (map_ideal_le h).trans hp
 
-/-- Composition of `Generalization.map`s is again a `Generalization.map`. -/
-private lemma Generalization.map_comp_apply {f₁ f₂ f₃ : A} {I₁ I₂ I₃ : Ideal A}
-    (h₁₂ : Generalization.locClosedSubset f₂ I₂ ⊆ Generalization.locClosedSubset f₁ I₁)
-    (h₂₃ : Generalization.locClosedSubset f₃ I₃ ⊆ Generalization.locClosedSubset f₂ I₂)
-    (x : Generalization f₁ I₁) :
-    Generalization.map h₂₃ (Generalization.map h₁₂ x) =
-      Generalization.map (h₂₃.trans h₁₂) x := by
-  obtain ⟨a, s, rfl⟩ := IsLocalization.exists_mk'_eq (Generalization.submonoid f₁ I₁) x
-  simp only [Generalization.map, AlgHom.coe_mk, IsLocalization.map_mk', RingHom.id_apply]
-
 /-- If two indices share `left` and `right`, then transporting a `ProdStrata`-component along
 `Generalization.map` recovers the other component. -/
-private lemma map_transport_eq {E : Finset A}
+private lemma ProdStrata.map_transport_eq {E : Finset A}
     {i j : Stratification.Index E}
     (hl : j.left = i.left) (hr : j.right = i.right)
     (h : Generalization.locClosedSubset i.function i.ideal ⊆
          Generalization.locClosedSubset j.function j.ideal)
     (x : ProdStrata E) :
     Generalization.map h (x j) = x i := by
-  have hij : j = i := by
+  obtain rfl : j = i := by
     cases i; cases j
-    simp only [Stratification.Index.mk.injEq]
-    exact ⟨hl, hr⟩
-  subst hij
-  simp only [Generalization.map, AlgHom.coe_mk]
-  exact IsLocalization.map_id _
+    simpa only [Stratification.Index.mk.injEq] using ⟨hl, hr⟩
+  simp
 
 /-- Two `Generalization.map` calls into the same target, starting from `ProdStrata`-components
 of indices that share `left` and `right`, give equal results. -/
-private lemma map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ideal A}
+private lemma ProdStrata.map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ideal A}
     {j₁ j₂ : Stratification.Index E}
     (hl : j₁.left = j₂.left) (hr : j₁.right = j₂.right)
     (h₁ : Generalization.locClosedSubset f' I' ⊆
@@ -461,11 +462,9 @@ private lemma map_transport_comp_eq {E : Finset A} {f' : A} {I' : Ideal A}
             Generalization.locClosedSubset j₂.function j₂.ideal)
     (x : ProdStrata E) :
     Generalization.map h₁ (x j₁) = Generalization.map h₂ (x j₂) := by
-  have hij : j₁ = j₂ := by
+  obtain rfl : j₁ = j₂ := by
     cases j₁; cases j₂
-    simp only [Stratification.Index.mk.injEq]
-    exact ⟨hl, hr⟩
-  subst hij
+    simpa only [Stratification.Index.mk.injEq] using ⟨hl, hr⟩
   rfl
 
 variable (A) in
@@ -475,24 +474,20 @@ noncomputable def diag : Finset A ⥤ CommAlgCat A where
   map {E F} f := CommAlgCat.ofHom (ProdStrata.map <| leOfHom f)
   map_id E := by
     classical
-    apply CommAlgCat.hom_ext
-    refine AlgHom.ext fun x => ProdStrata.ext _ _ fun i => ?_
-    change ProdStrata.map (leOfHom (𝟙 E)) x i = x i
-    rw [ProdStrata.map_apply]
-    refine map_transport_eq ?_ ?_ _ x
+    ext x i
+    simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_id, AlgHom.coe_id, id_eq,
+      ProdStrata.map_apply]
+    refine ProdStrata.map_transport_eq ?_ ?_ _ x
     · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
         Set.subset_union_left.trans i.union_eq.le
     · exact Finset.inter_eq_right.mpr <| Finset.coe_subset.mp <|
         Set.subset_union_right.trans i.union_eq.le
   map_comp {E F G} f g := by
     classical
-    apply CommAlgCat.hom_ext
-    refine AlgHom.ext fun x => ProdStrata.ext _ _ fun i => ?_
-    change ProdStrata.map (leOfHom (f ≫ g)) x i =
-      ((ProdStrata.map (leOfHom g)).comp (ProdStrata.map (leOfHom f))) x i
-    rw [ProdStrata.map_apply, AlgHom.comp_apply, ProdStrata.map_apply, ProdStrata.map_apply,
-      Generalization.map_comp_apply]
-    refine map_transport_comp_eq ?_ ?_ _ _ x
+    ext x i
+    simp only [CommAlgCat.hom_ofHom, CommAlgCat.hom_comp, AlgHom.coe_comp, Function.comp_apply,
+      ProdStrata.map_apply, Generalization.map_map]
+    refine ProdStrata.map_transport_comp_eq ?_ ?_ _ _ x
     · simp only [Stratification.Index.restrict_left,
         ← Finset.inter_assoc, Finset.inter_eq_left.mpr (leOfHom f)]
     · simp only [Stratification.Index.restrict_right,


### PR DESCRIPTION
Fills the two functoriality `sorry`-placeholders for `WLocalization.diag`, the
diagram `Finset A ⥤ CommAlgCat A` whose colimit is the w-localization. After this
PR, the existing `\leanok` on `def:w-localization` (which already references
`WLocalization.commAlgCat`) accurately reflects the underlying Lean state.

The proofs route through three small private helpers:

* `Generalization.map_comp_apply`: two `Generalization.map`s compose to a single
  `Generalization.map` whose subset proof is the transitivity of the inputs.
* `map_transport_eq`: between equal indices (matching `left` and `right`),
  `Generalization.map` acts as the identity on the corresponding `ProdStrata`
  component.
* `map_transport_comp_eq`: two `Generalization.map`s landing in the same target
  from equal indices give equal results.

For `map_id`, the restricted index `i.restrict (𝟙 E)` equals `i` (using
`i.left, i.right ⊆ E`); for `map_comp`, the doubly-restricted index
`(i.restrict g).restrict f` equals the directly-restricted `i.restrict (f ≫ g)`
(using `E ⊆ F` and associativity of finite intersection).
