### PR TITLE
feat(Topology/SpectralSpace/WLocal/Pullback): fill sorries for Stacks 096C (second part)

### DIFF
--- a/Proetale/Mathlib/Topology/JacobsonSpace.lean
+++ b/Proetale/Mathlib/Topology/JacobsonSpace.lean
@@ -7,3 +7,18 @@ theorem closedPoints.isClosed_singleton (x : closedPoints X) :
     IsClosed ({x} : Set (closedPoints X)) := by
   simpa [Set.preimage, Subtype.val_inj] using
       x.2.preimage (f := fun (x : closedPoints X) ↦ (x : X)) continuous_subtype_val
+
+lemma closedPoints_prod (Y : Type*) [TopologicalSpace Y] :
+    closedPoints (X × Y) = closedPoints X ×ˢ closedPoints Y := by
+  ext ⟨x, y⟩
+  simp only [mem_closedPoints_iff, Set.mem_prod, ← closure_eq_iff_isClosed,
+    ← Set.singleton_prod_singleton, closure_prod_eq]
+  refine ⟨fun h ↦ ?_, fun ⟨hx, hy⟩ ↦ by rw [hx, hy]⟩
+  refine ⟨Set.Subset.antisymm (fun z hz ↦ ?_) subset_closure,
+    Set.Subset.antisymm (fun z hz ↦ ?_) subset_closure⟩
+  · have : (z, y) ∈ closure ({x} : Set X) ×ˢ closure ({y} : Set Y) := ⟨hz, subset_closure rfl⟩
+    rw [h] at this
+    exact this.1
+  · have : (x, z) ∈ closure ({x} : Set X) ×ˢ closure ({y} : Set Y) := ⟨subset_closure rfl, hz⟩
+    rw [h] at this
+    exact this.2

--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -5,12 +5,34 @@ Authors: Jiedong Jiang, Christian Merten
 -/
 import Proetale.Topology.SpectralSpace.ConnectedComponent
 import Proetale.Topology.SpectralSpace.WLocal.ClosedPoints
+import Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
 
 /-!
 # Pullback of w-local spaces
 
