### PR TITLE
chore(mk_all): add missing imports to root umbrella

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -32,11 +32,13 @@ import Proetale.Mathlib.Algebra.Category.CommAlgCat.Basic
 import Proetale.Mathlib.Algebra.Category.CommAlgCat.Limits
 import Proetale.Mathlib.Algebra.Category.Ring.FilteredColimits
 import Proetale.Mathlib.Algebra.Homology.ShortComplex.Exact
+import Proetale.Mathlib.AlgebraicGeometry.AffineTransitionLimit
 import Proetale.Mathlib.AlgebraicGeometry.Cover.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Extensive
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.FinitePresentation
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap
+import Proetale.Mathlib.AlgebraicGeometry.Sites.AffineEtale
 import Proetale.Mathlib.AlgebraicGeometry.Sites.BigZariski
 import Proetale.Mathlib.AlgebraicGeometry.Sites.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Sites.Small


### PR DESCRIPTION
## Summary

`lake exe mk_all --git --check` was failing on master because two files
that exist on disk had not been added to the `Proetale.lean` root umbrella:

- `Proetale.Mathlib.AlgebraicGeometry.AffineTransitionLimit`
- `Proetale.Mathlib.AlgebraicGeometry.Sites.AffineEtale`

Both files landed via #133 without the corresponding `Proetale.lean`
update. This PR re-runs `lake exe mk_all --git` and commits the two
missing import lines.

## Test plan

- [x] `lake exe mk_all --git --check` is clean.
- [x] `bash .agent/validation.sh` passes (full build succeeds).
