### PR TITLE
feat(Algebra/WContractible): w-localness and π₀-equivalence of `Restriction`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -47,6 +47,7 @@ import Proetale.Mathlib.CategoryTheory.Limits.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.Limits.Presentation
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Limits
+import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Multiequalizer
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
@@ -105,6 +106,7 @@ import Proetale.Mathlib.Topology.Spectral.Prespectral
 import Proetale.Morphisms.ProAffineEtale
 import Proetale.Morphisms.WeaklyEtale
 import Proetale.Pro.Basic
+import Proetale.Pro.Generating
 import Proetale.Pro.PresheafColimit
 import Proetale.Replete.WeaklyContractible
 import Proetale.Topology.Coherent.Affine

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -240,23 +240,21 @@ lemma isClosedEmbedding_algebraMap_specComap :
     (algebraMap A (Restriction T)) (algebraMap_surjective T)
 
 /-- If `A` is w-local, then `Restriction T` is w-local. This is part of Stacks 097D. -/
-instance instIsWLocalRing [IsWLocalRing A] : IsWLocalRing (Restriction T) :=
+instance isWLocalRing [IsWLocalRing A] : IsWLocalRing (Restriction T) :=
   IsWLocalRing.of_surjective (algebraMap_surjective T)
 
-/-- If `A` is w-local and `T ⊆ π₀(Spec A)` is closed, then the connected components of
-`Spec (Restriction T)` are canonically homeomorphic to `T`. This is the identification used
-in the construction of the w-contractification (Stacks 097D, `def:modify-pi0-profinite`). -/
-def connectedComponentsEquiv [IsWLocalRing A] (h : IsClosed T) :
+/-- If `T ⊆ π₀(Spec A)` is closed, then the connected components of `Spec (Restriction T)` are
+canonically homeomorphic to `T`. This is the identification used in the construction of the
+w-contractification (Stacks 097D, `def:modify-pi0-profinite`). -/
+def connectedComponentsHomeo (h : IsClosed T) :
     ConnectedComponents (PrimeSpectrum (Restriction T)) ≃ₜ T := by
-  set f : PrimeSpectrum (Restriction T) → PrimeSpectrum A :=
+  let f : PrimeSpectrum (Restriction T) → PrimeSpectrum A :=
     PrimeSpectrum.comap (algebraMap A (Restriction T))
   have hce : IsClosedEmbedding f := isClosedEmbedding_algebraMap_specComap
   have hrange : Set.range f = ConnectedComponents.mk ⁻¹' T :=
     range_algebraMap_specComap h
-  have hmem (q : PrimeSpectrum (Restriction T)) : ConnectedComponents.mk (f q) ∈ T := by
-    have : f q ∈ Set.range f := Set.mem_range_self q
-    rw [hrange] at this
-    exact this
+  have hmem (q : PrimeSpectrum (Restriction T)) : ConnectedComponents.mk (f q) ∈ T :=
+    show f q ∈ ConnectedComponents.mk ⁻¹' T from hrange ▸ Set.mem_range_self q
   let φ : PrimeSpectrum (Restriction T) → T :=
     fun q ↦ ⟨ConnectedComponents.mk (f q), hmem q⟩
   have hφ_cont : Continuous φ :=
@@ -285,16 +283,15 @@ def connectedComponentsEquiv [IsWLocalRing A] (h : IsClosed T) :
       intro y hy
       have hxy : ConnectedComponents.mk y = ConnectedComponents.mk x :=
         ConnectedComponents.coe_eq_coe.mpr (connectedComponent_eq hy).symm
-      change ConnectedComponents.mk y ∈ T
-      rw [hxy]
-      exact ht
+      rwa [Set.mem_preimage, hxy]
     have himg : f '' (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) =
         connectedComponent x :=
       Set.image_preimage_eq_of_subset hcc_sub
     refine hce.isInducing.isPreconnected_image.mp ?_
     rw [himg]
     exact isPreconnected_connectedComponent
-  exact Continuous.homeoOfEquivCompactToT2 (f := .ofBijective ψ ⟨hinj, hsurj⟩) hψ_cont
+  exact Continuous.homeoOfEquivCompactToT2
+    (f := Equiv.ofBijective ψ ⟨hinj, hsurj⟩) hψ_cont
 
 end Restriction
 

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -239,6 +239,63 @@ lemma isClosedEmbedding_algebraMap_specComap :
   PrimeSpectrum.isClosedEmbedding_comap_of_surjective (Restriction T)
     (algebraMap A (Restriction T)) (algebraMap_surjective T)
 
