### PR TITLE
feat(Mathlib/RingTheory/Idempotents): idempotent in Jacobson radical is zero

### DIFF
--- a/Proetale/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Proetale/Mathlib/Algebra/Algebra/Pi.lean
@@ -22,6 +22,7 @@ def AlgEquiv.piFinTwo (A : Type*) [CommSemiring A] (R : Fin 2 → Type*)
   { RingEquiv.piFinTwo R with
     commutes' := fun _ => rfl }
 
+-- `_root_.Finite` is required below because `AlgHom.Finite` is in scope inside this namespace.
 namespace AlgHom
 
 variable {k : Type*} [CommSemiring k] {I : Type*} [DecidableEq I]

--- a/Proetale/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Proetale/Mathlib/Algebra/Algebra/Pi.lean
@@ -31,7 +31,7 @@ variable {k : Type*} [CommSemiring k] {I : Type*} [DecidableEq I]
 /-- An algebra homomorphism from a finite product of commutative rings to a nontrivial local
 algebra factors through one of the factors: there exists `j : I` with `ψ (Pi.single j 1) = 1`
 and `ψ (Pi.single i 1) = 0` for every `i ≠ j`. -/
-lemma exists_pi_single_eq_one_of_isLocalRing [Finite I] [IsLocalRing B]
+lemma exists_pi_single_eq_one_of_isLocalRing [_root_.Finite I] [IsLocalRing B]
     (ψ : (∀ i, A i) →ₐ[k] B) :
     ∃ j : I, ψ (Pi.single j 1) = 1 ∧ ∀ i, i ≠ j → ψ (Pi.single i 1) = 0 := by
   have : Fintype I := Fintype.ofFinite I
@@ -87,7 +87,7 @@ lemma piFactor_apply (ψ : (∀ i, A i) →ₐ[k] B) (j : I)
 
 /-- An algebra homomorphism `ψ : (∀ i, A i) →ₐ[k] B` to a local algebra is recovered from its
 factor through the unique component `A j` selected by the unit idempotents. -/
-lemma eq_piFactor_apply [Finite I] (ψ : (∀ i, A i) →ₐ[k] B) (j : I)
+lemma eq_piFactor_apply [_root_.Finite I] (ψ : (∀ i, A i) →ₐ[k] B) (j : I)
     (hj : ψ (Pi.single j 1) = 1) (hothers : ∀ i, i ≠ j → ψ (Pi.single i 1) = 0)
     (x : ∀ i, A i) : ψ x = piFactor ψ j hj hothers (x j) := by
   have : Fintype I := Fintype.ofFinite I

--- a/Proetale/Mathlib/RingTheory/Idempotents.lean
+++ b/Proetale/Mathlib/RingTheory/Idempotents.lean
@@ -5,7 +5,7 @@ Authors: Jiedong Jiang, Christian Merten
 -/
 import Mathlib.RingTheory.Idempotents
 import Mathlib.RingTheory.Jacobson.Ideal
-import Mathlib.RingTheory.LocalRing.Basic
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 
 /-!
 # Idempotents in local rings and in the Jacobson radical
@@ -15,25 +15,20 @@ More generally, any idempotent lying in the Jacobson radical of an arbitrary
 commutative ring must be zero.
 -/
 
-/-- An idempotent that lies in the Jacobson radical is zero.
-
-If `e` is idempotent and `e ∈ jacobson ⊥`, then `1 - e` is a unit (by definition of
-the Jacobson radical applied to `-1`). Combined with the idempotent relation
-`e * (1 - e) = 0`, multiplying by `(1 - e)⁻¹` gives `e = 0`. -/
+/-- An idempotent element of a commutative ring that lies in the Jacobson radical
+(of the zero ideal) is zero. -/
 lemma IsIdempotentElem.eq_zero_of_mem_jacobson_bot {R : Type*} [CommRing R]
     {e : R} (he : IsIdempotentElem e) (hmem : e ∈ Ideal.jacobson (⊥ : Ideal R)) :
     e = 0 := by
   rw [Ideal.mem_jacobson_bot] at hmem
-  have hu : IsUnit (1 - e) := by
-    have := hmem (-1)
-    rwa [mul_neg_one, neg_add_eq_sub] at this
+  have hu : IsUnit (1 - e) := by simpa [mul_neg_one, neg_add_eq_sub] using hmem (-1)
   exact hu.mul_left_eq_zero.mp he.mul_one_sub_self
 
 /-- In a local ring, every idempotent element is `0` or `1`. -/
 lemma IsIdempotentElem.eq_zero_or_one_of_isLocalRing {R : Type*} [CommRing R]
     [IsLocalRing R] {e : R} (he : IsIdempotentElem e) : e = 0 ∨ e = 1 := by
-  have hsum : e + (1 - e) = 1 := by ring
-  have hmul : e * (1 - e) = 0 := he.mul_one_sub_self
-  rcases IsLocalRing.isUnit_or_isUnit_of_add_one hsum with hu | hu
-  · exact .inr (sub_eq_zero.mp (hu.mul_right_eq_zero.mp hmul)).symm
-  · exact .inl (hu.mul_left_eq_zero.mp hmul)
+  rcases Classical.em (e ∈ IsLocalRing.maximalIdeal R) with hmem | hnmem
+  · exact .inl <| he.eq_zero_of_mem_jacobson_bot <| by
+      rwa [IsLocalRing.jacobson_eq_maximalIdeal ⊥ bot_ne_top]
+  · rw [IsLocalRing.notMem_maximalIdeal] at hnmem
+    exact .inr (sub_eq_zero.mp (hnmem.mul_right_eq_zero.mp he.mul_one_sub_self)).symm

--- a/Proetale/Mathlib/RingTheory/Idempotents.lean
+++ b/Proetale/Mathlib/RingTheory/Idempotents.lean
@@ -4,13 +4,30 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jiedong Jiang, Christian Merten
 -/
 import Mathlib.RingTheory.Idempotents
+import Mathlib.RingTheory.Jacobson.Ideal
 import Mathlib.RingTheory.LocalRing.Basic
 
 /-!
-# Idempotents in local rings
+# Idempotents in local rings and in the Jacobson radical
 
 In a local ring, the only idempotent elements are `0` and `1`.
+More generally, any idempotent lying in the Jacobson radical of an arbitrary
+commutative ring must be zero.
 -/
+
+/-- An idempotent that lies in the Jacobson radical is zero.
+
+If `e` is idempotent and `e ∈ jacobson ⊥`, then `1 - e` is a unit (by definition of
+the Jacobson radical applied to `-1`). Combined with the idempotent relation
+`e * (1 - e) = 0`, multiplying by `(1 - e)⁻¹` gives `e = 0`. -/
+lemma IsIdempotentElem.eq_zero_of_mem_jacobson_bot {R : Type*} [CommRing R]
+    {e : R} (he : IsIdempotentElem e) (hmem : e ∈ Ideal.jacobson (⊥ : Ideal R)) :
+    e = 0 := by
+  rw [Ideal.mem_jacobson_bot] at hmem
+  have hu : IsUnit (1 - e) := by
+    have := hmem (-1)
+    rwa [mul_neg_one, neg_add_eq_sub] at this
+  exact hu.mul_left_eq_zero.mp he.mul_one_sub_self
 
 /-- In a local ring, every idempotent element is `0` or `1`. -/
 lemma IsIdempotentElem.eq_zero_or_one_of_isLocalRing {R : Type*} [CommRing R]


### PR DESCRIPTION
## Summary

Add `IsIdempotentElem.eq_zero_of_mem_jacobson_bot` to
`Proetale/Mathlib/RingTheory/Idempotents.lean`: in any commutative ring `R`,
an idempotent element `e ∈ jacobson (⊥ : Ideal R)` must be zero.

The proof is two lines: `Ideal.mem_jacobson_bot` applied to `-1` gives that
`1 - e` is a unit; combined with the idempotent identity `e * (1 - e) = 0`,
multiplying by the inverse forces `e = 0`.

This is the underlying generalisation of the existing
`IsIdempotentElem.eq_zero_or_one_of_isLocalRing` lemma in the same file: in a
local ring, the Jacobson radical is exactly the maximal ideal, so an idempotent
in the maximal ideal must be zero, and hence every idempotent is `0` or `1`.

The lemma is currently a `private` helper inside
`Proetale/Mathlib/RingTheory/Etale/HenselianIdempotentLift.lean` on the
`archon` branch (named `_isIdempotentElem_eq_zero_of_mem_jacobson_bot`); pulling
it out and naming it for Mathlib makes it independently usable and is a
prerequisite for future extraction of the Hensel-idempotent-lift material.

It does not appear to exist in Mathlib proper (no `IsIdempotentElem.*jacobson*`
declarations under `Mathlib/RingTheory/`).

## Drive-by fix

Adding `import Mathlib.RingTheory.Jacobson.Ideal` to `Idempotents.lean` pulls
in `Mathlib.RingTheory.LocalProperties.Finite`, which defines `AlgHom.Finite`.
Inside `namespace AlgHom` in `Proetale/Mathlib/Algebra/Algebra/Pi.lean`, the
bare `[Finite I]` instance argument was then resolved to `AlgHom.Finite I`,
which expects an algebra homomorphism, breaking the build. Two `[Finite I]`
occurrences are now qualified as `[_root_.Finite I]`.

## Test plan

- [x] `lake build Proetale.Mathlib.RingTheory.Idempotents` succeeds
- [x] full `lake build Proetale` succeeds (validation script passes)
- [x] no `sorry` in the modified files
