### PR TITLE
feat(Algebra/WContractible): fill `range_algebraMap_specComap` and `isClosedEmbedding_algebraMap_specComap` sorries

### DIFF
--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -150,14 +150,107 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap A (Restriction T))
 
 variable {T}
 
+private lemma restrictClopen_range_eq (W : Clopens (PrimeSpectrum A)) :
+    Set.range (PrimeSpectrum.comap (algebraMap A (RestrictClopen W))) =
+      (W : Set (PrimeSpectrum A)) := by
+  rw [localization_away_comap_range (RestrictClopen W) (isIdempotentElemEquivClopens.symm W).val]
+  exact congr_arg Opens.carrier (basicOpen_isIdempotentElemEquivClopens_symm W)
+
+private lemma ker_algebraMap_restrictClopen_le
+    {W : Clopens (PrimeSpectrum A)} (hW : ConnectedComponents.mk ⁻¹' T ≤ W) :
+    RingHom.ker (algebraMap A (RestrictClopen W)) ≤
+      RingHom.ker (algebraMap A (Restriction T)) := by
+  intro a ha
+  rw [RingHom.mem_ker] at ha ⊢
+  let ι : RestrictClopen W →ₐ[A] Restriction T :=
+    (colimit.ι (Restriction.diag T) (Opposite.op ⟨W, hW⟩)).hom
+  calc algebraMap A (Restriction T) a = ι (algebraMap A (RestrictClopen W) a) :=
+        (ι.commutes a).symm
+    _ = ι 0 := by rw [ha]
+    _ = 0 := map_zero _
+
 lemma range_algebraMap_specComap (h : IsClosed T) :
     Set.range (PrimeSpectrum.comap <| algebraMap A (Restriction T)) =
-      ConnectedComponents.mk ⁻¹' T :=
-  sorry
+      ConnectedComponents.mk ⁻¹' T := by
+  rw [range_comap_of_surjective _ _ (algebraMap_surjective T)]
+  apply Set.Subset.antisymm
+  · intro p hp
+    have hp_in_W : ∀ (W : Clopens (PrimeSpectrum A)),
+        ConnectedComponents.mk ⁻¹' T ≤ W → p ∈ (W : Set (PrimeSpectrum A)) := by
+      intro W hW
+      have hzl : zeroLocus (RingHom.ker (algebraMap A (Restriction T)) : Set A) ⊆
+          zeroLocus (RingHom.ker (algebraMap A (RestrictClopen W)) : Set A) :=
+        zeroLocus_anti_mono (ker_algebraMap_restrictClopen_le (T := T) hW)
+      have hrW := range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
+        (IsLocalization.Away.algebraMap_surjective_of_isIdempotentElem _
+          (isIdempotentElemEquivClopens.symm W).prop)
+      rw [← restrictClopen_range_eq W, hrW]
+      exact hzl hp
+    have hclosed : IsClosed (ConnectedComponents.mk ⁻¹' T : Set (PrimeSpectrum A)) :=
+      h.preimage ConnectedComponents.continuous_coe
+    have hunion : ∃ I : Set (PrimeSpectrum A),
+        ⋃ x ∈ I, connectedComponent x = ConnectedComponents.mk ⁻¹' T := by
+      refine ⟨ConnectedComponents.mk ⁻¹' T, ?_⟩
+      ext x
+      simp only [Set.mem_iUnion, Set.mem_preimage]
+      refine ⟨?_, fun hx ↦ ⟨x, hx, mem_connectedComponent⟩⟩
+      rintro ⟨y, hy, hxy⟩
+      have : (x : ConnectedComponents (PrimeSpectrum A)) = (y : _) :=
+        ConnectedComponents.coe_eq_coe'.mpr hxy
+      exact this ▸ hy
+    obtain ⟨J, hJ⟩ := isClosed_and_iUnion_connectedComponent_eq_iff.1 ⟨hclosed, hunion⟩
+    rw [← hJ]
+    simp only [Set.iInter_coe_set, Set.mem_iInter, Subtype.forall]
+    intro V hV hVJ
+    have hTsubV : ConnectedComponents.mk ⁻¹' T ≤
+        (⟨V, hV⟩ : {U : Set (PrimeSpectrum A) // IsClopen U}).val := by
+      rw [← hJ]
+      exact Set.iInter_subset_of_subset ⟨⟨V, hV⟩, hVJ⟩ le_rfl
+    exact hp_in_W ⟨V, hV⟩ hTsubV
+  · intro p hp
+    rw [mem_zeroLocus]
+    intro a ha
+    rw [SetLike.mem_coe, RingHom.mem_ker] at ha
+    let top_idx : {W : Clopens (PrimeSpectrum A) // ConnectedComponents.mk ⁻¹' T ≤ W} :=
+      ⟨⊤, le_top⟩
+    let ι_top := colimit.ι (Restriction.diag T) (Opposite.op top_idx)
+    have heq_in_colim : ι_top.hom (algebraMap A (RestrictClopen ⊤) a) =
+        ι_top.hom (0 : RestrictClopen ⊤) :=
+      (ι_top.hom.commutes a).trans (ha.trans (map_zero ι_top.hom).symm)
+    have hc' := isColimitOfPreserves (CategoryTheory.forget (CommAlgCat A))
+      (colimit.isColimit (Restriction.diag T))
+    have heq_types : (CategoryTheory.forget (CommAlgCat A)).map ι_top
+        (algebraMap A (RestrictClopen ⊤) a) =
+        (CategoryTheory.forget (CommAlgCat A)).map ι_top (0 : RestrictClopen ⊤) :=
+      heq_in_colim
+    obtain ⟨k, f_top_k, g_top_k, hfg⟩ :=
+      (Types.FilteredColimit.isColimit_eq_iff
+        (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)) hc').mp heq_types
+    let W := k.unop.val
+    have hW : ConnectedComponents.mk ⁻¹' T ≤ W := k.unop.property
+    have hg0 : (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)).map g_top_k
+        (0 : RestrictClopen ⊤) = (0 : RestrictClopen W) :=
+      map_zero ((Restriction.diag T).map g_top_k).hom
+    have hf_alg : (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)).map f_top_k
+        (algebraMap A (RestrictClopen ⊤) a) = algebraMap A (RestrictClopen W) a :=
+      ((Restriction.diag T).map f_top_k).hom.commutes a
+    have ha_zero : algebraMap A (RestrictClopen W) a = 0 := by
+      rw [← hf_alg, hfg, hg0]
+    have hzl_eq : zeroLocus ↑(RingHom.ker (algebraMap A (RestrictClopen W))) =
+        (W : Set (PrimeSpectrum A)) := by
+      rw [← range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
+        (IsLocalization.Away.algebraMap_surjective_of_isIdempotentElem _
+          (isIdempotentElemEquivClopens.symm W).prop),
+        restrictClopen_range_eq]
+    have hker_le : RingHom.ker (algebraMap A (RestrictClopen W)) ≤ p.asIdeal := by
+      rw [← SetLike.coe_subset_coe, ← PrimeSpectrum.mem_zeroLocus]
+      exact hzl_eq ▸ hW hp
+    exact SetLike.mem_coe.mp (hker_le (RingHom.mem_ker.mpr ha_zero))
 
-lemma isClosedEmbedding_algebraMap_specComap (h : IsClosed T) :
+lemma isClosedEmbedding_algebraMap_specComap (_h : IsClosed T) :
     IsClosedEmbedding (PrimeSpectrum.comap <| algebraMap A (Restriction T)) :=
-  sorry
+  PrimeSpectrum.isClosedEmbedding_comap_of_surjective (Restriction T)
+    (algebraMap A (Restriction T)) (algebraMap_surjective T)
 
 end Restriction
 

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -79,6 +79,13 @@ def map {W₁ W₂ : Clopens (PrimeSpectrum A)} (h : W₁ ≤ W₂) :
   toRingHom := lift (isIdempotentElemEquivClopens.symm W₂).val (isUnit_of_dvd _ (val_dvd h))
   commutes' r := by simp
 
+/-- The range of `Spec`-side comap of the algebra map `A → RestrictClopen W` is `W`. -/
+lemma range_comap (W : Clopens (PrimeSpectrum A)) :
+    Set.range (PrimeSpectrum.comap (algebraMap A (RestrictClopen W))) =
+      (W : Set (PrimeSpectrum A)) := by
+  rw [localization_away_comap_range (RestrictClopen W) (isIdempotentElemEquivClopens.symm W).val]
+  exact congr_arg Opens.carrier (basicOpen_isIdempotentElemEquivClopens_symm W)
+
 end RestrictClopen
 
 open scoped CategoryTheory
@@ -150,12 +157,17 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap A (Restriction T))
 
 variable {T}
 
-private lemma restrictClopen_range_eq (W : Clopens (PrimeSpectrum A)) :
-    Set.range (PrimeSpectrum.comap (algebraMap A (RestrictClopen W))) =
+/-- The zero locus of the kernel of `A → RestrictClopen W` equals `W`. -/
+private lemma zeroLocus_ker_restrictClopen_eq (W : Clopens (PrimeSpectrum A)) :
+    zeroLocus (RingHom.ker (algebraMap A (RestrictClopen W)) : Set A) =
       (W : Set (PrimeSpectrum A)) := by
-  rw [localization_away_comap_range (RestrictClopen W) (isIdempotentElemEquivClopens.symm W).val]
-  exact congr_arg Opens.carrier (basicOpen_isIdempotentElemEquivClopens_symm W)
+  rw [← range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
+        (IsLocalization.Away.algebraMap_surjective_of_isIdempotentElem _
+          (isIdempotentElemEquivClopens.symm W).prop),
+      RestrictClopen.range_comap]
 
+/-- For `W` a clopen containing the preimage of `T`, the kernel of `A → RestrictClopen W`
+is contained in the kernel of the algebra map into the colimit `Restriction T`. -/
 private lemma ker_algebraMap_restrictClopen_le
     {W : Clopens (PrimeSpectrum A)} (hW : ConnectedComponents.mk ⁻¹' T ≤ W) :
     RingHom.ker (algebraMap A (RestrictClopen W)) ≤
@@ -164,90 +176,65 @@ private lemma ker_algebraMap_restrictClopen_le
   rw [RingHom.mem_ker] at ha ⊢
   let ι : RestrictClopen W →ₐ[A] Restriction T :=
     (colimit.ι (Restriction.diag T) (Opposite.op ⟨W, hW⟩)).hom
-  calc algebraMap A (Restriction T) a = ι (algebraMap A (RestrictClopen W) a) :=
-        (ι.commutes a).symm
+  calc algebraMap A (Restriction T) a
+      = ι (algebraMap A (RestrictClopen W) a) := (ι.commutes a).symm
     _ = ι 0 := by rw [ha]
     _ = 0 := map_zero _
 
+/-- The image of `Spec(Restriction T) → Spec A` is the preimage of `T` under the projection
+`Spec A → π₀(Spec A)`, whenever `T` is closed. -/
 lemma range_algebraMap_specComap (h : IsClosed T) :
     Set.range (PrimeSpectrum.comap <| algebraMap A (Restriction T)) =
       ConnectedComponents.mk ⁻¹' T := by
   rw [range_comap_of_surjective _ _ (algebraMap_surjective T)]
-  apply Set.Subset.antisymm
-  · intro p hp
-    have hp_in_W : ∀ (W : Clopens (PrimeSpectrum A)),
-        ConnectedComponents.mk ⁻¹' T ≤ W → p ∈ (W : Set (PrimeSpectrum A)) := by
-      intro W hW
-      have hzl : zeroLocus (RingHom.ker (algebraMap A (Restriction T)) : Set A) ⊆
-          zeroLocus (RingHom.ker (algebraMap A (RestrictClopen W)) : Set A) :=
-        zeroLocus_anti_mono (ker_algebraMap_restrictClopen_le (T := T) hW)
-      have hrW := range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
-        (IsLocalization.Away.algebraMap_surjective_of_isIdempotentElem _
-          (isIdempotentElemEquivClopens.symm W).prop)
-      rw [← restrictClopen_range_eq W, hrW]
-      exact hzl hp
-    have hclosed : IsClosed (ConnectedComponents.mk ⁻¹' T : Set (PrimeSpectrum A)) :=
-      h.preimage ConnectedComponents.continuous_coe
-    have hunion : ∃ I : Set (PrimeSpectrum A),
-        ⋃ x ∈ I, connectedComponent x = ConnectedComponents.mk ⁻¹' T := by
-      refine ⟨ConnectedComponents.mk ⁻¹' T, ?_⟩
-      ext x
-      simp only [Set.mem_iUnion, Set.mem_preimage]
-      refine ⟨?_, fun hx ↦ ⟨x, hx, mem_connectedComponent⟩⟩
-      rintro ⟨y, hy, hxy⟩
-      have : (x : ConnectedComponents (PrimeSpectrum A)) = (y : _) :=
-        ConnectedComponents.coe_eq_coe'.mpr hxy
-      exact this ▸ hy
-    obtain ⟨J, hJ⟩ := isClosed_and_iUnion_connectedComponent_eq_iff.1 ⟨hclosed, hunion⟩
+  refine Set.Subset.antisymm ?_ ?_
+  · -- ⊆: any prime in `V(ker)` lies in every clopen containing the preimage of `T`,
+    -- hence in the intersection of all such clopens, which is the preimage of `T`
+    -- by Stacks 04PL.
+    intro p hp
+    have hp_mem_W : ∀ (W : Clopens (PrimeSpectrum A)),
+        ConnectedComponents.mk ⁻¹' T ≤ W → p ∈ (W : Set (PrimeSpectrum A)) := fun W hW ↦ by
+      rw [← zeroLocus_ker_restrictClopen_eq W]
+      exact zeroLocus_anti_mono (ker_algebraMap_restrictClopen_le (T := T) hW) hp
+    obtain ⟨J, hJ⟩ := isClosed_and_iUnion_connectedComponent_eq_iff.mp
+      ⟨h.preimage ConnectedComponents.continuous_coe,
+        _, ConnectedComponents.iUnion_connectedComponent_preimage_mk T⟩
     rw [← hJ]
     simp only [Set.iInter_coe_set, Set.mem_iInter, Subtype.forall]
     intro V hV hVJ
-    have hTsubV : ConnectedComponents.mk ⁻¹' T ≤
-        (⟨V, hV⟩ : {U : Set (PrimeSpectrum A) // IsClopen U}).val := by
-      rw [← hJ]
-      exact Set.iInter_subset_of_subset ⟨⟨V, hV⟩, hVJ⟩ le_rfl
-    exact hp_in_W ⟨V, hV⟩ hTsubV
-  · intro p hp
+    refine hp_mem_W ⟨V, hV⟩ ?_
+    rw [← hJ]
+    exact Set.iInter_subset_of_subset ⟨⟨V, hV⟩, hVJ⟩ le_rfl
+  · -- ⊇: given `a ∈ ker(A → Restriction T)`, the equality criterion for filtered colimits
+    -- yields a clopen `W ⊇ T` at which `a` already vanishes. Then `p ∈ W` forces `a ∈ p`.
+    intro p hp
     rw [mem_zeroLocus]
     intro a ha
     rw [SetLike.mem_coe, RingHom.mem_ker] at ha
-    let top_idx : {W : Clopens (PrimeSpectrum A) // ConnectedComponents.mk ⁻¹' T ≤ W} :=
-      ⟨⊤, le_top⟩
-    let ι_top := colimit.ι (Restriction.diag T) (Opposite.op top_idx)
+    let ι_top := colimit.ι (Restriction.diag T) (Opposite.op ⟨(⊤ : Clopens _), le_top⟩)
     have heq_in_colim : ι_top.hom (algebraMap A (RestrictClopen ⊤) a) =
         ι_top.hom (0 : RestrictClopen ⊤) :=
       (ι_top.hom.commutes a).trans (ha.trans (map_zero ι_top.hom).symm)
-    have hc' := isColimitOfPreserves (CategoryTheory.forget (CommAlgCat A))
-      (colimit.isColimit (Restriction.diag T))
-    have heq_types : (CategoryTheory.forget (CommAlgCat A)).map ι_top
-        (algebraMap A (RestrictClopen ⊤) a) =
-        (CategoryTheory.forget (CommAlgCat A)).map ι_top (0 : RestrictClopen ⊤) :=
-      heq_in_colim
-    obtain ⟨k, f_top_k, g_top_k, hfg⟩ :=
+    obtain ⟨k, f, g, hfg⟩ :=
       (Types.FilteredColimit.isColimit_eq_iff
-        (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)) hc').mp heq_types
+        (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A))
+        (isColimitOfPreserves (CategoryTheory.forget (CommAlgCat A))
+          (colimit.isColimit (Restriction.diag T)))).mp heq_in_colim
     let W := k.unop.val
     have hW : ConnectedComponents.mk ⁻¹' T ≤ W := k.unop.property
-    have hg0 : (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)).map g_top_k
-        (0 : RestrictClopen ⊤) = (0 : RestrictClopen W) :=
-      map_zero ((Restriction.diag T).map g_top_k).hom
-    have hf_alg : (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)).map f_top_k
+    have hf_alg : (Restriction.diag T ⋙ CategoryTheory.forget (CommAlgCat A)).map f
         (algebraMap A (RestrictClopen ⊤) a) = algebraMap A (RestrictClopen W) a :=
-      ((Restriction.diag T).map f_top_k).hom.commutes a
+      ((Restriction.diag T).map f).hom.commutes a
     have ha_zero : algebraMap A (RestrictClopen W) a = 0 := by
-      rw [← hf_alg, hfg, hg0]
-    have hzl_eq : zeroLocus ↑(RingHom.ker (algebraMap A (RestrictClopen W))) =
-        (W : Set (PrimeSpectrum A)) := by
-      rw [← range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
-        (IsLocalization.Away.algebraMap_surjective_of_isIdempotentElem _
-          (isIdempotentElemEquivClopens.symm W).prop),
-        restrictClopen_range_eq]
+      rw [← hf_alg, hfg]
+      exact map_zero ((Restriction.diag T).map g).hom
     have hker_le : RingHom.ker (algebraMap A (RestrictClopen W)) ≤ p.asIdeal := by
       rw [← SetLike.coe_subset_coe, ← PrimeSpectrum.mem_zeroLocus]
-      exact hzl_eq ▸ hW hp
-    exact SetLike.mem_coe.mp (hker_le (RingHom.mem_ker.mpr ha_zero))
+      exact zeroLocus_ker_restrictClopen_eq W ▸ hW hp
+    exact hker_le (RingHom.mem_ker.mpr ha_zero)
 
-lemma isClosedEmbedding_algebraMap_specComap (_h : IsClosed T) :
+/-- The map `Spec(Restriction T) → Spec A` is a closed embedding. -/
+lemma isClosedEmbedding_algebraMap_specComap :
     IsClosedEmbedding (PrimeSpectrum.comap <| algebraMap A (Restriction T)) :=
   PrimeSpectrum.isClosedEmbedding_comap_of_surjective (Restriction T)
     (algebraMap A (Restriction T)) (algebraMap_surjective T)

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -158,7 +158,7 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap A (Restriction T))
 variable {T}
 
 /-- The zero locus of the kernel of `A → RestrictClopen W` equals `W`. -/
-private lemma zeroLocus_ker_restrictClopen_eq (W : Clopens (PrimeSpectrum A)) :
+lemma zeroLocus_ker_restrictClopen_eq (W : Clopens (PrimeSpectrum A)) :
     zeroLocus (RingHom.ker (algebraMap A (RestrictClopen W)) : Set A) =
       (W : Set (PrimeSpectrum A)) := by
   rw [← range_comap_of_surjective (RestrictClopen W) (algebraMap A (RestrictClopen W))
@@ -168,7 +168,7 @@ private lemma zeroLocus_ker_restrictClopen_eq (W : Clopens (PrimeSpectrum A)) :
 
 /-- For `W` a clopen containing the preimage of `T`, the kernel of `A → RestrictClopen W`
 is contained in the kernel of the algebra map into the colimit `Restriction T`. -/
-private lemma ker_algebraMap_restrictClopen_le
+lemma ker_algebraMap_restrictClopen_le
     {W : Clopens (PrimeSpectrum A)} (hW : ConnectedComponents.mk ⁻¹' T ≤ W) :
     RingHom.ker (algebraMap A (RestrictClopen W)) ≤
       RingHom.ker (algebraMap A (Restriction T)) := by

--- a/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
+++ b/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
@@ -12,6 +12,17 @@ lemma Specializes.connectedComponents_mk_eq {a b : X} (hab : a ⤳ b) :
     isConnected_singleton.closure.subset_connectedComponent
       (subset_closure rfl) hab.mem_closure
 
+/-- Any preimage under `ConnectedComponents.mk` is a union of connected components. -/
+lemma ConnectedComponents.iUnion_connectedComponent_preimage_mk
+    (T : Set (ConnectedComponents X)) :
+    ⋃ x ∈ (ConnectedComponents.mk ⁻¹' T : Set X), connectedComponent x =
+      ConnectedComponents.mk ⁻¹' T := by
+  ext x
+  simp only [Set.mem_iUnion, Set.mem_preimage, exists_prop]
+  refine ⟨?_, fun hx ↦ ⟨x, hx, mem_connectedComponent⟩⟩
+  rintro ⟨y, hy, hxy⟩
+  exact (ConnectedComponents.coe_eq_coe'.mpr hxy) ▸ hy
+
 -- add `@[stacks 0906]` to `ConnectedComponents.totallyDisconnectedSpace`
 
 -- after `IsPreconnected.eqOn_const_of_mapsTo` if the proof need some lemma of the form

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -2087,6 +2087,7 @@ The goal of this section is to show that every ring $A$ admits a faithfully flat
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{thm:intersection-closed-open-iff}
   Each $A \to A_W$ is a localization at an idempotent. Passing to filtered colimits, $A \to A_T$ is surjective and ind-Zariski.
 


### PR DESCRIPTION
## Summary

Fills two sorries in `WContractification.Restriction` (Proetale/Algebra/WContractible.lean) describing the prime spectrum of `A_T = colim_{Z ⊆ W} A_W` (where `Z = mk⁻¹' T` for a closed `T ⊆ π₀(Spec A)`):

- `range_algebraMap_specComap`: the image of `Spec(A_T) → Spec(A)` is `Z`.
- `isClosedEmbedding_algebraMap_specComap`: this map is a closed embedding.

The proofs proceed via:
1. **Forward (`⊆`).** Show `Spec(A_T)` has image inside every clopen `W ⊇ Z`. Using `thm:intersection-closed-open-iff` (`isClosed_and_iUnion_connectedComponent_eq_iff`), `Z` is the intersection of the clopens containing it, so any prime in the image lies in `Z`.
2. **Backward (`⊇`).** For `p ∈ Z` and `a` in the kernel of `A → A_T`, use the filtered-colimit equality criterion (`Types.FilteredColimit.isColimit_eq_iff`) to find a stage `W ⊇ Z` at which the image of `a` already vanishes, hence `a ∈ p.asIdeal` since `p ∈ W = zeroLocus (ker (A → A_W))`.
3. The closed-embedding statement is immediate from surjectivity of `A → A_T` (`PrimeSpectrum.isClosedEmbedding_comap_of_surjective`).

Two private helpers are added:
- `restrictClopen_range_eq`: the range of `Spec(A_W) → Spec(A)` is `W` as a set.
- `ker_algebraMap_restrictClopen_le`: each `ker(A → A_W)` is contained in `ker(A → A_T)`.

Also adds `\leanok` to the blueprint proof of `thm:colim-open-closed-localizations-surj-ind-zariski` (Stacks [097C](https://stacks.math.columbia.edu/tag/097C)), now that all four `\lean{...}` items in the statement (`indZariski`, `algebraMap_surjective`, `range_algebraMap_specComap`, `isClosedEmbedding_algebraMap_specComap`) are sorry-free.

Proofs ported from the `archon` branch.

## Test plan

- [x] `lake build --wfail Proetale.Algebra.WContractible` succeeds with no warnings.
- [x] `lake build --wfail Proetale` (full project) succeeds.
- [x] No downstream callers of the two filled lemmas needed updating.