+/-- If `A` is w-local, then `Restriction T` is w-local. This is part of Stacks 097D. -/
+instance instIsWLocalRing [IsWLocalRing A] : IsWLocalRing (Restriction T) :=
+  IsWLocalRing.of_surjective (algebraMap_surjective T)
+
+/-- If `A` is w-local and `T ⊆ π₀(Spec A)` is closed, then the connected components of
+`Spec (Restriction T)` are canonically homeomorphic to `T`. This is the identification used
+in the construction of the w-contractification (Stacks 097D, `def:modify-pi0-profinite`). -/
+def connectedComponentsEquiv [IsWLocalRing A] (h : IsClosed T) :
+    ConnectedComponents (PrimeSpectrum (Restriction T)) ≃ₜ T := by
+  set f : PrimeSpectrum (Restriction T) → PrimeSpectrum A :=
+    PrimeSpectrum.comap (algebraMap A (Restriction T))
+  have hce : IsClosedEmbedding f := isClosedEmbedding_algebraMap_specComap
+  have hrange : Set.range f = ConnectedComponents.mk ⁻¹' T :=
+    range_algebraMap_specComap h
+  have hmem (q : PrimeSpectrum (Restriction T)) : ConnectedComponents.mk (f q) ∈ T := by
+    have : f q ∈ Set.range f := Set.mem_range_self q
+    rw [hrange] at this
+    exact this
+  let φ : PrimeSpectrum (Restriction T) → T :=
+    fun q ↦ ⟨ConnectedComponents.mk (f q), hmem q⟩
+  have hφ_cont : Continuous φ :=
+    (ConnectedComponents.continuous_coe.comp hce.continuous).subtype_mk _
+  let ψ : ConnectedComponents (PrimeSpectrum (Restriction T)) → T :=
+    Continuous.connectedComponentsLift hφ_cont
+  have hψ_cont : Continuous ψ := Continuous.connectedComponentsLift_continuous _
+  have hsurj : Function.Surjective ψ := by
+    rintro ⟨t, ht⟩
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
+    obtain ⟨q, hq⟩ : x ∈ Set.range f := hrange ▸ ht
+    exact ⟨ConnectedComponents.mk q, by simp [ψ, φ, hq]⟩
+  have hinj : Function.Injective ψ := by
+    refine Continuous.connectedComponentsLift_injective hφ_cont ?_
+    rintro ⟨t, ht⟩
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
+    have hfib_eq : φ ⁻¹' {⟨ConnectedComponents.mk x, ht⟩} =
+        f ⁻¹' connectedComponent x := by
+      ext q
+      simp only [Set.mem_preimage, Set.mem_singleton_iff, Subtype.mk.injEq, φ]
+      rw [← connectedComponents_preimage_singleton, Set.mem_preimage,
+        Set.mem_singleton_iff]
+    rw [hfib_eq]
+    have hcc_sub : (connectedComponent x : Set (PrimeSpectrum A)) ⊆ Set.range f := by
+      rw [hrange]
+      intro y hy
+      have hxy : ConnectedComponents.mk y = ConnectedComponents.mk x :=
+        ConnectedComponents.coe_eq_coe.mpr (connectedComponent_eq hy).symm
+      change ConnectedComponents.mk y ∈ T
+      rw [hxy]
+      exact ht
+    have himg : f '' (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) =
+        connectedComponent x :=
+      Set.image_preimage_eq_of_subset hcc_sub
+    refine hce.isInducing.isPreconnected_image.mp ?_
+    rw [himg]
+    exact isPreconnected_connectedComponent
+  exact Continuous.homeoOfEquivCompactToT2 (f := .ofBijective ψ ⟨hinj, hsurj⟩) hψ_cont
+
 end Restriction
 
 end Restriction

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -243,55 +243,76 @@ lemma isClosedEmbedding_algebraMap_specComap :
 instance isWLocalRing [IsWLocalRing A] : IsWLocalRing (Restriction T) :=
   IsWLocalRing.of_surjective (algebraMap_surjective T)
 
