### PR TITLE
feat(Topology/Comparison/Affine): fill `HasPullbacks (AffineProEt S)` sorry

### DIFF
--- a/Proetale/Mathlib/CategoryTheory/Limits/MorphismProperty.lean
+++ b/Proetale/Mathlib/CategoryTheory/Limits/MorphismProperty.lean
@@ -20,4 +20,50 @@ end Comma
 
 end MorphismProperty
 
+section CostructuredArrow
+
+variable {A : Type*} [Category A] {L : A ⥤ T}
+
+/-- A variant of `CategoryTheory.CostructuredArrow.closedUnderLimitsOfShape_walkingCospan`
+that only requires `P.IsStableUnderBaseChangeAlong` for the cospan legs of each cone, rather
+than the global `P.IsStableUnderBaseChange`. -/
+lemma CostructuredArrow.closedUnderLimitsOfShape_walkingCospan_of_baseChangeAlong
+    [HasPullbacks A] [HasPullbacks T] [PreservesLimitsOfShape WalkingCospan L] (X : T)
+    [P.IsStableUnderComposition] [P.HasOfPostcompProperty P]
+    (hbc : ∀ {Y₁ Y₂ : CostructuredArrow L X} (_ : P Y₁.hom) (_ : P Y₂.hom) (f : Y₁ ⟶ Y₂),
+        P.IsStableUnderBaseChangeAlong (L.map f.left)) :
+    (P.costructuredArrowObj L (X := X)).IsClosedUnderLimitsOfShape WalkingCospan where
+  limitsOfShape_le := by
+    rintro Y ⟨pres, hpres⟩
+    have h : IsPullback (L.map (pres.π.app .left).left) (L.map (pres.π.app .right).left)
+        (L.map (pres.diag.map WalkingCospan.Hom.inl).left)
+        (L.map (pres.diag.map WalkingCospan.Hom.inr).left) :=
+      IsPullback.of_isLimit_cone <| isLimitOfPreserves
+        (CategoryTheory.CostructuredArrow.toOver L X ⋙ CategoryTheory.Over.forget X) pres.isLimit
+    have hY : Y.hom = L.map (pres.π.app .left).left ≫ (pres.diag.obj .left).hom := by simp
+    have := hbc (hpres .left) (hpres .one) (pres.diag.map WalkingCospan.Hom.inl)
+    rw [MorphismProperty.costructuredArrowObj_iff, hY]
+    refine P.comp_mem _ _ ?_ (hpres _)
+    refine MorphismProperty.IsStableUnderBaseChangeAlong.of_isPullback h.flip ?_
+    exact P.of_postcomp _ (pres.diag.obj WalkingCospan.one).hom (hpres .one)
+      (by simpa using hpres .right)
+
+end CostructuredArrow
+
+section Over
+
+variable {X : T}
+
+/-- A variant of `CategoryTheory.Over.closedUnderLimitsOfShape_pullback` that only requires
+`P.IsStableUnderBaseChangeAlong` for the cospan legs of each cone, rather than the global
+`P.IsStableUnderBaseChange`. -/
+lemma Over.closedUnderLimitsOfShape_walkingCospan_of_baseChangeAlong [HasPullbacks T]
+    [P.IsStableUnderComposition] [P.HasOfPostcompProperty P]
+    (hbc : ∀ {Y₁ Y₂ : Over X} (_ : P Y₁.hom) (_ : P Y₂.hom) (f : Y₁ ⟶ Y₂),
+        P.IsStableUnderBaseChangeAlong f.left) :
+    (P.overObj (X := X)).IsClosedUnderLimitsOfShape WalkingCospan :=
+  CostructuredArrow.closedUnderLimitsOfShape_walkingCospan_of_baseChangeAlong (L := 𝟭 T) P X hbc
+
+end Over
+
 end CategoryTheory

--- a/Proetale/Morphisms/ProAffineEtale.lean
+++ b/Proetale/Morphisms/ProAffineEtale.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten
 import Mathlib.AlgebraicGeometry.Limits
 import Mathlib.AlgebraicGeometry.Morphisms.WeaklyEtale
 import Proetale.Algebra.IndEtale
