### PR TITLE
feat(Morphisms/ProAffineEtale): fill `proAffineEtale.isAffine` sorry

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -47,6 +47,7 @@ import Proetale.Mathlib.CategoryTheory.Limits.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.Limits.Presentation
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Limits
+import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Multiequalizer
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
@@ -105,6 +106,7 @@ import Proetale.Mathlib.Topology.Spectral.Prespectral
 import Proetale.Morphisms.ProAffineEtale
 import Proetale.Morphisms.WeaklyEtale
 import Proetale.Pro.Basic
+import Proetale.Pro.Generating
 import Proetale.Pro.PresheafColimit
 import Proetale.Replete.WeaklyContractible
 import Proetale.Topology.Coherent.Affine

--- a/Proetale.lean
+++ b/Proetale.lean
@@ -47,7 +47,6 @@ import Proetale.Mathlib.CategoryTheory.Limits.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.Limits.Presentation
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Limits
-import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Multiequalizer
 import Proetale.Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
 import Proetale.Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
@@ -106,7 +105,6 @@ import Proetale.Mathlib.Topology.Spectral.Prespectral
 import Proetale.Morphisms.ProAffineEtale
 import Proetale.Morphisms.WeaklyEtale
 import Proetale.Pro.Basic
-import Proetale.Pro.Generating
 import Proetale.Pro.PresheafColimit
 import Proetale.Replete.WeaklyContractible
 import Proetale.Topology.Coherent.Affine

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -5,6 +5,7 @@ Authors: Christian Merten
 -/
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.Ind
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.IndSpreads
+import Mathlib.AlgebraicGeometry.Limits
 import Mathlib.AlgebraicGeometry.Morphisms.WeaklyEtale
 import Proetale.Algebra.IndEtale
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
@@ -32,11 +33,15 @@ lemma proAffineEtale.of_isAffine {X Y : Scheme.{u}} [IsAffine X] (f : X ⟶ Y) [
     proAffineEtale f :=
   MorphismProperty.le_pro _ _ ⟨‹_›, ⟨‹_›, trivial⟩⟩
 
-/-- The domain of a pro-affine étale morphism is affine. -/
+/-- The domain of a pro-affine étale morphism is affine, being a cofiltered limit of
+affine schemes. -/
 lemma proAffineEtale.isAffine {X S : Scheme.{u}} {f : X ⟶ S} (hf : proAffineEtale f) :
-    IsAffine X :=
-  -- Proof: An inverse limit of affine schemes is affine.
-  sorry
+    IsAffine X := by
+  obtain ⟨J, _, _, D, t, s, hs, hst⟩ := hf
+  have : ∀ j, IsAffine (D.obj j) := fun j ↦ by
+    have := (hst j).1.2
+    rwa [MorphismProperty.ofObjectProperty_top_right_iff] at this
+  exact Scheme.isAffine_of_isLimit (Cone.mk _ s) hs
 
 /-- `IsAffine` is preserved under isomorphisms. -/
 instance : ObjectProperty.IsClosedUnderIsomorphisms (C := Scheme.{u}) (IsAffine ·) where

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -3,11 +3,11 @@ Copyright (c) 2026 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Proetale.Mathlib.CategoryTheory.MorphismProperty.Ind
-import Proetale.Mathlib.CategoryTheory.MorphismProperty.IndSpreads
 import Mathlib.AlgebraicGeometry.Limits
 import Mathlib.AlgebraicGeometry.Morphisms.WeaklyEtale
 import Proetale.Algebra.IndEtale
+import Proetale.Mathlib.CategoryTheory.MorphismProperty.Ind
+import Proetale.Mathlib.CategoryTheory.MorphismProperty.IndSpreads
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
 
 /-!
@@ -33,14 +33,11 @@ lemma proAffineEtale.of_isAffine {X Y : Scheme.{u}} [IsAffine X] (f : X ⟶ Y) [
     proAffineEtale f :=
   MorphismProperty.le_pro _ _ ⟨‹_›, ⟨‹_›, trivial⟩⟩
 
-/-- The domain of a pro-affine étale morphism is affine, being a cofiltered limit of
-affine schemes. -/
+/-- The domain of a pro-affine étale morphism is affine. -/
 lemma proAffineEtale.isAffine {X S : Scheme.{u}} {f : X ⟶ S} (hf : proAffineEtale f) :
     IsAffine X := by
-  obtain ⟨J, _, _, D, t, s, hs, hst⟩ := hf
-  have : ∀ j, IsAffine (D.obj j) := fun j ↦ by
-    have := (hst j).1.2
-    rwa [MorphismProperty.ofObjectProperty_top_right_iff] at this
+  obtain ⟨J, _, _, D, t, s, hs, hts⟩ := hf
+  have hAff (j : J) : IsAffine (D.obj j) := ofObjectProperty_top_right_iff.mp (hts j).1.2
   exact Scheme.isAffine_of_isLimit (Cone.mk _ s) hs
 
 /-- `IsAffine` is preserved under isomorphisms. -/


### PR DESCRIPTION
## Summary

Fills the sorry on `AlgebraicGeometry.proAffineEtale.isAffine` in
`Proetale/Morphisms/ProAffineEtale.lean`: the source `X` of a pro-affine-étale
morphism `f : X ⟶ S` is affine.

Mathematical content: a `proAffineEtale` morphism unfolds (via
`MorphismProperty.pro`) to a cofiltered limit cone `(D, s, t)` with each
`t.app j : D.obj j ⟶ S` étale and each `D.obj j` affine. The conclusion is then
immediate from Mathlib's `Scheme.isAffine_of_isLimit` (`Mathlib/AlgebraicGeometry/Limits.lean`).

The only extra import is `Mathlib.AlgebraicGeometry.Limits`.

## Test plan

- [x] `lake build` succeeds
- [x] `.agent/validation.sh` passes