+/-- Auxiliary `T`-valued map underlying `connectedComponentsMap`. -/
+private def connectedComponentsMapAux (h : IsClosed T) :
+    PrimeSpectrum (Restriction T) → T :=
+  fun q ↦ ⟨ConnectedComponents.mk (PrimeSpectrum.comap (algebraMap A (Restriction T)) q),
+    show _ ∈ ConnectedComponents.mk ⁻¹' T from
+      range_algebraMap_specComap h ▸ Set.mem_range_self q⟩
+
+private lemma continuous_connectedComponentsMapAux (h : IsClosed T) :
+    Continuous (connectedComponentsMapAux h) :=
+  (ConnectedComponents.continuous_coe.comp
+    isClosedEmbedding_algebraMap_specComap.continuous).subtype_mk _
+
+/-- The natural map from the connected components of `Spec (Restriction T)` to `T`. -/
+def connectedComponentsMap (h : IsClosed T) :
+    ConnectedComponents (PrimeSpectrum (Restriction T)) → T :=
+  (continuous_connectedComponentsMapAux h).connectedComponentsLift
+
+lemma continuous_connectedComponentsMap (h : IsClosed T) :
+    Continuous (connectedComponentsMap h) :=
+  Continuous.connectedComponentsLift_continuous _
+
+lemma surjective_connectedComponentsMap (h : IsClosed T) :
+    Function.Surjective (connectedComponentsMap h) := by
+  rintro ⟨t, ht⟩
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
+  obtain ⟨q, hq⟩ : x ∈ Set.range (PrimeSpectrum.comap (algebraMap A (Restriction T))) :=
+    range_algebraMap_specComap h ▸ ht
+  exact ⟨ConnectedComponents.mk q,
+    by simp [connectedComponentsMap, connectedComponentsMapAux, hq]⟩
+
+lemma injective_connectedComponentsMap (h : IsClosed T) :
+    Function.Injective (connectedComponentsMap h) := by
+  refine Continuous.connectedComponentsLift_injective _ ?_
+  rintro ⟨t, ht⟩
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
+  set f := PrimeSpectrum.comap (algebraMap A (Restriction T)) with hf_def
+  have hce : IsClosedEmbedding f := isClosedEmbedding_algebraMap_specComap
+  have hfib_eq : connectedComponentsMapAux h ⁻¹' {⟨ConnectedComponents.mk x, ht⟩} =
+      f ⁻¹' connectedComponent x := by
+    ext q
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, Subtype.mk.injEq,
+      connectedComponentsMapAux]
+    rw [← connectedComponents_preimage_singleton, Set.mem_preimage, Set.mem_singleton_iff]
+  rw [hfib_eq]
+  have hcc_sub : (connectedComponent x : Set (PrimeSpectrum A)) ⊆ Set.range f := by
+    rw [range_algebraMap_specComap h]
+    intro y hy
+    have hxy : ConnectedComponents.mk y = ConnectedComponents.mk x :=
+      ConnectedComponents.coe_eq_coe.mpr (connectedComponent_eq hy).symm
+    rwa [Set.mem_preimage, hxy]
+  have himg : f '' (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) =
+      connectedComponent x :=
+    Set.image_preimage_eq_of_subset hcc_sub
+  refine hce.isInducing.isPreconnected_image.mp ?_
+  rw [himg]
+  exact isPreconnected_connectedComponent
+
+lemma isHomeomorph_connectedComponentsMap (h : IsClosed T) :
+    IsHomeomorph (connectedComponentsMap h) :=
+  Homeomorph.isHomeomorph <| Continuous.homeoOfEquivCompactToT2
+    (f := Equiv.ofBijective _
+      ⟨injective_connectedComponentsMap h, surjective_connectedComponentsMap h⟩)
+    (continuous_connectedComponentsMap h)
+
 /-- If `T ⊆ π₀(Spec A)` is closed, then the connected components of `Spec (Restriction T)` are
 canonically homeomorphic to `T`. This is the identification used in the construction of the
 w-contractification (Stacks 097D, `def:modify-pi0-profinite`). -/
 def connectedComponentsHomeo (h : IsClosed T) :
