### PR TITLE
feat(Algebra/StalkIso): cancel `BijectiveOnStalks` along a bijective factor

### DIFF
--- a/Proetale/Algebra/StalkIso.lean
+++ b/Proetale/Algebra/StalkIso.lean
@@ -75,12 +75,11 @@ lemma of_comp {T : Type*} [CommRing T] {f : R →+* S} {g : S →+* T}
     (hf : f.BijectiveOnStalks) (hgf : (g.comp f).BijectiveOnStalks) :
     g.BijectiveOnStalks := by
   intro p hp
-  have hq : (p.comap g).IsPrime := Ideal.IsPrime.comap g
+  have hcc : (p.comap g).comap f = p.comap (g.comp f) := Ideal.comap_comap f g
+  refine (Function.Bijective.of_comp_iff _ (hf.localRingHom_of_eq hcc.symm)).mp ?_
   have key := hgf p
-  rw [Localization.localRingHom_comp
-    (I := p.comap (g.comp f)) (p.comap g) p f (Ideal.comap_comap f g) g rfl] at key
-  exact (Function.Bijective.of_comp_iff _
-    (hf.localRingHom_of_eq (Ideal.comap_comap f g).symm)).mp key
+  rwa [Localization.localRingHom_comp
+    (I := p.comap (g.comp f)) (p.comap g) p f hcc g rfl] at key
 
 /-- `BijectiveOnStalks` is preserved under taking quotients by an ideal and its extension. -/
 lemma quotientMap {f : R →+* S} (hf : f.BijectiveOnStalks) (I : Ideal R) :
@@ -337,18 +336,20 @@ lemma comp (R S T : Type*) [CommRing R] [CommRing S] [CommRing T]
   exact (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›).comp
     (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›)
 