+import Proetale.Mathlib.CategoryTheory.Limits.MorphismProperty
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.Ind
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.IndSpreads
 import Proetale.Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
@@ -78,6 +79,17 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffineHom f] :
     rw [ofObjectProperty_top_right_iff]
     exact isAffine_of_isAffineHom f'
   infer_instance
+
+/-- `proAffineEtale.overObj S` is closed under cospan limits in `Over S`: a pullback of a
+cospan whose three legs have `proAffineEtale` structural maps again has
+`proAffineEtale` structural map. -/
+instance {S : Scheme.{u}} :
+    (proAffineEtale.overObj (X := S)).IsClosedUnderLimitsOfShape WalkingCospan :=
+  Over.closedUnderLimitsOfShape_walkingCospan_of_baseChangeAlong (P := proAffineEtale)
+    fun h₁ h₂ _ ↦ by
+      have : IsAffine _ := h₁.isAffine
+      have : IsAffine _ := h₂.isAffine
+      infer_instance
 
 /-- For any `MorphismProperty Scheme` `P` coming from a ring-hom property `Q` via
 `HasRingHomProperty`, a morphism `Spec.map f` between affine schemes lies in

--- a/Proetale/Topology/Comparison/Affine.lean
+++ b/Proetale/Topology/Comparison/Affine.lean
@@ -120,31 +120,12 @@ instance : (toProEt S).Faithful :=
   inferInstanceAs <|
     (MorphismProperty.Over.changeProp _ proAffineEtale_le_weaklyEtale le_rfl).Faithful
 
-/-- `proAffineEtale` is closed under cospan limits in `Over S`: a pullback of a
-cospan whose three legs have `proAffineEtale` structural maps again has
-`proAffineEtale` structural map. The cospan legs are maps between affine
-schemes, so `proAffineEtale` is stable under base change along them. -/
-instance : (proAffineEtale.overObj (X := S)).IsClosedUnderLimitsOfShape WalkingCospan where
-  limitsOfShape_le := by
-    rintro Y ⟨p⟩
-    haveI : ∀ j : WalkingCospan, IsAffine (p.diag.obj j).left := fun j =>
-      (p.prop_diag_obj j).isAffine
-    haveI : IsAffineHom (p.diag.map WalkingCospan.Hom.inl).left :=
-      isAffineHom_of_isAffine _
-    have h : IsPullback ((p.π.app .left).left) ((p.π.app .right).left)
-        ((p.diag.map WalkingCospan.Hom.inl).left)
-          ((p.diag.map WalkingCospan.Hom.inr).left) :=
-      IsPullback.of_isLimit_cone <|
-        Limits.isLimitOfPreserves (CategoryTheory.Over.forget S) p.isLimit
-    rw [MorphismProperty.overObj_iff,
-      show Y.hom = (p.π.app .left).left ≫ (p.diag.obj .left).hom by simp]
-    refine proAffineEtale.comp_mem _ _ ?_ (p.prop_diag_obj _)
-    refine MorphismProperty.IsStableUnderBaseChangeAlong.of_isPullback h.flip ?_
-    exact MorphismProperty.of_postcomp _ _ (p.diag.obj WalkingCospan.one).hom
-      (p.prop_diag_obj .one) (by simpa using p.prop_diag_obj .right)
-
+/-- The affine pro-étale site has pullbacks, computed as in `Over S`. -/
 instance : HasPullbacks (AffineProEt S) := by
-  apply +allowSynthFailures MorphismProperty.Comma.hasLimitsOfShape_of_closedUnderLimitsOfShape
+  -- `allowSynthFailures` is needed because the closure instance is registered on
+  -- `proAffineEtale.overObj S`, but the goal here is phrased in terms of `commaObj`.
+  apply (config := { allowSynthFailures := true })
+    MorphismProperty.Comma.hasLimitsOfShape_of_closedUnderLimitsOfShape
   · exact inferInstanceAs (HasLimitsOfShape WalkingCospan (Over S))
   · exact inferInstanceAs ((proAffineEtale.overObj (X := S)).IsClosedUnderLimitsOfShape _)
 