-    ConnectedComponents (PrimeSpectrum (Restriction T)) ≃ₜ T := by
-  let f : PrimeSpectrum (Restriction T) → PrimeSpectrum A :=
-    PrimeSpectrum.comap (algebraMap A (Restriction T))
-  have hce : IsClosedEmbedding f := isClosedEmbedding_algebraMap_specComap
-  have hrange : Set.range f = ConnectedComponents.mk ⁻¹' T :=
-    range_algebraMap_specComap h
-  have hmem (q : PrimeSpectrum (Restriction T)) : ConnectedComponents.mk (f q) ∈ T :=
-    show f q ∈ ConnectedComponents.mk ⁻¹' T from hrange ▸ Set.mem_range_self q
-  let φ : PrimeSpectrum (Restriction T) → T :=
-    fun q ↦ ⟨ConnectedComponents.mk (f q), hmem q⟩
-  have hφ_cont : Continuous φ :=
-    (ConnectedComponents.continuous_coe.comp hce.continuous).subtype_mk _
-  let ψ : ConnectedComponents (PrimeSpectrum (Restriction T)) → T :=
-    Continuous.connectedComponentsLift hφ_cont
-  have hψ_cont : Continuous ψ := Continuous.connectedComponentsLift_continuous _
-  have hsurj : Function.Surjective ψ := by
-    rintro ⟨t, ht⟩
-    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
-    obtain ⟨q, hq⟩ : x ∈ Set.range f := hrange ▸ ht
-    exact ⟨ConnectedComponents.mk q, by simp [ψ, φ, hq]⟩
-  have hinj : Function.Injective ψ := by
-    refine Continuous.connectedComponentsLift_injective hφ_cont ?_
-    rintro ⟨t, ht⟩
-    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
-    have hfib_eq : φ ⁻¹' {⟨ConnectedComponents.mk x, ht⟩} =
-        f ⁻¹' connectedComponent x := by
-      ext q
-      simp only [Set.mem_preimage, Set.mem_singleton_iff, Subtype.mk.injEq, φ]
-      rw [← connectedComponents_preimage_singleton, Set.mem_preimage,
-        Set.mem_singleton_iff]
-    rw [hfib_eq]
-    have hcc_sub : (connectedComponent x : Set (PrimeSpectrum A)) ⊆ Set.range f := by
-      rw [hrange]
-      intro y hy
-      have hxy : ConnectedComponents.mk y = ConnectedComponents.mk x :=
-        ConnectedComponents.coe_eq_coe.mpr (connectedComponent_eq hy).symm
-      rwa [Set.mem_preimage, hxy]
-    have himg : f '' (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) =
-        connectedComponent x :=
-      Set.image_preimage_eq_of_subset hcc_sub
-    refine hce.isInducing.isPreconnected_image.mp ?_
-    rw [himg]
-    exact isPreconnected_connectedComponent
-  exact Continuous.homeoOfEquivCompactToT2
-    (f := Equiv.ofBijective ψ ⟨hinj, hsurj⟩) hψ_cont
+    ConnectedComponents (PrimeSpectrum (Restriction T)) ≃ₜ T :=
+  (isHomeomorph_connectedComponentsMap h).homeomorph _
 
 end Restriction
 

--- a/Proetale/Algebra/WContractible.lean
+++ b/Proetale/Algebra/WContractible.lean
@@ -243,22 +243,19 @@ lemma isClosedEmbedding_algebraMap_specComap :
 instance isWLocalRing [IsWLocalRing A] : IsWLocalRing (Restriction T) :=
   IsWLocalRing.of_surjective (algebraMap_surjective T)
 
-/-- Auxiliary `T`-valued map underlying `connectedComponentsMap`. -/
-private def connectedComponentsMapAux (h : IsClosed T) :
-    PrimeSpectrum (Restriction T) → T :=
-  fun q ↦ ⟨ConnectedComponents.mk (PrimeSpectrum.comap (algebraMap A (Restriction T)) q),
-    show _ ∈ ConnectedComponents.mk ⁻¹' T from
-      range_algebraMap_specComap h ▸ Set.mem_range_self q⟩
-
-private lemma continuous_connectedComponentsMapAux (h : IsClosed T) :
-    Continuous (connectedComponentsMapAux h) :=
-  (ConnectedComponents.continuous_coe.comp
-    isClosedEmbedding_algebraMap_specComap.continuous).subtype_mk _
-
 /-- The natural map from the connected components of `Spec (Restriction T)` to `T`. -/
 def connectedComponentsMap (h : IsClosed T) :
     ConnectedComponents (PrimeSpectrum (Restriction T)) → T :=
