### PR TITLE
feat(Mathlib/RingTheory/Ideal/GoingUp): integral ring map of local rings is a local ring hom

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -83,6 +83,7 @@ import Proetale.Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 import Proetale.Mathlib.RingTheory.Flat.Pi
 import Proetale.Mathlib.RingTheory.Henselian
 import Proetale.Mathlib.RingTheory.Ideal.GoingDown
+import Proetale.Mathlib.RingTheory.Ideal.GoingUp
 import Proetale.Mathlib.RingTheory.Ideal.Pure
 import Proetale.Mathlib.RingTheory.Idempotents
 import Proetale.Mathlib.RingTheory.RingHom.Flat

--- a/Proetale/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Proetale/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+
+/-!
+# Integral ring maps of local rings are local
+
+If `R → S` is an integral ring map of local rings, then `R → S` is automatically a
+local ring homomorphism. This is `Ideal.IsMaximal.under` (going-up) packaged through
+the local-hom TFAE, with no injectivity hypothesis (cf. Mathlib's
+`RingHom.IsIntegral.isLocalHom`, which assumes injectivity).
+-/
+
+namespace RingHom
+
+variable {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
+
+/-- An integral ring homomorphism between local rings is a local ring homomorphism.
+
+Note that, unlike `RingHom.IsIntegral.isLocalHom`, this does not require injectivity of `f`. -/
+theorem IsIntegral.isLocalHom_of_isLocalRing {f : R →+* S} (hf : f.IsIntegral) :
+    IsLocalHom f := by
+  have h : IsLocalHom f ↔ (IsLocalRing.maximalIdeal S).comap f = IsLocalRing.maximalIdeal R :=
+    (IsLocalRing.local_hom_TFAE f).out 0 4
+  have hmax : ((IsLocalRing.maximalIdeal S).comap f).IsMaximal :=
+    Ideal.isMaximal_comap_of_isIntegral_of_isMaximal' f hf _
+  exact h.mpr (IsLocalRing.eq_maximalIdeal hmax)
+
+end RingHom
+
+namespace Algebra
+
+variable {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
+  [Algebra R S]
+
+/-- The structure map of an integral algebra between local rings is a local ring homomorphism.
+
+Note that, unlike `Algebra.IsIntegral.isLocalHom`, this does not require `FaithfulSMul R S`. -/
+theorem IsIntegral.isLocalHom_of_isLocalRing [Algebra.IsIntegral R S] :
+    IsLocalHom (algebraMap R S) :=
+  RingHom.IsIntegral.isLocalHom_of_isLocalRing Algebra.IsIntegral.isIntegral
+
+end Algebra

--- a/Proetale/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Proetale/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -3,44 +3,36 @@ Copyright (c) 2026 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib
+import Mathlib.RingTheory.Ideal.GoingUp
+import Mathlib.RingTheory.LocalRing.RingHom.Basic
 
 /-!
 # Integral ring maps of local rings are local
 
 If `R → S` is an integral ring map of local rings, then `R → S` is automatically a
-local ring homomorphism. This is `Ideal.IsMaximal.under` (going-up) packaged through
-the local-hom TFAE, with no injectivity hypothesis (cf. Mathlib's
-`RingHom.IsIntegral.isLocalHom`, which assumes injectivity).
+local ring homomorphism. Unlike `RingHom.IsIntegral.isLocalHom`, this version does
+not assume that `f` is injective.
 -/
-
-namespace RingHom
-
-variable {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
 
 /-- An integral ring homomorphism between local rings is a local ring homomorphism.
 
 Note that, unlike `RingHom.IsIntegral.isLocalHom`, this does not require injectivity of `f`. -/
-theorem IsIntegral.isLocalHom_of_isLocalRing {f : R →+* S} (hf : f.IsIntegral) :
-    IsLocalHom f := by
-  have h : IsLocalHom f ↔ (IsLocalRing.maximalIdeal S).comap f = IsLocalRing.maximalIdeal R :=
-    (IsLocalRing.local_hom_TFAE f).out 0 4
-  have hmax : ((IsLocalRing.maximalIdeal S).comap f).IsMaximal :=
-    Ideal.isMaximal_comap_of_isIntegral_of_isMaximal' f hf _
-  exact h.mpr (IsLocalRing.eq_maximalIdeal hmax)
-
-end RingHom
-
-namespace Algebra
-
-variable {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
-  [Algebra R S]
+theorem RingHom.IsIntegral.isLocalHom_of_isLocalRing
+    {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
+    {f : R →+* S} (hf : f.IsIntegral) :
+    IsLocalHom f :=
+  ((IsLocalRing.local_hom_TFAE f).out 0 4).mpr <|
+    IsLocalRing.eq_maximalIdeal
+      (Ideal.isMaximal_comap_of_isIntegral_of_isMaximal' f hf _)
 
 /-- The structure map of an integral algebra between local rings is a local ring homomorphism.
 
-Note that, unlike `Algebra.IsIntegral.isLocalHom`, this does not require `FaithfulSMul R S`. -/
-theorem IsIntegral.isLocalHom_of_isLocalRing [Algebra.IsIntegral R S] :
+Note that, unlike `Algebra.IsIntegral.isLocalHom`, this does not require `FaithfulSMul R S`.
+This is intentionally not registered as an instance: the analogous Mathlib instance
+`Algebra.IsIntegral.isLocalHom` is already known to cause typeclass search performance issues
+(see `attribute [-instance]` in `Mathlib/RingTheory/QuasiFinite/Basic.lean`). -/
+theorem Algebra.IsIntegral.isLocalHom_of_isLocalRing
+    {R S : Type*} [CommRing R] [IsLocalRing R] [CommRing S] [IsLocalRing S]
+    [Algebra R S] [Algebra.IsIntegral R S] :
     IsLocalHom (algebraMap R S) :=
   RingHom.IsIntegral.isLocalHom_of_isLocalRing Algebra.IsIntegral.isIntegral
-
-end Algebra

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -62,15 +62,15 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
 \end{proof}
 
 \begin{lemma}
+    Let $R \to S$ be an integral ring map of local rings. Then $R \to S$ is a local ring homomorphism.
     \label{lemma:integral-local-hom}
     \lean{RingHom.IsIntegral.isLocalHom_of_isLocalRing}
     \leanok
-    Let $R \to S$ be an integral ring map of local rings. Then $R \to S$ is a local ring homomorphism.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    This follows from going-up (use \verb`Ideal.IsMaximal.under`).
+    This follows from going-up.
 \end{proof}
 
 \begin{lemma}

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -62,11 +62,14 @@ The proof goes via the local input \label{weakly-etale-over-sh}.
 \end{proof}
 
 \begin{lemma}
-    Let $R \to S$ be an integral ring map of local rings. Then $R \to S$ is a local ring homomorphism.
     \label{lemma:integral-local-hom}
+    \lean{RingHom.IsIntegral.isLocalHom_of_isLocalRing}
+    \leanok
+    Let $R \to S$ be an integral ring map of local rings. Then $R \to S$ is a local ring homomorphism.
 \end{lemma}
 
 \begin{proof}
+    \leanok
     This follows from going-up (use \verb`Ideal.IsMaximal.under`).
 \end{proof}
 


### PR DESCRIPTION
Add `RingHom.IsIntegral.isLocalHom_of_isLocalRing` (and its `Algebra` variant), strengthening Mathlib's `RingHom.IsIntegral.isLocalHom` / `Algebra.IsIntegral.isLocalHom` by dropping the injectivity / `FaithfulSMul` hypothesis when both source and target are local rings.

Proves the blueprint statement `lemma:integral-local-hom` in `more-on-local-structure.tex`; `\lean{...}` and `\leanok` markers added for both statement and proof.