### PR TITLE
chore(mk_all): add missing import for `Proetale.Replete.Basic`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -112,6 +112,7 @@ import Proetale.Morphisms.WeaklyEtale
 import Proetale.Pro.Basic
 import Proetale.Pro.Generating
 import Proetale.Pro.PresheafColimit
+import Proetale.Replete.Basic
 import Proetale.Replete.WeaklyContractible
 import Proetale.Topology.Coherent.Affine
 import Proetale.Topology.Coherent.Etale


### PR DESCRIPTION
## Summary

PR #135 introduced `Proetale/Replete/Basic.lean` without updating the root umbrella `Proetale.lean`. This restores `lake exe mk_all --git --check`.

## Test plan

- [x] `lake exe mk_all --git --check` passes.
- [x] `lake build --wfail` succeeds.
- [x] `bash .agent/validation.sh` passes end-to-end.
