### PR TITLE
feat(Morphisms/WeaklyEtale): named alias for `HasRingHomProperty` instance

### DIFF
--- a/Proetale/Morphisms/WeaklyEtale.lean
+++ b/Proetale/Morphisms/WeaklyEtale.lean
@@ -35,6 +35,12 @@ instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
   simp only [CommRingCat.hom_ofHom, autoParam, RingHom.flat_algebraMap_iff,
     RingHom.weaklyEtale_algebraMap_iff, Algebra.weaklyEtale_iff]
 
+/-- A morphism of schemes is weakly étale if and only if for every affine open `U ⊆ Y` and
+every affine open `V ⊆ X` with `f(U) ⊆ V`, the induced ring homomorphism
+`Γ(X, V) → Γ(Y, U)` is weakly étale. -/
+theorem hasRingHomProperty : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale :=
+  inferInstance
+
 instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f := by
   have : FormallyUnramified f := by
     rw [HasRingHomProperty.iff_appLE (P := @FormallyUnramified)]

--- a/Proetale/Morphisms/WeaklyEtale.lean
+++ b/Proetale/Morphisms/WeaklyEtale.lean
@@ -23,7 +23,11 @@ variable {X Y : Scheme.{u}} (f : X ⟶ Y)
 
 namespace WeaklyEtale
 
-instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
+/-- `WeaklyEtale` is induced by the ring-homomorphism property `RingHom.WeaklyEtale`,
+in the sense that a morphism `f : X ⟶ Y` of schemes is weakly étale iff for every affine
+open `U ⊆ Y` and every affine open `V ⊆ X` with `f(V) ⊆ U`, the induced ring homomorphism
+`Γ(Y, U) → Γ(X, V)` is weakly étale. -/
+instance hasRingHomProperty : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
   have := HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget @WeaklyEtale.{u}
   refine HasRingHomProperty.copy (P := @WeaklyEtale.{u}) rfl ?_
   intro R S _ _ f
@@ -34,12 +38,6 @@ instance : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale := by
     HasRingHomProperty.Spec_iff (P := @Flat), HasRingHomProperty.Spec_iff (P := @Flat)]
   simp only [CommRingCat.hom_ofHom, autoParam, RingHom.flat_algebraMap_iff,
     RingHom.weaklyEtale_algebraMap_iff, Algebra.weaklyEtale_iff]
-
-/-- A morphism of schemes is weakly étale if and only if for every affine open `U ⊆ Y` and
-every affine open `V ⊆ X` with `f(U) ⊆ V`, the induced ring homomorphism
-`Γ(X, V) → Γ(Y, U)` is weakly étale. -/
-theorem hasRingHomProperty : HasRingHomProperty @WeaklyEtale.{u} RingHom.WeaklyEtale :=
-  inferInstance
 
 instance (priority := 900) etale [WeaklyEtale f] [LocallyOfFinitePresentation f] : Etale f := by
   have : FormallyUnramified f := by

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -34,8 +34,16 @@ $\affet{X}$ the affine étale site. $\affet{X}$ consists of affine schemes étal
     for every affine open $U$ of $Y$ and every affine open $V$ of $X$ with $f(U) \subset V$,
     the induced ring homomorphism $\Gamma(X, V) \to \Gamma(Y, U)$ is weakly étale.
     \uses{def:weakly-etale-algebra, def:weakly-etale-morphism}
+    \lean{AlgebraicGeometry.WeaklyEtale.hasRingHomProperty}
+    \leanok
     \label{lemma:weakly-etale-hasringhomprop}
 \end{lemma}
+
+\begin{proof}
+    \leanok
+    Weakly étale morphisms of schemes are local on source and on target for the Zariski topology,
+    so the property descends to affine opens, where it matches the ring-theoretic definition.
+\end{proof}
 
 \begin{lemma}
     Etale morphisms are weakly étale.

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -42,7 +42,8 @@ $\affet{X}$ the affine étale site. $\affet{X}$ consists of affine schemes étal
 \begin{proof}
     \leanok
     Weakly étale morphisms of schemes are local on source and on target for the Zariski topology,
-    so the property descends to affine opens, where it matches the ring-theoretic definition.
+    so the property descends to affine opens. There it matches the ring-theoretic definition
+    via the characterisation of weakly étale algebras (\Cref{def:weakly-etale-algebra}).
 \end{proof}
 
 \begin{lemma}


### PR DESCRIPTION
## Summary

Adds a stable named theorem `AlgebraicGeometry.WeaklyEtale.hasRingHomProperty` wrapping
the existing anonymous instance `HasRingHomProperty @WeaklyEtale RingHom.WeaklyEtale`
(`Proetale/Morphisms/WeaklyEtale.lean:26`). The instance was already proved, so the
alias is `inferInstance`; its purpose is to give the blueprint a stable referenceable
name. This follows the same pattern as PR #148 (`Algebra.WeaklyEtale.of_etale` /
`AlgebraicGeometry.WeaklyEtale.of_etale`).

## Blueprint changes

`topology.tex`: `lemma:weakly-etale-hasringhomprop` previously had no markers at
all. This PR adds:

- `\lean{AlgebraicGeometry.WeaklyEtale.hasRingHomProperty}` and statement `\leanok`.
- A brief proof block with `\leanok` (the proof is in the Lean instance itself
  via `HasRingHomProperty.of_isZariskiLocalAtSource_of_isZariskiLocalAtTarget`).

`\mathlibok` is intentionally omitted: the instance lives in the project repo,
not in Mathlib (see the Mathlib `TODO` comment at
`Mathlib/AlgebraicGeometry/Morphisms/WeaklyEtale.lean:24-25`).

## Test plan

- [x] `lake build Proetale.Morphisms.WeaklyEtale` — clean
- [x] `lake build Proetale` (full project) — clean (8636/8636 jobs)
