### PR TITLE
feat(Mathlib/RingTheory/WeaklyEtale/Localization): localization maps are weakly étale

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -91,6 +91,7 @@ import Proetale.Mathlib.RingTheory.Spectrum.Prime.RingHom
 import Proetale.Mathlib.RingTheory.Spectrum.Prime.Topology
 import Proetale.Mathlib.RingTheory.TensorProduct.Maps
 import Proetale.Mathlib.RingTheory.WeaklyEtale.Local
+import Proetale.Mathlib.RingTheory.WeaklyEtale.Localization
 import Proetale.Mathlib.RingTheory.WeaklyEtale.Pi
 import Proetale.Mathlib.Topology.Category.TopCat.Limits.Pullbacks
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Localization.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Localization.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 The slopetale Authors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.RingTheory.Etale.Weakly
+import Mathlib.RingTheory.Flat.Localization
+
+/-!
+# Localization maps are weakly étale
+
+This file records the fact that any localization map `R → S⁻¹R` is weakly étale,
+which is item (1) of Stacks
+[092J](https://stacks.math.columbia.edu/tag/092J).
+
+## Main results
+
+* `Algebra.WeaklyEtale.of_isLocalization` — for any commutative ring `R`,
+  multiplicative submonoid `S ⊆ R`, and ring `T` that is the localization of `R`
+  at `S`, the structure map `R → T` is weakly étale. Stated as a theorem because
+  the submonoid `S` cannot be inferred from `WeaklyEtale R T` alone.
+* `Algebra.WeaklyEtale.localization` — the canonical instance for the explicit
+  `Localization S` construction, derived from the theorem above.
+
+## Proof strategy
+
+We unwind Mathlib's definition of weakly étale, which packages two flatness
+conditions:
+
+* (F1) `T` is flat as an `R`-module;
+* (F2) `T ⊗[R] T` is flat as a `T`-module via the multiplication map
+  `Algebra.TensorProduct.lmul' R : T ⊗[R] T →ₐ[R] T`.
+
+Condition (F1) is `IsLocalization.flat`. Condition (F2) follows from the
+sharper fact that when `R → T` is a localization, the multiplication map
+`T ⊗[R] T → T` is itself bijective (the diagonal ideal vanishes because every
+element of `S` is already a unit in `T`), so flatness is immediate from
+`RingHom.Flat.of_bijective`. Bijectivity is exactly
+`IsLocalization.bijective_linearMap_mul'` from
+`Mathlib/RingTheory/Localization/BaseChange.lean`.
+-/
+
+namespace Algebra.WeaklyEtale
+
+/-- **Stacks [092J], localization clause.**
+
+For any commutative ring `R`, multiplicative submonoid `S ⊆ R`, and ring `T`
+that is the localization of `R` at `S`, the structure map `R → T` is weakly
+étale.
+
+This is stated as a theorem (rather than an instance) because the submonoid `S`
+cannot be inferred from the head `Algebra.WeaklyEtale R T`. The canonical
+instance for `Localization S` is `Algebra.WeaklyEtale.localization` below. -/
+theorem of_isLocalization (R : Type*) [CommRing R] (S : Submonoid R)
+    (T : Type*) [CommRing T] [Algebra R T] [IsLocalization S T] :
+    Algebra.WeaklyEtale R T where
+  flat := IsLocalization.flat T S
+  flat_lmul' :=
+    -- Stacks 092J Step 2: `lmul' : T ⊗[R] T → T` is bijective when `R → T` is
+    -- a localization (the elements of `S` are already units in `T`, so the
+    -- diagonal ideal vanishes). Bijective ring maps are flat.
+    RingHom.Flat.of_bijective
+      (f := (Algebra.TensorProduct.lmul' R (S := T)).toRingHom)
+      (IsLocalization.bijective_linearMap_mul' (R := R) (A := T) S)
+
+/-- The canonical localization `R → Localization S` is weakly étale. -/
+instance localization (R : Type*) [CommRing R] (S : Submonoid R) :
+    Algebra.WeaklyEtale R (Localization S) :=
+  of_isLocalization R S _
+
+end Algebra.WeaklyEtale

--- a/Proetale/Mathlib/RingTheory/WeaklyEtale/Localization.lean
+++ b/Proetale/Mathlib/RingTheory/WeaklyEtale/Localization.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 The slopetale Authors. All rights reserved.
+Copyright (c) 2026 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
 -/
 import Mathlib.RingTheory.Etale.Weakly
 import Mathlib.RingTheory.Flat.Localization
@@ -14,50 +15,22 @@ which is item (1) of Stacks
 
 ## Main results
 
-* `Algebra.WeaklyEtale.of_isLocalization` — for any commutative ring `R`,
-  multiplicative submonoid `S ⊆ R`, and ring `T` that is the localization of `R`
-  at `S`, the structure map `R → T` is weakly étale. Stated as a theorem because
-  the submonoid `S` cannot be inferred from `WeaklyEtale R T` alone.
-* `Algebra.WeaklyEtale.localization` — the canonical instance for the explicit
-  `Localization S` construction, derived from the theorem above.
-
-## Proof strategy
-
-We unwind Mathlib's definition of weakly étale, which packages two flatness
-conditions:
-
-* (F1) `T` is flat as an `R`-module;
-* (F2) `T ⊗[R] T` is flat as a `T`-module via the multiplication map
-  `Algebra.TensorProduct.lmul' R : T ⊗[R] T →ₐ[R] T`.
-
-Condition (F1) is `IsLocalization.flat`. Condition (F2) follows from the
-sharper fact that when `R → T` is a localization, the multiplication map
-`T ⊗[R] T → T` is itself bijective (the diagonal ideal vanishes because every
-element of `S` is already a unit in `T`), so flatness is immediate from
-`RingHom.Flat.of_bijective`. Bijectivity is exactly
-`IsLocalization.bijective_linearMap_mul'` from
-`Mathlib/RingTheory/Localization/BaseChange.lean`.
+* `Algebra.WeaklyEtale.of_isLocalization` — if `T` is the localization of `R` at a
+  submonoid `S`, then `T` is a weakly étale `R`-algebra.
+* `Algebra.WeaklyEtale.localization` — the canonical instance for `Localization S`.
 -/
 
 namespace Algebra.WeaklyEtale
 
 /-- **Stacks [092J], localization clause.**
 
-For any commutative ring `R`, multiplicative submonoid `S ⊆ R`, and ring `T`
-that is the localization of `R` at `S`, the structure map `R → T` is weakly
-étale.
-
-This is stated as a theorem (rather than an instance) because the submonoid `S`
-cannot be inferred from the head `Algebra.WeaklyEtale R T`. The canonical
-instance for `Localization S` is `Algebra.WeaklyEtale.localization` below. -/
+If `T` is the localization of `R` at a submonoid `S`, then `T` is weakly étale over `R`. -/
+@[stacks 092J "(1)"]
 theorem of_isLocalization (R : Type*) [CommRing R] (S : Submonoid R)
     (T : Type*) [CommRing T] [Algebra R T] [IsLocalization S T] :
     Algebra.WeaklyEtale R T where
   flat := IsLocalization.flat T S
   flat_lmul' :=
-    -- Stacks 092J Step 2: `lmul' : T ⊗[R] T → T` is bijective when `R → T` is
-    -- a localization (the elements of `S` are already units in `T`, so the
-    -- diagonal ideal vanishes). Bijective ring maps are flat.
     RingHom.Flat.of_bijective
       (f := (Algebra.TensorProduct.lmul' R (S := T)).toRingHom)
       (IsLocalization.bijective_linearMap_mul' (R := R) (A := T) S)

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -170,6 +170,21 @@ of this property.
     Omitted, see \stacksproject{092J}.
 \end{proof}
 
+\begin{lemma}[\stacksproject{092J}]
+    \uses{def:weakly-etale-algebra}
+    \label{lem:weakly-etale-localization}
+    \lean{Algebra.WeaklyEtale.of_isLocalization}
+    \leanok
+    For any commutative ring $A$ and multiplicative submonoid $S \subseteq A$, the
+    localization map $A \to S^{-1} A$ is weakly étale.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The localization $A \to S^{-1} A$ is flat. Moreover, the multiplication map
+    $S^{-1} A \otimes_{A} S^{-1} A \to S^{-1} A$ is bijective, hence flat.
+\end{proof}
+
 \begin{lemma}[\stacksproject{092H}]
     \label{lem:weakly-etale-base-change}
     If $B$ is a weakly-étale $A$-algebra and $A'$ is any $A$-algebra, the base change


### PR DESCRIPTION
## Summary

Add `Algebra.WeaklyEtale.of_isLocalization`: if `T` is the localization of `R` at a
submonoid `S`, then `T` is weakly étale over `R`. This is item (1) of Stacks
[092J](https://stacks.math.columbia.edu/tag/092J).

Also add the canonical instance `Algebra.WeaklyEtale.localization` for the
explicit `Localization S` construction, and mark the corresponding blueprint
lemma `lem:weakly-etale-localization` as `\leanok`.

## Proof

Both flatness conditions of `Algebra.WeaklyEtale` are immediate:

- `R → T` is flat: `IsLocalization.flat`.
- `Algebra.TensorProduct.lmul' R : T ⊗[R] T → T` is flat: by
  `IsLocalization.bijective_linearMap_mul'` the underlying map is bijective,
  hence flat by `RingHom.Flat.of_bijective`.