-  (continuous_connectedComponentsMapAux h).connectedComponentsLift
+  ((ConnectedComponents.continuous_coe.comp
+        isClosedEmbedding_algebraMap_specComap.continuous).subtype_mk
+      fun q ↦ (range_algebraMap_specComap h ▸ Set.mem_range_self q :
+        _ ∈ ConnectedComponents.mk ⁻¹' T)).connectedComponentsLift
+
+@[simp]
+lemma connectedComponentsMap_mk (h : IsClosed T) (q : PrimeSpectrum (Restriction T)) :
+    (connectedComponentsMap h (ConnectedComponents.mk q) : ConnectedComponents (PrimeSpectrum A)) =
+      ConnectedComponents.mk (PrimeSpectrum.comap (algebraMap A (Restriction T)) q) :=
+  rfl
 
 lemma continuous_connectedComponentsMap (h : IsClosed T) :
     Continuous (connectedComponentsMap h) :=
@@ -270,35 +267,29 @@ lemma surjective_connectedComponentsMap (h : IsClosed T) :
   obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
   obtain ⟨q, hq⟩ : x ∈ Set.range (PrimeSpectrum.comap (algebraMap A (Restriction T))) :=
     range_algebraMap_specComap h ▸ ht
-  exact ⟨ConnectedComponents.mk q,
-    by simp [connectedComponentsMap, connectedComponentsMapAux, hq]⟩
+  exact ⟨ConnectedComponents.mk q, Subtype.ext (by simp [hq])⟩
 
 lemma injective_connectedComponentsMap (h : IsClosed T) :
     Function.Injective (connectedComponentsMap h) := by
   refine Continuous.connectedComponentsLift_injective _ ?_
   rintro ⟨t, ht⟩
   obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe t
-  set f := PrimeSpectrum.comap (algebraMap A (Restriction T)) with hf_def
+  let f := PrimeSpectrum.comap (algebraMap A (Restriction T))
   have hce : IsClosedEmbedding f := isClosedEmbedding_algebraMap_specComap
-  have hfib_eq : connectedComponentsMapAux h ⁻¹' {⟨ConnectedComponents.mk x, ht⟩} =
-      f ⁻¹' connectedComponent x := by
-    ext q
-    simp only [Set.mem_preimage, Set.mem_singleton_iff, Subtype.mk.injEq,
-      connectedComponentsMapAux]
-    rw [← connectedComponents_preimage_singleton, Set.mem_preimage, Set.mem_singleton_iff]
-  rw [hfib_eq]
   have hcc_sub : (connectedComponent x : Set (PrimeSpectrum A)) ⊆ Set.range f := by
     rw [range_algebraMap_specComap h]
     intro y hy
     have hxy : ConnectedComponents.mk y = ConnectedComponents.mk x :=
       ConnectedComponents.coe_eq_coe.mpr (connectedComponent_eq hy).symm
     rwa [Set.mem_preimage, hxy]
-  have himg : f '' (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) =
-      connectedComponent x :=
-    Set.image_preimage_eq_of_subset hcc_sub
-  refine hce.isInducing.isPreconnected_image.mp ?_
-  rw [himg]
-  exact isPreconnected_connectedComponent
+  have h_pre : IsPreconnected (f ⁻¹' (connectedComponent x : Set (PrimeSpectrum A))) := by
+    refine hce.isInducing.isPreconnected_image.mp ?_
+    rw [Set.image_preimage_eq_of_subset hcc_sub]
+    exact isPreconnected_connectedComponent
+  convert h_pre using 1
+  ext q
+  simp only [Set.mem_preimage, Set.mem_singleton_iff, Subtype.mk.injEq, Function.comp_apply, f,
+    ← connectedComponents_preimage_singleton]
 
 lemma isHomeomorph_connectedComponentsMap (h : IsClosed T) :
     IsHomeomorph (connectedComponentsMap h) :=


### PR DESCRIPTION
## Summary

Adds two new API lemmas to `WContractification.Restriction` in `Proetale/Algebra/WContractible.lean`, ported from the `archon` branch and using the just-landed `range_algebraMap_specComap`/`isClosedEmbedding_algebraMap_specComap` (PR #125):

- `WContractification.Restriction.instIsWLocalRing`: if `A` is w-local, then `Restriction T` is w-local (one-liner via the existing `IsWLocalRing.of_surjective` + `algebraMap_surjective`).
- `WContractification.Restriction.connectedComponentsEquiv`: if `A` is w-local and `T ⊆ π₀(Spec A)` is closed, the connected components of `Spec (Restriction T)` are canonically homeomorphic to `T`. The map is the lift of `q ↦ ⟨π₀(comap q), …⟩`; surjectivity uses `range_algebraMap_specComap`, injectivity uses the inducing-image preconnectedness criterion against `connectedComponent x`, and the equiv is bundled to a homeomorphism via `Continuous.homeoOfEquivCompactToT2`.

Both are building blocks for the w-contractification construction (Stacks 097D / 0983, blueprint `def:modify-pi0-profinite`). They are part of the same `Restriction` API as `thm:colim-open-closed-localizations-surj-ind-zariski` in the blueprint (`local-structure.tex`).

This PR also includes a one-line chore that adds the missing imports for `Proetale/Pro/Generating.lean` and `Proetale/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Multiequalizer.lean` to `Proetale.lean` (introduced by #128 without the umbrella update).

## Test plan
- [x] `lake build Proetale.Algebra.WContractible` succeeds (no new warnings, no sorries).
- [x] `bash .agent/validation.sh` passes (`mk_all --check` + full `lake build --wfail`).