### PR TITLE
feat(Topology/Connected): fill `bijective` field of `isHomeomorph_connectedComponentsLift_prod`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -32,11 +32,13 @@ import Proetale.Mathlib.Algebra.Category.CommAlgCat.Basic
 import Proetale.Mathlib.Algebra.Category.CommAlgCat.Limits
 import Proetale.Mathlib.Algebra.Category.Ring.FilteredColimits
 import Proetale.Mathlib.Algebra.Homology.ShortComplex.Exact
+import Proetale.Mathlib.AlgebraicGeometry.AffineTransitionLimit
 import Proetale.Mathlib.AlgebraicGeometry.Cover.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Extensive
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.FinitePresentation
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap
+import Proetale.Mathlib.AlgebraicGeometry.Sites.AffineEtale
 import Proetale.Mathlib.AlgebraicGeometry.Sites.BigZariski
 import Proetale.Mathlib.AlgebraicGeometry.Sites.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Sites.Small

--- a/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
+++ b/Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean
@@ -129,12 +129,32 @@ theorem connectedComponent.prod (s : S) (t : T) :
       hconn_prod.subset_connectedComponent hmem
     exact hsub ⟨hs, ht⟩
 
+theorem ConnectedComponents.bijective_connectedComponentsLift_prod :
+    Function.Bijective (Continuous.connectedComponentsLift
+      (f := fun x : S × T ↦ (mk x.1, mk x.2)) (by continuity)) := by
+  refine ⟨Continuous.connectedComponentsLift_injective _ ?_, ?_⟩
+  · rintro ⟨c, d⟩
+    obtain ⟨s, rfl⟩ := ConnectedComponents.surjective_coe c
+    obtain ⟨t, rfl⟩ := ConnectedComponents.surjective_coe d
+    have heq : (fun x : S × T ↦ (ConnectedComponents.mk x.1, ConnectedComponents.mk x.2)) ⁻¹'
+        {(ConnectedComponents.mk s, ConnectedComponents.mk t)} =
+        connectedComponent s ×ˢ connectedComponent t := by
+      ext ⟨s', t'⟩
+      simp only [Set.mem_preimage, Set.mem_singleton_iff, Prod.mk.injEq,
+        Set.mem_prod, ConnectedComponents.coe_eq_coe']
+    rw [heq]
+    exact isPreconnected_connectedComponent.prod isPreconnected_connectedComponent
+  · rintro ⟨c, d⟩
+    obtain ⟨s, rfl⟩ := ConnectedComponents.surjective_coe c
+    obtain ⟨t, rfl⟩ := ConnectedComponents.surjective_coe d
+    exact ⟨ConnectedComponents.mk (s, t), rfl⟩
+
 theorem ConnectedComponents.isHomeomorph_connectedComponentsLift_prod :
     IsHomeomorph (Continuous.connectedComponentsLift
     (f := fun x : S × T ↦ (mk x.1, mk x.2)) (by continuity)) where
   continuous := Continuous.connectedComponentsLift_continuous (by continuity)
   isOpenMap := sorry
-  bijective := sorry
+  bijective := bijective_connectedComponentsLift_prod S T
 
 variable {S T} in
 noncomputable def ConnectedComponents.prodMap :

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -80,7 +80,8 @@ In general, $\pi_0(X) \times \pi_0(Y)$ is continuous and bijective, but not nece
 
 \begin{lemma}
   \label{thm:pi0-prod}
-  \lean{connectedComponent.prod,ConnectedComponents.isHomeomorph_connectedComponentsLift_prod,
+  \lean{connectedComponent.prod,ConnectedComponents.bijective_connectedComponentsLift_prod,
+    ConnectedComponents.isHomeomorph_connectedComponentsLift_prod,
     ConnectedComponents.prodMap}
   \leanok
   Let \(X, Y\) be topological spaces. Then we have 


### PR DESCRIPTION
## Summary

Closes one of the two `sorry`s in
`ConnectedComponents.isHomeomorph_connectedComponentsLift_prod`
(`Proetale/Mathlib/Topology/Connected/TotallyDisconnected.lean`) by
extracting a standalone lemma
`ConnectedComponents.bijective_connectedComponentsLift_prod` that proves
the underlying map `π₀(X × Y) → π₀(X) × π₀(Y)` is bijective.

The `isOpenMap` field remains `sorry` — and is in fact mathematically
false without stronger hypotheses (`LocallyConnectedSpace`, or
`CompactSpace`+`T2Space`, on both factors), as the existing red `jiedong`
note in the blueprint already acknowledges. So this PR makes the
mathematically-correct half of the homeomorphism statement formal,
without claiming the false half.

The proof reuses `Continuous.connectedComponentsLift_injective` already
in the same file:

- **Injectivity**: the preimage of a singleton `{(mk s, mk t)}` is
  `connectedComponent s ×ˢ connectedComponent t`, which is preconnected
  by `IsPreconnected.prod`.
- **Surjectivity**: immediate — `mk (s, t)` hits `(mk s, mk t)`.

Also adds the new lemma name to the `\lean{...}` cross-reference list
of `thm:pi0-prod` in `blueprint/src/chapters/local-structure.tex`. The
existing `\leanok` markers on the statement and proof stay in place —
they correspond to `connectedComponent.prod` (already filled on
master) being the substantive content; the bundled
`isHomeomorph_…_prod` and `prodMap` are still partial.

## Test plan

- [x] `lake build Proetale.Mathlib.Topology.Connected.TotallyDisconnected` succeeds; the only remaining sorry warning in the file is line 156 (`isOpenMap`).
- [x] `lake build` (full project) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)