--- a/Proetale/Topology/Comparison/Affine.lean
+++ b/Proetale/Topology/Comparison/Affine.lean
@@ -120,8 +120,33 @@ instance : (toProEt S).Faithful :=
   inferInstanceAs <|
     (MorphismProperty.Over.changeProp _ proAffineEtale_le_weaklyEtale le_rfl).Faithful
 
-instance : HasPullbacks (AffineProEt S) :=
-  sorry
+/-- `proAffineEtale` is closed under cospan limits in `Over S`: a pullback of a
+cospan whose three legs have `proAffineEtale` structural maps again has
+`proAffineEtale` structural map. The cospan legs are maps between affine
+schemes, so `proAffineEtale` is stable under base change along them. -/
+instance : (proAffineEtale.overObj (X := S)).IsClosedUnderLimitsOfShape WalkingCospan where
+  limitsOfShape_le := by
+    rintro Y ⟨p⟩
+    haveI : ∀ j : WalkingCospan, IsAffine (p.diag.obj j).left := fun j =>
+      (p.prop_diag_obj j).isAffine
+    haveI : IsAffineHom (p.diag.map WalkingCospan.Hom.inl).left :=
+      isAffineHom_of_isAffine _
+    have h : IsPullback ((p.π.app .left).left) ((p.π.app .right).left)
+        ((p.diag.map WalkingCospan.Hom.inl).left)
+          ((p.diag.map WalkingCospan.Hom.inr).left) :=
+      IsPullback.of_isLimit_cone <|
+        Limits.isLimitOfPreserves (CategoryTheory.Over.forget S) p.isLimit
+    rw [MorphismProperty.overObj_iff,
+      show Y.hom = (p.π.app .left).left ≫ (p.diag.obj .left).hom by simp]
+    refine proAffineEtale.comp_mem _ _ ?_ (p.prop_diag_obj _)
+    refine MorphismProperty.IsStableUnderBaseChangeAlong.of_isPullback h.flip ?_
+    exact MorphismProperty.of_postcomp _ _ (p.diag.obj WalkingCospan.one).hom
+      (p.prop_diag_obj .one) (by simpa using p.prop_diag_obj .right)
+
+instance : HasPullbacks (AffineProEt S) := by
+  apply +allowSynthFailures MorphismProperty.Comma.hasLimitsOfShape_of_closedUnderLimitsOfShape
+  · exact inferInstanceAs (HasLimitsOfShape WalkingCospan (Over S))
+  · exact inferInstanceAs ((proAffineEtale.overObj (X := S)).IsClosedUnderLimitsOfShape _)
 
 /-- The affine pro-étale site embeds densely in the pro-étale site. The key ingredient
 of the proof is the commutative algebra lemma `RingHom.WeaklyEtale.exists_indEtale_comp`. -/


### PR DESCRIPTION
## Summary

Fills the `HasPullbacks (AffineProEt S)` sorry in
`Proetale/Topology/Comparison/Affine.lean`. The affine pro-étale site
`AffineProEt S` — the full subcategory of `ProEt S` whose structural maps
satisfy `proAffineEtale` — has pullbacks.

The proof factors through closure under `WalkingCospan`-limits:

* `proAffineEtale` is closed under base change along `IsAffineHom`
  morphisms (existing instance on `master`). The two legs of a cospan in
  `AffineProEt S` are maps between affine schemes, so this stability
  applies.
* This gives an
  `IsClosedUnderLimitsOfShape WalkingCospan (proAffineEtale.overObj (X := S))`
  instance, after which the Mathlib infrastructure
  `MorphismProperty.Comma.hasLimitsOfShape_of_closedUnderLimitsOfShape`
  upgrades the closure statement to `HasPullbacks` on the comma subcategory.

Net effect: removes one `sorry` from
`Proetale/Topology/Comparison/Affine.lean` (sorry count drops 9 → 8).

## Test plan

- [x] `lake env lean Proetale/Topology/Comparison/Affine.lean` produces the
      same error count as on `master` (the file has pre-existing,
      unrelated breakage further down in `isCoverDense_toProEt`; the new
      `HasPullbacks` proof and the `IsClosedUnderLimitsOfShape WalkingCospan`
      instance both elaborate cleanly).
- [x] No new `sorry` introduced; existing `HasPullbacks` `sorry` removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)