-Stacks Project 096C
+We formalise the second part of [Stacks 096C](https://stacks.math.columbia.edu/tag/096C):
+given a w-local space `X`, a profinite space `T`, a continuous map `i : T → π₀ X`, and
+a pullback square
+
+```
+      Y ─g─> T
+      │      │
+      f      i
+      v      v
+      X ─π─> π₀ X
+```
+
+(with `π : X → π₀ X` the canonical map to connected components), the total space `Y` is
+again w-local, the projection `f : Y → X` is a w-local map, and `f⁻¹ (X_max) = Y_max`
+where `X_max`/`Y_max` denote the closed points.
+
+## Main results
+
+* `ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback`:
+  `f⁻¹ (closedPoints X) = closedPoints Y`.
+* `ConnectedComponents.wlocalSpace_of_isPullback`: `Y` is w-local.
+* `ConnectedComponents.isWLocalMap_of_isPullback`: `f : Y → X` is a w-local map.
 -/
 
 open CategoryTheory TopCat
@@ -19,23 +41,171 @@ universe u
 variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
     [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
 
+namespace ConnectedComponents
+
+section IsPullback
+
+variable {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
+  (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+
+include pb
+
+/-- The pullback `Y` is homeomorphic to the subspace
+`{(t, x) : T × X | i t = π x}` of `T × X` via the categorical pullback isomorphism. -/
+private noncomputable def pullbackHomeo :
+    Y ≃ₜ {p : T × X // i p.1 = ConnectedComponents.mk p.2} :=
+  haveI := pb.hasPullback
+  homeoOfIso (pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _)
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma pullbackHomeo_fst (y : Y) : (pullbackHomeo pb y).val.1 = g y := by
+  haveI := pb.hasPullback
+  change ((pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _).hom y).val.1 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  rw [pullbackIsoProdSubtype_hom_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma pullbackHomeo_snd (y : Y) : (pullbackHomeo pb y).val.2 = f y := by
+  haveI := pb.hasPullback
+  change ((pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _).hom y).val.2 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  rw [pullbackIsoProdSubtype_hom_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+/-- `(g, f)` jointly identifies points of `Y`, because `Y` embeds into `T × X` via the
+homeomorphism `pullbackHomeo`. -/
+private lemma fg_injective_of_isPullback
+    {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
+  apply (pullbackHomeo pb).injective
+  apply Subtype.ext
+  apply Prod.ext
+  · simp only [pullbackHomeo_fst]; exact hg
+  · simp only [pullbackHomeo_snd]; exact hf
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+/-- The pointwise form of the commuting square `g ≫ i = f ≫ π`. -/
+private lemma hw_of_isPullback (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
+  ConcreteCategory.congr_hom pb.w y
+
+set_option linter.unusedSectionVars false in
 @[stacks 096C "second part"]
-theorem ConnectedComponents.wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    WLocalSpace Y where
+theorem preimage_closedPoints_eq_closedPoints_of_isPullback :
+    f ⁻¹' (closedPoints X) = closedPoints Y := by
+  have hw := hw_of_isPullback pb
+  ext y; constructor
+  · -- Forward: separate `y` from any `z ≠ y` using either `f` (when `f z ≠ f y`, via the
+    -- closed point `f y`) or `g` (when `f z = f y`, via `T` being `T2`).
+    intro hy
+    rw [Set.mem_preimage, mem_closedPoints_iff] at hy
+    rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+    intro z hz
+    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+    by_cases hfzy : f z = f y
+    · have hgzy : g z ≠ g y := fun h => hz (fg_injective_of_isPullback pb hfzy h)
+      obtain ⟨U, V, hU, hV, hgzU, hgyV, hUV⟩ := t2_separation hgzy
+      exact ⟨g ⁻¹' U, fun w hw => by
+        simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+        intro heq; subst heq
+        exact Set.disjoint_left.mp hUV hw hgyV,
+        hU.preimage g.2, hgzU⟩
+    · exact ⟨f ⁻¹' {f y}ᶜ, fun w hw => by
+        simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw ⊢
+        intro heq; subst heq; exact hw rfl,
+        hy.isOpen_compl.preimage f.2,
+        by simp [hfzy]⟩
+  · -- Backward: `y` closed implies `f y` closed. Pick the closed point `x_c` of `X`
+    -- specialized by `f y` (using `WLocalSpace X`), then lift to `y_c ∈ Y` with
+    -- `f y_c = x_c` and `g y_c = g y`. Componentwise specialization gives `y ⤳ y_c`,
+    -- so `y = y_c` and `f y = x_c`.
+    intro hy
+    rw [Set.mem_preimage, mem_closedPoints_iff]
+    rw [mem_closedPoints_iff] at hy
+    haveI : SpectralSpace Y := pb.spectralSpace
+    obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
+    have hcc : ConnectedComponents.mk x_c = ConnectedComponents.mk (f y) := by
+      rw [ConnectedComponents.coe_eq_coe']
+      exact closure_minimal (Set.singleton_subset_iff.mpr mem_connectedComponent)
+        isClosed_connectedComponent hfy_xc.mem_closure
+    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
+    let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+      (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+      (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
+    have hgy_c : g y_c = g y := ConcreteCategory.congr_hom
+      (pb.lift_fst (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hfy_c : f y_c = x_c := ConcreteCategory.congr_hom
+      (pb.lift_snd (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hy_spec_yc : y ⤳ y_c := by
+      rw [specializes_iff_mem_closure]
+      have hval_spec : (pullbackHomeo pb y).val ⤳ (pullbackHomeo pb y_c).val := by
+        rw [specializes_prod]
+        refine ⟨?_, ?_⟩
+        · change (pullbackHomeo pb y).val.1 ⤳ (pullbackHomeo pb y_c).val.1
+          rw [pullbackHomeo_fst, pullbackHomeo_fst, hgy_c]
+        · change (pullbackHomeo pb y).val.2 ⤳ (pullbackHomeo pb y_c).val.2
+          rw [pullbackHomeo_snd, pullbackHomeo_snd, hfy_c]; exact hfy_xc
+      have hsub_spec : pullbackHomeo pb y ⤳ pullbackHomeo pb y_c :=
+        Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec
+      exact ((pullbackHomeo pb).isInducing.specializes_iff.mp hsub_spec).mem_closure
+    have heq : y = y_c := by
+      have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
+      rw [hy.closure_eq, Set.mem_singleton_iff] at hmem
+      exact hmem.symm
+    have : f y = x_c := by rw [heq, hfy_c]
+    rw [this]; exact hx_c_closed
+
+@[stacks 096C "second part"]
+theorem wlocalSpace_of_isPullback : WLocalSpace Y where
   __ := pb.spectralSpace
-  eq_of_specializes := sorry
-  isClosed_closedPoints := sorry
+  eq_of_specializes := by
+    intro y c c' hc hc' hyc hyc'
+    -- `f c, f c'` are closed points of `X`, both specialized by `f y`. By `WLocalSpace X`
+    -- they coincide; `g c = g c'` follows from `T` being `T2`. Injectivity of `(g, f)`
+    -- on `Y` then forces `c = c'`.
+    have hfc : f c ∈ closedPoints X := by
+      have : c ∈ closedPoints Y := mem_closedPoints_iff.mpr hc
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hfc' : f c' ∈ closedPoints X := by
+      have : c' ∈ closedPoints Y := mem_closedPoints_iff.mpr hc'
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hf_eq : f c = f c' :=
+      WLocalSpace.eq_of_specializes (mem_closedPoints_iff.mp hfc)
+        (mem_closedPoints_iff.mp hfc') (hyc.map f.2) (hyc'.map f.2)
+    have hg_eq : g c = g c' := (hyc.map g.2).eq.symm.trans (hyc'.map g.2).eq
+    exact fg_injective_of_isPullback pb hf_eq hg_eq
+  isClosed_closedPoints := by
+    rw [← preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
 
 @[stacks 096C "second part"]
-theorem ConnectedComponents.isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    IsWLocalMap f := sorry
+theorem isWLocalMap_of_isPullback : IsWLocalMap f where
+  toIsSpectralMap := by
+    haveI := pb.spectralSpace
+    haveI := wlocalSpace_of_isPullback pb
+    refine ⟨f.2, ?_⟩
+    -- `f` factors as `Y ≃ₜ {p : T × X // i p.1 = π p.2} ↪ T × X ─snd→ X`. The first map is a
+    -- homeomorphism, the second a closed embedding (since `T` is `T2`), and the third is
+    -- proper (since `T` is compact). The composition is proper, hence spectral.
+    have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
+      isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
+    have hsnd_proper : IsProperMap (Prod.snd : T × X → X) :=
+      isProperMap_snd_of_compactSpace
+    have hf_proper : IsProperMap f := by
+      have heq : f = Prod.snd ∘ Subtype.val ∘ pullbackHomeo pb :=
+        funext fun y => (pullbackHomeo_snd pb y).symm
+      rw [heq]
+      exact (hsnd_proper.comp hclosed.isProperMap_subtypeVal).comp (pullbackHomeo pb).isProperMap
+    intro s hs hsc
+    exact hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc
+  closedPoints_subset_preimage_closedPoints := by
+    intro y hy
+    rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]
 
-@[stacks 096C "second part"]
-theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)}
-    {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    f ⁻¹' (closedPoints X) = closedPoints Y := sorry
+end IsPullback
+
+end ConnectedComponents

--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -7,6 +7,7 @@ import Proetale.Topology.SpectralSpace.ConnectedComponent
 import Proetale.Topology.SpectralSpace.WLocal.ClosedPoints
 import Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
+import Proetale.Mathlib.Topology.JacobsonSpace
 
 /-!
 # Pullback of w-local spaces
@@ -29,6 +30,11 @@ where `X_max`/`Y_max` denote the closed points.
 
 ## Main results
 
+* `ConnectedComponents.pullbackHomeo`: `Y` is homeomorphic to the subspace
+  `{(t, x) : T × X | i t = π x}` of `T × X`.
+* `ConnectedComponents.isClosedEmbedding_prodMk_of_isPullback`: `(g, f) : Y → T × X` is
+  a closed embedding.
+* `ConnectedComponents.isProperMap_of_isPullback`: `f : Y → X` is proper.
 * `ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback`:
   `f⁻¹ (closedPoints X) = closedPoints Y`.
 * `ConnectedComponents.wlocalSpace_of_isPullback`: `Y` is w-local.
@@ -38,8 +44,7 @@ where `X_max`/`Y_max` denote the closed points.
 open CategoryTheory TopCat
 
 universe u
-variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
-    [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
+variable {X Y T : Type u} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace T]
 
 namespace ConnectedComponents
 
@@ -52,112 +57,54 @@ include pb
 
 /-- The pullback `Y` is homeomorphic to the subspace
 `{(t, x) : T × X | i t = π x}` of `T × X` via the categorical pullback isomorphism. -/
-private noncomputable def pullbackHomeo :
+noncomputable def pullbackHomeo :
     Y ≃ₜ {p : T × X // i p.1 = ConnectedComponents.mk p.2} :=
   haveI := pb.hasPullback
   homeoOfIso (pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _)
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-private lemma pullbackHomeo_fst (y : Y) : (pullbackHomeo pb y).val.1 = g y := by
+@[simp]
+lemma pullbackHomeo_fst (y : Y) : (pullbackHomeo pb y).val.1 = g y := by
   haveI := pb.hasPullback
   change ((pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _).hom y).val.1 = _
   simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
   rw [pullbackIsoProdSubtype_hom_apply]
   exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-private lemma pullbackHomeo_snd (y : Y) : (pullbackHomeo pb y).val.2 = f y := by
+@[simp]
+lemma pullbackHomeo_snd (y : Y) : (pullbackHomeo pb y).val.2 = f y := by
   haveI := pb.hasPullback
   change ((pb.isoPullback ≪≫ pullbackIsoProdSubtype _ _).hom y).val.2 = _
   simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
   rw [pullbackIsoProdSubtype_hom_apply]
   exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-/-- `(g, f)` jointly identifies points of `Y`, because `Y` embeds into `T × X` via the
-homeomorphism `pullbackHomeo`. -/
-private lemma fg_injective_of_isPullback
-    {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
-  apply (pullbackHomeo pb).injective
-  apply Subtype.ext
-  apply Prod.ext
-  · simp only [pullbackHomeo_fst]; exact hg
-  · simp only [pullbackHomeo_snd]; exact hf
+variable [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] [WLocalSpace X]
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-/-- The pointwise form of the commuting square `g ≫ i = f ≫ π`. -/
-private lemma hw_of_isPullback (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
-  ConcreteCategory.congr_hom pb.w y
+omit [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+/-- The map `(g, f) : Y → T × X` is a closed embedding. -/
+lemma isClosedEmbedding_prodMk_of_isPullback :
+    Topology.IsClosedEmbedding (fun y ↦ (g y, f y)) := by
+  have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
+    isClosed_eq (i.continuous.comp continuous_fst) (continuous_coe.comp continuous_snd)
+  have h : (fun y ↦ (g y, f y)) = Subtype.val ∘ pullbackHomeo pb := by
+    ext y <;> simp
+  rw [h]
+  exact hclosed.isClosedEmbedding_subtypeVal.comp (pullbackHomeo pb).isClosedEmbedding
 
-set_option linter.unusedSectionVars false in
+omit [T2Space T] [TotallyDisconnectedSpace T] in
+/-- `f : Y → X` is proper, as a base change of the proper map `T → π₀ X` along `X → π₀ X`. -/
+lemma isProperMap_of_isPullback : IsProperMap f :=
+  isProperMap_snd_of_compactSpace.comp
+    (isClosedEmbedding_prodMk_of_isPullback pb).isProperMap
+
+omit [CompactSpace T] [TotallyDisconnectedSpace T] in
 @[stacks 096C "second part"]
 theorem preimage_closedPoints_eq_closedPoints_of_isPullback :
     f ⁻¹' (closedPoints X) = closedPoints Y := by
-  have hw := hw_of_isPullback pb
-  ext y; constructor
-  · -- Forward: separate `y` from any `z ≠ y` using either `f` (when `f z ≠ f y`, via the
-    -- closed point `f y`) or `g` (when `f z = f y`, via `T` being `T2`).
-    intro hy
-    rw [Set.mem_preimage, mem_closedPoints_iff] at hy
-    rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
-    intro z hz
-    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
-    by_cases hfzy : f z = f y
-    · have hgzy : g z ≠ g y := fun h => hz (fg_injective_of_isPullback pb hfzy h)
-      obtain ⟨U, V, hU, hV, hgzU, hgyV, hUV⟩ := t2_separation hgzy
-      exact ⟨g ⁻¹' U, fun w hw => by
-        simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
-        intro heq; subst heq
-        exact Set.disjoint_left.mp hUV hw hgyV,
-        hU.preimage g.2, hgzU⟩
-    · exact ⟨f ⁻¹' {f y}ᶜ, fun w hw => by
-        simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw ⊢
-        intro heq; subst heq; exact hw rfl,
-        hy.isOpen_compl.preimage f.2,
-        by simp [hfzy]⟩
-  · -- Backward: `y` closed implies `f y` closed. Pick the closed point `x_c` of `X`
-    -- specialized by `f y` (using `WLocalSpace X`), then lift to `y_c ∈ Y` with
-    -- `f y_c = x_c` and `g y_c = g y`. Componentwise specialization gives `y ⤳ y_c`,
-    -- so `y = y_c` and `f y = x_c`.
-    intro hy
-    rw [Set.mem_preimage, mem_closedPoints_iff]
-    rw [mem_closedPoints_iff] at hy
-    haveI : SpectralSpace Y := pb.spectralSpace
-    obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
-    have hcc : ConnectedComponents.mk x_c = ConnectedComponents.mk (f y) := by
-      rw [ConnectedComponents.coe_eq_coe']
-      exact closure_minimal (Set.singleton_subset_iff.mpr mem_connectedComponent)
-        isClosed_connectedComponent hfy_xc.mem_closure
-    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
-    let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-      (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-      (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
-    have hgy_c : g y_c = g y := ConcreteCategory.congr_hom
-      (pb.lift_fst (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
-    have hfy_c : f y_c = x_c := ConcreteCategory.congr_hom
-      (pb.lift_snd (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
-    have hy_spec_yc : y ⤳ y_c := by
-      rw [specializes_iff_mem_closure]
-      have hval_spec : (pullbackHomeo pb y).val ⤳ (pullbackHomeo pb y_c).val := by
-        rw [specializes_prod]
-        refine ⟨?_, ?_⟩
-        · change (pullbackHomeo pb y).val.1 ⤳ (pullbackHomeo pb y_c).val.1
-          rw [pullbackHomeo_fst, pullbackHomeo_fst, hgy_c]
-        · change (pullbackHomeo pb y).val.2 ⤳ (pullbackHomeo pb y_c).val.2
-          rw [pullbackHomeo_snd, pullbackHomeo_snd, hfy_c]; exact hfy_xc
-      have hsub_spec : pullbackHomeo pb y ⤳ pullbackHomeo pb y_c :=
-        Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec
-      exact ((pullbackHomeo pb).isInducing.specializes_iff.mp hsub_spec).mem_closure
-    have heq : y = y_c := by
-      have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
-      rw [hy.closure_eq, Set.mem_singleton_iff] at hmem
-      exact hmem.symm
-    have : f y = x_c := by rw [heq, hfy_c]
-    rw [this]; exact hx_c_closed
+  rw [← (isClosedEmbedding_prodMk_of_isPullback pb).preimage_closedPoints,
+    closedPoints_prod, closedPoints_eq_univ (X := T)]
+  ext y
+  simp
 
 @[stacks 096C "second part"]
 theorem wlocalSpace_of_isPullback : WLocalSpace Y where
@@ -168,40 +115,25 @@ theorem wlocalSpace_of_isPullback : WLocalSpace Y where
     -- they coincide; `g c = g c'` follows from `T` being `T2`. Injectivity of `(g, f)`
     -- on `Y` then forces `c = c'`.
     have hfc : f c ∈ closedPoints X := by
-      have : c ∈ closedPoints Y := mem_closedPoints_iff.mpr hc
-      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+      rw [← Set.mem_preimage, preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+      exact hc
     have hfc' : f c' ∈ closedPoints X := by
-      have : c' ∈ closedPoints Y := mem_closedPoints_iff.mpr hc'
-      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+      rw [← Set.mem_preimage, preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+      exact hc'
     have hf_eq : f c = f c' :=
       WLocalSpace.eq_of_specializes (mem_closedPoints_iff.mp hfc)
-        (mem_closedPoints_iff.mp hfc') (hyc.map f.2) (hyc'.map f.2)
-    have hg_eq : g c = g c' := (hyc.map g.2).eq.symm.trans (hyc'.map g.2).eq
-    exact fg_injective_of_isPullback pb hf_eq hg_eq
+        (mem_closedPoints_iff.mp hfc') (hyc.map f.continuous) (hyc'.map f.continuous)
+    have hg_eq : g c = g c' :=
+      (hyc.map g.continuous).eq.symm.trans (hyc'.map g.continuous).eq
+    exact (isClosedEmbedding_prodMk_of_isPullback pb).injective (Prod.ext hg_eq hf_eq)
   isClosed_closedPoints := by
     rw [← preimage_closedPoints_eq_closedPoints_of_isPullback pb]
-    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
+    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.continuous
 
+omit [TotallyDisconnectedSpace T] in
 @[stacks 096C "second part"]
 theorem isWLocalMap_of_isPullback : IsWLocalMap f where
-  toIsSpectralMap := by
-    haveI := pb.spectralSpace
-    haveI := wlocalSpace_of_isPullback pb
-    refine ⟨f.2, ?_⟩
-    -- `f` factors as `Y ≃ₜ {p : T × X // i p.1 = π p.2} ↪ T × X ─snd→ X`. The first map is a
-    -- homeomorphism, the second a closed embedding (since `T` is `T2`), and the third is
-    -- proper (since `T` is compact). The composition is proper, hence spectral.
-    have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
-      isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
-    have hsnd_proper : IsProperMap (Prod.snd : T × X → X) :=
-      isProperMap_snd_of_compactSpace
-    have hf_proper : IsProperMap f := by
-      have heq : f = Prod.snd ∘ Subtype.val ∘ pullbackHomeo pb :=
-        funext fun y => (pullbackHomeo_snd pb y).symm
-      rw [heq]
-      exact (hsnd_proper.comp hclosed.isProperMap_subtypeVal).comp (pullbackHomeo pb).isProperMap
-    intro s hs hsc
-    exact hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc
+  toIsSpectralMap := (isProperMap_of_isPullback pb).isSpectralMap
   closedPoints_subset_preimage_closedPoints := by
     intro y hy
     rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1094,6 +1094,7 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{thm:pullback-spectral,thm:cartesian-profinite,thm:closed-points-isom-pi0}
   We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}. Assume $X$ is w-local and let $X^c \subset X$ be its closed points. The inverse image $Y^c \subset Y$ of $X^c$ maps bijectively onto $T$, since $X^c \to \pi_0(X)$ is a bijection by \Cref{thm:closed-points-isom-pi0}. (Note that we do not yet know whether $Y^c$ is the set of closed points of $Y$.) Moreover, $Y^c$ is quasi-compact as a closed subset of the spectral space $Y$. Hence $Y^c \to \pi_0(Y) = T$ is a homeomorphism by \verb`isHomeomorph_iff_continuous_bijective` (\stacksproject{08YE}). It follows that all points of $Y^c$ are closed in $Y$: if some $y \in Y^c$ specialized to a distinct closed point $y'$ (which also falls in $Y$ since $Y$ is closed), then both would map to the same point in $T$, contradicting the bijectivity of $Y^c \to T$.
 

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1096,9 +1096,20 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 \begin{proof}
   \leanok
   \uses{thm:pullback-spectral,thm:cartesian-profinite,thm:closed-points-isom-pi0}
-  We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}. Assume $X$ is w-local and let $X^c \subset X$ be its closed points. The inverse image $Y^c \subset Y$ of $X^c$ maps bijectively onto $T$, since $X^c \to \pi_0(X)$ is a bijection by \Cref{thm:closed-points-isom-pi0}. (Note that we do not yet know whether $Y^c$ is the set of closed points of $Y$.) Moreover, $Y^c$ is quasi-compact as a closed subset of the spectral space $Y$. Hence $Y^c \to \pi_0(Y) = T$ is a homeomorphism by \verb`isHomeomorph_iff_continuous_bijective` (\stacksproject{08YE}). It follows that all points of $Y^c$ are closed in $Y$: if some $y \in Y^c$ specialized to a distinct closed point $y'$ (which also falls in $Y$ since $Y$ is closed), then both would map to the same point in $T$, contradicting the bijectivity of $Y^c \to T$.
-
-  Conversely, if $y \in Y$ is a closed point, then it is closed in its fibre over $T$, and its image $x \in X$ is closed in the corresponding (homeomorphic) fibre of $X \to \pi_0(X)$. Since a point in a w-local space is closed if and only if it is closed in its connected component (which is closed), we have $x \in X^c$, so $y \in Y^c$. Thus $Y^c$ is exactly the set of closed points of $Y$. Moreover, since $Y^c \cong T$, each connected component contains a unique closed point, and for each $y \in Y^c$ the set of generalizations of $y$ is precisely the fibre of $Y \to \pi_0(Y)$ (as any generalization of $y$ lies in the same connected component with $y$). The lemma follows.
+  We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}.
+  Via the categorical pullback isomorphism, $Y$ is homeomorphic to the closed subspace
+  $\{(t, x) \in T \times X \mid i(t) = \pi(x)\}$ of $T \times X$, and we identify $Y$
+  with this subspace; in particular the map $(g, f) : Y \to T \times X$ is a closed
+  embedding.
+  Since $T$ is compact Hausdorff, $f : Y \to X$ is a base change of the proper map
+  $T \to \pi_0(X)$, hence proper, hence spectral. This gives $f$ as a spectral map.
+  Closed points of a product $T \times X$ with $T$ Hausdorff are precisely pairs whose
+  second coordinate is a closed point of $X$. Pulling back along the closed embedding
+  $(g, f)$ thus yields $Y^c = f^{-1}(X^c)$ (using that closed embeddings detect closed
+  points). In particular $Y^c$ is closed in $Y$.
+  Finally, the uniqueness of the closed specialisation in $Y$ follows from injectivity
+  of $(g, f)$ combined with uniqueness of closed specialisations in $X$ (for $f$) and
+  $T2$-ness of $T$ (for $g$).
 \end{proof}
 
 \section{w-local rings}


### PR DESCRIPTION
## Summary

Fills the four `sorry` placeholders in `Proetale/Topology/SpectralSpace/WLocal/Pullback.lean`, proving the second part of [Stacks 096C](https://stacks.math.columbia.edu/tag/096C): given a w-local space `X`, a profinite space `T`, a continuous map `i : T → π₀ X`, and a pullback square

```
      Y ─g─> T
      │      │
      f      i
      v      v
      X ─π─> π₀ X
```

the total space `Y` is w-local, the projection `f : Y → X` is a w-local map, and `f⁻¹ (closedPoints X) = closedPoints Y`.

## Proof strategy

A private homeomorphism `pullbackHomeo` realises `Y` as the closed subspace `{(t, x) : T × X // i t = π x}` of `T × X`, with projection lemmas `pullbackHomeo_fst` and `pullbackHomeo_snd` giving `g` and `f` respectively. From this:

- `fg_injective_of_isPullback`: `(g, f)` separates points of `Y`.
- `preimage_closedPoints_eq_closedPoints_of_isPullback`:
  - **Forward**: if `f y` is closed in `X`, separate `y` from any `z ≠ y` using either `f` (when `f z ≠ f y`, via the closed point `f y`) or `g` (when `f z = f y`, via `T` being `T2`).
  - **Backward**: if `y` is closed in `Y`, pick the closed point `x_c` of `X` specialised by `f y` (using `WLocalSpace X`), lift to `y_c ∈ Y` with `f y_c = x_c` and `g y_c = g y`, and transfer the componentwise specialisation via the homeomorphism.
- `wlocalSpace_of_isPullback`: w-locality follows directly from the preimage identification and injectivity of `(g, f)`.
- `isWLocalMap_of_isPullback`: `f` is proper as the composition of a homeomorphism, a closed embedding, and the proper projection `Prod.snd` (since `T` is compact), hence spectral.

Also adds `\leanok` to the corresponding blueprint proof of `thm:cartesian-profinite-w-local` in `blueprint/src/chapters/local-structure.tex`.

Upstreamed from the `archon` branch.

## Test plan

- [x] `lake build Proetale.Topology.SpectralSpace.WLocal.Pullback` builds cleanly.
- [x] `lake build --wfail` succeeds across the full project (no lint warnings).
- [x] `lake exe mk_all --git --check` passes.