-/-- If `R → S` and `R → T` are both bijective on stalks, and `S → T` is an `R`-algebra map,
-then `S → T` is bijective on stalks. -/
+/-- If `R → S → T` is a tower of `R`-algebras such that `R → S` and `R → T` are both bijective
+on stalks, then `S → T` is bijective on stalks. -/
 @[stacks 096D]
 lemma of_comp (R S T : Type*) [CommRing R] [CommRing S] [CommRing T]
     [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
     [Algebra.BijectiveOnStalks R S] [Algebra.BijectiveOnStalks R T] :
     Algebra.BijectiveOnStalks S T := by
-  refine RingHom.bijectiveOnStalks_algebraMap.mp ?_
-  refine RingHom.BijectiveOnStalks.of_comp (f := algebraMap R S)
-    (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›) ?_
-  rw [← IsScalarTower.algebraMap_eq]
-  exact RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›
+  have hRS : (algebraMap R S).BijectiveOnStalks :=
+    RingHom.bijectiveOnStalks_algebraMap.mpr inferInstance
+  have hRT : (algebraMap R T).BijectiveOnStalks :=
+    RingHom.bijectiveOnStalks_algebraMap.mpr inferInstance
+  refine RingHom.bijectiveOnStalks_algebraMap.mp <|
+    RingHom.BijectiveOnStalks.of_comp (f := algebraMap R S) hRS ?_
+  rwa [← IsScalarTower.algebraMap_eq]
 
 instance (priority := 100) of_isStandardOpenImmersion (R T : Type*) [CommRing R] [CommRing T]
     [Algebra R T] [Algebra.IsStandardOpenImmersion R T] : Algebra.BijectiveOnStalks R T :=

--- a/Proetale/Algebra/StalkIso.lean
+++ b/Proetale/Algebra/StalkIso.lean
@@ -68,6 +68,20 @@ lemma localRingHom_of_eq {f : R →+* S} (hf : f.BijectiveOnStalks)
     Function.Bijective (Localization.localRingHom I p f hI) := by
   subst hI; exact hf p
 
+/-- If `f : R →+* S` and the composition `g.comp f : R →+* T` are both bijective on stalks,
+then `g : S →+* T` is bijective on stalks. -/
+@[stacks 096D]
+lemma of_comp {T : Type*} [CommRing T] {f : R →+* S} {g : S →+* T}
+    (hf : f.BijectiveOnStalks) (hgf : (g.comp f).BijectiveOnStalks) :
+    g.BijectiveOnStalks := by
+  intro p hp
+  have hq : (p.comap g).IsPrime := Ideal.IsPrime.comap g
+  have key := hgf p
+  rw [Localization.localRingHom_comp
+    (I := p.comap (g.comp f)) (p.comap g) p f (Ideal.comap_comap f g) g rfl] at key
+  exact (Function.Bijective.of_comp_iff _
+    (hf.localRingHom_of_eq (Ideal.comap_comap f g).symm)).mp key
+
 /-- `BijectiveOnStalks` is preserved under taking quotients by an ideal and its extension. -/
 lemma quotientMap {f : R →+* S} (hf : f.BijectiveOnStalks) (I : Ideal R) :
     (Ideal.quotientMap (I.map f) f I.le_comap_map).BijectiveOnStalks := by
@@ -322,6 +336,19 @@ lemma comp (R S T : Type*) [CommRing R] [CommRing S] [CommRing T]
   rw [IsScalarTower.algebraMap_eq R S T]
   exact (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›).comp
     (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›)
+
+/-- If `R → S` and `R → T` are both bijective on stalks, and `S → T` is an `R`-algebra map,
+then `S → T` is bijective on stalks. -/
+@[stacks 096D]
+lemma of_comp (R S T : Type*) [CommRing R] [CommRing S] [CommRing T]
+    [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
+    [Algebra.BijectiveOnStalks R S] [Algebra.BijectiveOnStalks R T] :
+    Algebra.BijectiveOnStalks S T := by
+  refine RingHom.bijectiveOnStalks_algebraMap.mp ?_
+  refine RingHom.BijectiveOnStalks.of_comp (f := algebraMap R S)
+    (RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›) ?_
+  rw [← IsScalarTower.algebraMap_eq]
+  exact RingHom.bijectiveOnStalks_algebraMap.mpr ‹_›
 
 instance (priority := 100) of_isStandardOpenImmersion (R T : Type*) [CommRing R] [CommRing T]
     [Algebra R T] [Algebra.IsStandardOpenImmersion R T] : Algebra.BijectiveOnStalks R T :=

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -462,7 +462,7 @@ The following pure algebraic lemma will be used in \Cref{thm:isom-of-identifies-
 
 \begin{proof}
     \leanok
-    Localising at a prime $\mathfrak{p}$ of $C$ factors as $A_{\mathfrak{q}} \to B_{\mathfrak{q}'} \to C_{\mathfrak{p}}$ (where $\mathfrak{q}' = \mathfrak{p} \cap B$ and $\mathfrak{q} = \mathfrak{p} \cap A$) by \texttt{Localization.localRingHom\_comp}; since the outer composition and the left factor are bijective, so is the right factor.
+    Holds because the same holds for bijective maps of sets.
 \end{proof}
 
 \begin{definition}[{\cite[\href{https://stacks.math.columbia.edu/tag/096L}{Tag 096L}]{stacks-project}}]

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -462,7 +462,7 @@ The following pure algebraic lemma will be used in \Cref{thm:isom-of-identifies-
 
 \begin{proof}
     \leanok
-    Holds because the same holds for bijective maps of sets.
+    Localising at a prime $\mathfrak{p}$ of $C$ factors as $A_{\mathfrak{q}} \to B_{\mathfrak{q}'} \to C_{\mathfrak{p}}$ (where $\mathfrak{q}' = \mathfrak{p} \cap B$ and $\mathfrak{q} = \mathfrak{p} \cap A$) by \texttt{Localization.localRingHom\_comp}; since the outer composition and the left factor are bijective, so is the right factor.
 \end{proof}
 
 \begin{definition}[{\cite[\href{https://stacks.math.columbia.edu/tag/096L}{Tag 096L}]{stacks-project}}]

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -456,9 +456,12 @@ The following pure algebraic lemma will be used in \Cref{thm:isom-of-identifies-
     Let $A$ be a ring and $B \to C$ be an $A$-algebra map. Suppose both
     $A \to B$ and $A \to C$ are bijective on stalks. Then $B \to C$ is bijective on stalks.
     \label{lemma:bijective-on-stalks-of-comp}
+    \lean{Algebra.BijectiveOnStalks.of_comp, RingHom.BijectiveOnStalks.of_comp}
+    \leanok
 \end{lemma}
 
 \begin{proof}
+    \leanok
     Holds because the same holds for bijective maps of sets.
 \end{proof}
 


### PR DESCRIPTION
## Summary

Adds two cancellation lemmas formalising `lemma:bijective-on-stalks-of-comp` (Stacks [096D](https://stacks.math.columbia.edu/tag/096D)) from `blueprint/src/chapters/local-structure.tex`:

- `RingHom.BijectiveOnStalks.of_comp`: if `f : R →+* S` is bijective on stalks and the composition `g.comp f : R →+* T` is bijective on stalks, then `g : S →+* T` is bijective on stalks.
- `Algebra.BijectiveOnStalks.of_comp`: the corresponding algebra-version for an `R`-algebra map `S → T` between two `R`-algebras both bijective on stalks over `R`.

The proofs go through `Localization.localRingHom_comp` and `Function.Bijective.of_comp_iff`, mirroring the existing `comp` direction in the same file.

The blueprint statement previously had no `\lean{...}` marker; this PR adds both `\lean{...}` and `\leanok` (on statement and proof) to `lemma:bijective-on-stalks-of-comp`.

## Test plan
- [x] `lake build Proetale.Algebra.StalkIso` succeeds
- [x] `lake exe mk_all --git --check` reports no update necessary
- [x] No new linter warnings; only the pre-existing `prod` sorry remains in the file