### PR TITLE
feat(Topology/SpectralSpace/WLocal/Pullback): fill `096C` sorries

### DIFF
--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -14,55 +14,71 @@ import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
 Stacks Project 096C
 -/
 
-open CategoryTheory TopCat
+open CategoryTheory TopCat Limits
 
 universe u
-variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
-    [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
 
 namespace ConnectedComponents
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-private lemma hw_of_isPullback {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-    (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
-  ConcreteCategory.congr_hom pb.w y
+section
 
-omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
-/-- In the pullback square defining `Y`, the map `(f, g) : Y → X × T` is injective. -/
-private lemma fg_injective_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
+variable {X Y T : Type u} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace T]
+    {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-    {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
-  have := pb.hasPullback
-  let E := homeoOfIso (pb.isoPullback ≪≫
+
+include pb
+
+/-- The pullback `Y` of `i : T → π₀(X)` along `mk : X → π₀(X)` is homeomorphic to the
+subspace `{p ∈ T × X | i p.1 = mk p.2}`. -/
+noncomputable def subtypeHomeo : Y ≃ₜ { p : T × X // i p.1 = mk p.2 } :=
+  letI : HasPullback (ofHom i) (ofHom ⟨mk, continuous_coe⟩) := pb.hasPullback
+  homeoOfIso (pb.isoPullback ≪≫
     pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-  have hE_g (y : Y) : (E y).val.1 = g y := by
-    change ((pb.isoPullback ≪≫
-      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
-    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-    rw [pullbackIsoProdSubtype_hom_apply]
-    exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
-  have hE_f (y : Y) : (E y).val.2 = f y := by
-    change ((pb.isoPullback ≪≫
-      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
-    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-    rw [pullbackIsoProdSubtype_hom_apply]
-    exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
-  refine E.injective <| Subtype.ext <| Prod.ext ?_ ?_
-  · simp only [hE_g]; exact hg
-  · simp only [hE_f]; exact hf
+
+@[simp]
+lemma subtypeHomeo_apply_fst (y : Y) : (subtypeHomeo pb y).val.1 = g y := by
+  letI : HasPullback (ofHom i) (ofHom ⟨mk, continuous_coe⟩) := pb.hasPullback
+  change ((pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  rw [pullbackIsoProdSubtype_hom_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
+
+@[simp]
+lemma subtypeHomeo_apply_snd (y : Y) : (subtypeHomeo pb y).val.2 = f y := by
+  letI : HasPullback (ofHom i) (ofHom ⟨mk, continuous_coe⟩) := pb.hasPullback
+  change ((pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
+  simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+  rw [pullbackIsoProdSubtype_hom_apply]
+  exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
+
+/-- In the pullback square defining `Y`, the map `(f, g) : Y → X × T` is injective. -/
+lemma fg_injective_of_isPullback {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) :
+    y₁ = y₂ :=
+  (subtypeHomeo pb).injective <| Subtype.ext <| Prod.ext
+    (by rw [subtypeHomeo_apply_fst, subtypeHomeo_apply_fst, hg])
+    (by rw [subtypeHomeo_apply_snd, subtypeHomeo_apply_snd, hf])
+
+end
+
+section
+
+variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
+    [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
+    {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+
+include pb
 
 @[stacks 096C "second part"]
-theorem preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
+theorem preimage_closedPoints_eq_closedPoints_of_isPullback :
     f ⁻¹' (closedPoints X) = closedPoints Y := by
-  have hw := hw_of_isPullback pb
+  have hw (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
+    ConcreteCategory.congr_hom pb.w y
   ext y
   refine ⟨fun hy ↦ ?_, fun hy ↦ ?_⟩
-  · -- `f y` closed in `X`; separate any `z ≠ y` from `y` via either the `f`-image (closedness)
-    -- or the `g`-image (T2-separation).
+  · -- `(f y, g y)` is T1: separate any `z ≠ y` via either `f`-closedness or T2 of `T`.
     rw [Set.mem_preimage, mem_closedPoints_iff] at hy
     rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
@@ -70,74 +86,53 @@ theorem preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)} {g : C
     by_cases hfzy : f z = f y
     · have hgzy : g z ≠ g y := fun h ↦ hz (fg_injective_of_isPullback pb hfzy h)
       obtain ⟨U, V, hU, _, hgzU, hgyV, hUV⟩ := t2_separation hgzy
-      refine ⟨g ⁻¹' U, fun w hw ↦ ?_, hU.preimage g.2, hgzU⟩
+      refine ⟨g ⁻¹' U, fun w hw ↦ ?_, hU.preimage g.continuous, hgzU⟩
       simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
       rintro rfl
       exact Set.disjoint_left.mp hUV hw hgyV
-    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw heq ↦ ?_, hy.isOpen_compl.preimage f.2, by simp [hfzy]⟩
+    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw heq ↦ ?_, hy.isOpen_compl.preimage f.continuous,
+        by simp [hfzy]⟩
       simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw
       exact hw (heq ▸ rfl)
-  · -- `y` closed in `Y`. The unique closed generalization of `f y` lifts back through the
-    -- pullback to a `y_c` with `y ⤳ y_c`; closedness of `y` forces `y = y_c`, so `f y = x_c`.
+  · -- The unique closed generalization `xc` of `f y` lifts back to `yc ∈ Y` with `y ⤳ yc`;
+    -- closedness of `y` forces `y = yc`, so `f y = xc`.
     rw [Set.mem_preimage, mem_closedPoints_iff]
     rw [mem_closedPoints_iff] at hy
     have : SpectralSpace Y := pb.spectralSpace
-    obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
-    have hcc : mk x_c = mk (f y) := by
+    obtain ⟨xc, hxc, hxcSpec⟩ := exists_isClosed_specializes (f y)
+    have hcc : mk xc = mk (f y) := by
       rw [coe_eq_coe']
       exact closure_minimal (Set.singleton_subset_iff.mpr mem_connectedComponent)
-        isClosed_connectedComponent hfy_xc.mem_closure
-    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
-    let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-      (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-      (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
-    have hgy_c : g y_c = g y := ConcreteCategory.congr_hom
-      (pb.lift_fst (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
-    have hfy_c : f y_c = x_c := ConcreteCategory.congr_hom
-      (pb.lift_snd (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
-        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
-        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
-    have hy_spec_yc : y ⤳ y_c := by
+        isClosed_connectedComponent hxcSpec.mem_closure
+    have hmk_eq : mk xc = i (g y) := hcc.trans (hw y).symm
+    let p₁ : TopCat.of PUnit.{u+1} ⟶ TopCat.of T :=
+      TopCat.ofHom (ContinuousMap.const _ (g y))
+    let p₂ : TopCat.of PUnit.{u+1} ⟶ TopCat.of X :=
+      TopCat.ofHom (ContinuousMap.const _ xc)
+    have hcomp : p₁ ≫ ofHom i = p₂ ≫ ofHom ⟨mk, continuous_coe⟩ := by
+      ext ⟨⟩; exact hmk_eq.symm
+    let yc := pb.lift p₁ p₂ hcomp PUnit.unit
+    have hgyc : g yc = g y :=
+      ConcreteCategory.congr_hom (pb.lift_fst p₁ p₂ hcomp) PUnit.unit
+    have hfyc : f yc = xc :=
+      ConcreteCategory.congr_hom (pb.lift_snd p₁ p₂ hcomp) PUnit.unit
+    have hyc_spec : y ⤳ yc := by
       rw [specializes_iff_mem_closure]
-      have := pb.hasPullback
-      let E := homeoOfIso (pb.isoPullback ≪≫
-        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
-      have hE_g (y' : Y) : (E y').val.1 = g y' := by
-        change ((pb.isoPullback ≪≫
-          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.1 = _
-        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-        rw [pullbackIsoProdSubtype_hom_apply]
-        exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y'
-      have hE_f (y' : Y) : (E y').val.2 = f y' := by
-        change ((pb.isoPullback ≪≫
-          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2 = _
-        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-        rw [pullbackIsoProdSubtype_hom_apply]
-        exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y'
-      have hval_spec : (E y).val ⤳ (E y_c).val := by
+      have hval_spec : (subtypeHomeo pb y).val ⤳ (subtypeHomeo pb yc).val := by
         rw [specializes_prod]
         refine ⟨?_, ?_⟩
-        · change (E y).val.1 ⤳ (E y_c).val.1
-          rw [hE_g, hE_g, hgy_c]
-        · change (E y).val.2 ⤳ (E y_c).val.2
-          rw [hE_f, hE_f, hfy_c]; exact hfy_xc
-      have hsub_spec : E y ⤳ E y_c :=
-        Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec
-      exact (E.isInducing.specializes_iff.mp hsub_spec).mem_closure
-    have heq : y = y_c := by
-      have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
+        · rw [subtypeHomeo_apply_fst, subtypeHomeo_apply_fst, hgyc]
+        · rw [subtypeHomeo_apply_snd, subtypeHomeo_apply_snd, hfyc]; exact hxcSpec
+      exact ((subtypeHomeo pb).isInducing.specializes_iff.mp
+        (Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec)).mem_closure
+    have heq : y = yc := by
+      have hmem : yc ∈ closure ({y} : Set Y) := hyc_spec.mem_closure
       rw [hy.closure_eq, Set.mem_singleton_iff] at hmem
       exact hmem.symm
-    have : f y = x_c := by rw [heq, hfy_c]
-    rw [this]; exact hx_c_closed
+    exact heq ▸ hfyc ▸ hxc
 
 @[stacks 096C "second part"]
-theorem wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    WLocalSpace Y where
+theorem wlocalSpace_of_isPullback : WLocalSpace Y where
   __ := pb.spectralSpace
   eq_of_specializes := by
     intro y c c' hc hc' hyc hyc'
@@ -149,43 +144,33 @@ theorem wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
       rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
     have hf_eq : f c = f c' :=
       WLocalSpace.eq_of_specializes (mem_closedPoints_iff.mp hfc) (mem_closedPoints_iff.mp hfc')
-        (hyc.map f.2) (hyc'.map f.2)
-    -- `T` is T2 so specializations are equalities.
-    have hg_eq : g c = g c' := (hyc.map g.2).eq.symm.trans (hyc'.map g.2).eq
+        (hyc.map f.continuous) (hyc'.map f.continuous)
+    -- `T` is T2, so specializations are equalities.
+    have hg_eq : g c = g c' :=
+      (hyc.map g.continuous).eq.symm.trans (hyc'.map g.continuous).eq
     exact fg_injective_of_isPullback pb hf_eq hg_eq
   isClosed_closedPoints := by
     rw [← preimage_closedPoints_eq_closedPoints_of_isPullback pb]
-    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
+    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.continuous
 
 @[stacks 096C "second part"]
-theorem isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
-    {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    IsWLocalMap f where
+theorem isWLocalMap_of_isPullback : IsWLocalMap f where
   toIsSpectralMap := by
     have := pb.spectralSpace
-    have := wlocalSpace_of_isPullback pb
-    -- `f` factors as homeomorphism `Y ≃ {p : T × X // ...}`, closed embedding into `T × X`,
-    -- then proper projection to `X`; hence `f` is proper, hence spectral.
-    have := pb.hasPullback
-    let E := homeoOfIso (pb.isoPullback ≪≫
-      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    -- `f` factors as the homeomorphism `Y ≃ {p : T × X | i p.1 = mk p.2}`, closed embedding
+    -- into `T × X`, then proper projection to `X`; hence `f` is proper, hence spectral.
     have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
-      isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
-    have hf_eq : ∀ y, f y = (E y).val.2 := fun y' ↦ by
-      change f y' = ((pb.isoPullback ≪≫
-        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2
-      simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
-      rw [pullbackIsoProdSubtype_hom_apply]
-      exact (ConcreteCategory.congr_hom pb.isoPullback_hom_snd y').symm
-    have hf_proper : IsProperMap f := by
-      have : f = Prod.snd ∘ Subtype.val ∘ E := funext hf_eq
-      rw [this]
-      exact (isProperMap_snd_of_compactSpace.comp hclosed.isProperMap_subtypeVal).comp
-        E.isProperMap
-    exact ⟨f.2, fun _ hs hsc ↦ hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc⟩
+      isClosed_eq (i.continuous.comp continuous_fst) (continuous_coe.comp continuous_snd)
+    have hf_eq : f = Prod.snd ∘ Subtype.val ∘ subtypeHomeo pb :=
+      funext fun y ↦ (subtypeHomeo_apply_snd pb y).symm
+    have hf_proper : IsProperMap f := hf_eq ▸
+      (isProperMap_snd_of_compactSpace.comp hclosed.isProperMap_subtypeVal).comp
+        (subtypeHomeo pb).isProperMap
+    exact hf_proper.isSpectralMap
   closedPoints_subset_preimage_closedPoints := by
     intro y hy
     rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+
+end
 
 end ConnectedComponents

--- a/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
+++ b/Proetale/Topology/SpectralSpace/WLocal/Pullback.lean
@@ -5,6 +5,7 @@ Authors: Jiedong Jiang, Christian Merten
 -/
 import Proetale.Topology.SpectralSpace.ConnectedComponent
 import Proetale.Topology.SpectralSpace.WLocal.ClosedPoints
+import Proetale.Topology.SpectralSpace.WLocal.ConnectedComponents
 import Proetale.Mathlib.Topology.Connected.TotallyDisconnected
 
 /-!
@@ -19,23 +20,172 @@ universe u
 variable {X Y T : Type u} [TopologicalSpace X] [WLocalSpace X] [TopologicalSpace Y]
     [TopologicalSpace T] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T]
 
+namespace ConnectedComponents
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+private lemma hw_of_isPullback {f : C(Y, X)} {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    (y : Y) : i (g y) = (f y : ConnectedComponents X) :=
+  ConcreteCategory.congr_hom pb.w y
+
+omit [WLocalSpace X] [CompactSpace T] [T2Space T] [TotallyDisconnectedSpace T] in
+/-- In the pullback square defining `Y`, the map `(f, g) : Y → X × T` is injective. -/
+private lemma fg_injective_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+    {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    {y₁ y₂ : Y} (hf : f y₁ = f y₂) (hg : g y₁ = g y₂) : y₁ = y₂ := by
+  have := pb.hasPullback
+  let E := homeoOfIso (pb.isoPullback ≪≫
+    pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+  have hE_g (y : Y) : (E y).val.1 = g y := by
+    change ((pb.isoPullback ≪≫
+      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.1 = _
+    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+    rw [pullbackIsoProdSubtype_hom_apply]
+    exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y
+  have hE_f (y : Y) : (E y).val.2 = f y := by
+    change ((pb.isoPullback ≪≫
+      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y).val.2 = _
+    simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+    rw [pullbackIsoProdSubtype_hom_apply]
+    exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y
+  refine E.injective <| Subtype.ext <| Prod.ext ?_ ?_
+  · simp only [hE_g]; exact hg
+  · simp only [hE_f]; exact hf
+
 @[stacks 096C "second part"]
-theorem ConnectedComponents.wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+theorem preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+    {i : C(T, ConnectedComponents X)}
+    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
+    f ⁻¹' (closedPoints X) = closedPoints Y := by
+  have hw := hw_of_isPullback pb
+  ext y
+  refine ⟨fun hy ↦ ?_, fun hy ↦ ?_⟩
+  · -- `f y` closed in `X`; separate any `z ≠ y` from `y` via either the `f`-image (closedness)
+    -- or the `g`-image (T2-separation).
+    rw [Set.mem_preimage, mem_closedPoints_iff] at hy
+    rw [mem_closedPoints_iff, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+    intro z hz
+    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+    by_cases hfzy : f z = f y
+    · have hgzy : g z ≠ g y := fun h ↦ hz (fg_injective_of_isPullback pb hfzy h)
+      obtain ⟨U, V, hU, _, hgzU, hgyV, hUV⟩ := t2_separation hgzy
+      refine ⟨g ⁻¹' U, fun w hw ↦ ?_, hU.preimage g.2, hgzU⟩
+      simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+      rintro rfl
+      exact Set.disjoint_left.mp hUV hw hgyV
+    · refine ⟨f ⁻¹' {f y}ᶜ, fun w hw heq ↦ ?_, hy.isOpen_compl.preimage f.2, by simp [hfzy]⟩
+      simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_preimage] at hw
+      exact hw (heq ▸ rfl)
+  · -- `y` closed in `Y`. The unique closed generalization of `f y` lifts back through the
+    -- pullback to a `y_c` with `y ⤳ y_c`; closedness of `y` forces `y = y_c`, so `f y = x_c`.
+    rw [Set.mem_preimage, mem_closedPoints_iff]
+    rw [mem_closedPoints_iff] at hy
+    have : SpectralSpace Y := pb.spectralSpace
+    obtain ⟨x_c, hx_c_closed, hfy_xc⟩ := exists_isClosed_specializes (f y)
+    have hcc : mk x_c = mk (f y) := by
+      rw [coe_eq_coe']
+      exact closure_minimal (Set.singleton_subset_iff.mpr mem_connectedComponent)
+        isClosed_connectedComponent hfy_xc.mem_closure
+    have hmk_eq : mk x_c = i (g y) := hcc.trans (hw y).symm
+    let y_c := pb.lift (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+      (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+      (by ext ⟨⟩; exact hmk_eq.symm) PUnit.unit
+    have hgy_c : g y_c = g y := ConcreteCategory.congr_hom
+      (pb.lift_fst (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hfy_c : f y_c = x_c := ConcreteCategory.congr_hom
+      (pb.lift_snd (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} (g y)))
+        (TopCat.ofHom (ContinuousMap.const PUnit.{u+1} x_c))
+        (by ext ⟨⟩; exact hmk_eq.symm)) PUnit.unit
+    have hy_spec_yc : y ⤳ y_c := by
+      rw [specializes_iff_mem_closure]
+      have := pb.hasPullback
+      let E := homeoOfIso (pb.isoPullback ≪≫
+        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+      have hE_g (y' : Y) : (E y').val.1 = g y' := by
+        change ((pb.isoPullback ≪≫
+          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.1 = _
+        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+        rw [pullbackIsoProdSubtype_hom_apply]
+        exact ConcreteCategory.congr_hom pb.isoPullback_hom_fst y'
+      have hE_f (y' : Y) : (E y').val.2 = f y' := by
+        change ((pb.isoPullback ≪≫
+          pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2 = _
+        simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+        rw [pullbackIsoProdSubtype_hom_apply]
+        exact ConcreteCategory.congr_hom pb.isoPullback_hom_snd y'
+      have hval_spec : (E y).val ⤳ (E y_c).val := by
+        rw [specializes_prod]
+        refine ⟨?_, ?_⟩
+        · change (E y).val.1 ⤳ (E y_c).val.1
+          rw [hE_g, hE_g, hgy_c]
+        · change (E y).val.2 ⤳ (E y_c).val.2
+          rw [hE_f, hE_f, hfy_c]; exact hfy_xc
+      have hsub_spec : E y ⤳ E y_c :=
+        Topology.IsInducing.subtypeVal.specializes_iff.mp hval_spec
+      exact (E.isInducing.specializes_iff.mp hsub_spec).mem_closure
+    have heq : y = y_c := by
+      have hmem : y_c ∈ closure ({y} : Set Y) := hy_spec_yc.mem_closure
+      rw [hy.closure_eq, Set.mem_singleton_iff] at hmem
+      exact hmem.symm
+    have : f y = x_c := by rw [heq, hfy_c]
+    rw [this]; exact hx_c_closed
+
+@[stacks 096C "second part"]
+theorem wlocalSpace_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
     {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
     WLocalSpace Y where
   __ := pb.spectralSpace
-  eq_of_specializes := sorry
-  isClosed_closedPoints := sorry
+  eq_of_specializes := by
+    intro y c c' hc hc' hyc hyc'
+    have hfc : f c ∈ closedPoints X := by
+      have : c ∈ closedPoints Y := mem_closedPoints_iff.mpr hc
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hfc' : f c' ∈ closedPoints X := by
+      have : c' ∈ closedPoints Y := mem_closedPoints_iff.mpr hc'
+      rwa [← preimage_closedPoints_eq_closedPoints_of_isPullback pb] at this
+    have hf_eq : f c = f c' :=
+      WLocalSpace.eq_of_specializes (mem_closedPoints_iff.mp hfc) (mem_closedPoints_iff.mp hfc')
+        (hyc.map f.2) (hyc'.map f.2)
+    -- `T` is T2 so specializations are equalities.
+    have hg_eq : g c = g c' := (hyc.map g.2).eq.symm.trans (hyc'.map g.2).eq
+    exact fg_injective_of_isPullback pb hf_eq hg_eq
+  isClosed_closedPoints := by
+    rw [← preimage_closedPoints_eq_closedPoints_of_isPullback pb]
+    exact (WLocalSpace.isClosed_closedPoints (X := X)).preimage f.2
 
 @[stacks 096C "second part"]
-theorem ConnectedComponents.isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
+theorem isWLocalMap_of_isPullback {f : C(Y, X)} {g : C(Y, T)}
     {i : C(T, ConnectedComponents X)}
     (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    IsWLocalMap f := sorry
+    IsWLocalMap f where
+  toIsSpectralMap := by
+    have := pb.spectralSpace
+    have := wlocalSpace_of_isPullback pb
+    -- `f` factors as homeomorphism `Y ≃ {p : T × X // ...}`, closed embedding into `T × X`,
+    -- then proper projection to `X`; hence `f` is proper, hence spectral.
+    have := pb.hasPullback
+    let E := homeoOfIso (pb.isoPullback ≪≫
+      pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩))
+    have hclosed : IsClosed {p : T × X | i p.1 = ConnectedComponents.mk p.2} :=
+      isClosed_eq (i.2.comp continuous_fst) (continuous_coe.comp continuous_snd)
+    have hf_eq : ∀ y, f y = (E y).val.2 := fun y' ↦ by
+      change f y' = ((pb.isoPullback ≪≫
+        pullbackIsoProdSubtype (ofHom i) (ofHom ⟨mk, continuous_coe⟩)).hom y').val.2
+      simp only [Iso.trans_hom, ConcreteCategory.comp_apply]
+      rw [pullbackIsoProdSubtype_hom_apply]
+      exact (ConcreteCategory.congr_hom pb.isoPullback_hom_snd y').symm
+    have hf_proper : IsProperMap f := by
+      have : f = Prod.snd ∘ Subtype.val ∘ E := funext hf_eq
+      rw [this]
+      exact (isProperMap_snd_of_compactSpace.comp hclosed.isProperMap_subtypeVal).comp
+        E.isProperMap
+    exact ⟨f.2, fun _ hs hsc ↦ hf_proper.isSpectralMap.isCompact_preimage_of_isOpen hs hsc⟩
+  closedPoints_subset_preimage_closedPoints := by
+    intro y hy
+    rwa [preimage_closedPoints_eq_closedPoints_of_isPullback pb]
 
-@[stacks 096C "second part"]
-theorem ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback {f : C(Y, X)}
-    {g : C(Y, T)} {i : C(T, ConnectedComponents X)}
-    (pb : IsPullback (ofHom g) (ofHom f) (ofHom i) (ofHom ⟨mk, continuous_coe⟩)) :
-    f ⁻¹' (closedPoints X) = closedPoints Y := sorry
+end ConnectedComponents

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1099,10 +1099,28 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 
 \begin{proof}
   \leanok
-  \uses{thm:pullback-spectral,thm:cartesian-profinite,thm:closed-points-isom-pi0}
-  We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}. Assume $X$ is w-local and let $X^c \subset X$ be its closed points. The inverse image $Y^c \subset Y$ of $X^c$ maps bijectively onto $T$, since $X^c \to \pi_0(X)$ is a bijection by \Cref{thm:closed-points-isom-pi0}. (Note that we do not yet know whether $Y^c$ is the set of closed points of $Y$.) Moreover, $Y^c$ is quasi-compact as a closed subset of the spectral space $Y$. Hence $Y^c \to \pi_0(Y) = T$ is a homeomorphism by \verb`isHomeomorph_iff_continuous_bijective` (\stacksproject{08YE}). It follows that all points of $Y^c$ are closed in $Y$: if some $y \in Y^c$ specialized to a distinct closed point $y'$ (which also falls in $Y$ since $Y$ is closed), then both would map to the same point in $T$, contradicting the bijectivity of $Y^c \to T$.
+  \uses{thm:pullback-spectral,thm:cartesian-profinite}
+  We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}. The Lean
+  formalisation transports $Y$ to the closed subspace
+  $\{p \in T \times X \mid i(p_1) = \mathrm{mk}(p_2)\}$ of $T \times X$ via the canonical
+  homeomorphism induced by the pullback. Hence the map $(g, f) : Y \to T \times X$ is injective.
+  Assume $X$ is w-local and let $X^c \subset X$ be its closed points.
 
-  Conversely, if $y \in Y$ is a closed point, then it is closed in its fibre over $T$, and its image $x \in X$ is closed in the corresponding (homeomorphic) fibre of $X \to \pi_0(X)$. Since a point in a w-local space is closed if and only if it is closed in its connected component (which is closed), we have $x \in X^c$, so $y \in Y^c$. Thus $Y^c$ is exactly the set of closed points of $Y$. Moreover, since $Y^c \cong T$, each connected component contains a unique closed point, and for each $y \in Y^c$ the set of generalizations of $y$ is precisely the fibre of $Y \to \pi_0(Y)$ (as any generalization of $y$ lies in the same connected component with $y$). The lemma follows.
+  We first show that $f^{-1}(X^c) = Y^c$, the closed points of $Y$.
+  For the forward inclusion, suppose $f(y) \in X^c$ and let $z \neq y$ in $Y$. Either
+  $f(z) \neq f(y)$, in which case $\{f(y)\}^c$ is an open neighbourhood of $z$ avoiding $y$,
+  or $f(z) = f(y)$, in which case injectivity of $(g, f)$ forces $g(z) \neq g(y)$ and $T$-Hausdorff
+  yields an open neighbourhood of $z$ avoiding $y$. For the converse, given a closed $y \in Y$,
+  pick a closed generalization $x_c \leadsto f(y)$ in $X$ (which exists since $X$ is spectral)
+  and lift it through the pullback to $y_c \in Y$ with $y \leadsto y_c$; closedness of $y$
+  forces $y = y_c$, so $f(y) = x_c$ is closed.
+
+  Finally, $Y$ is w-local: the map $(g, f)$ being injective combined with $T$ Hausdorff and
+  $X$ w-local gives that the closed points $Y^c = f^{-1}(X^c)$ form a closed subspace and any
+  point of $Y$ specializes to a unique closed point. The map $f : Y \to X$ is proper (it factors
+  through the closed embedding into $T \times X$ followed by the projection to $X$, which is
+  proper because $T$ is compact), hence spectral, hence w-local since it sends closed points to
+  closed points.
 \end{proof}
 
 \section{w-local rings}

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -1098,6 +1098,7 @@ be a cartesian diagram in the category of topological spaces with $T$ profinite.
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{thm:pullback-spectral,thm:cartesian-profinite,thm:closed-points-isom-pi0}
   We know that $Y$ is spectral and $T = \pi_0(Y)$ by \Cref{thm:cartesian-profinite}. Assume $X$ is w-local and let $X^c \subset X$ be its closed points. The inverse image $Y^c \subset Y$ of $X^c$ maps bijectively onto $T$, since $X^c \to \pi_0(X)$ is a bijection by \Cref{thm:closed-points-isom-pi0}. (Note that we do not yet know whether $Y^c$ is the set of closed points of $Y$.) Moreover, $Y^c$ is quasi-compact as a closed subset of the spectral space $Y$. Hence $Y^c \to \pi_0(Y) = T$ is a homeomorphism by \verb`isHomeomorph_iff_continuous_bijective` (\stacksproject{08YE}). It follows that all points of $Y^c$ are closed in $Y$: if some $y \in Y^c$ specialized to a distinct closed point $y'$ (which also falls in $Y$ since $Y$ is closed), then both would map to the same point in $T$, contradicting the bijectivity of $Y^c \to T$.
 


### PR DESCRIPTION
Closes the three sorries in `Proetale/Topology/SpectralSpace/WLocal/Pullback.lean` covering the second part of Stacks [096C](https://stacks.math.columbia.edu/tag/096C).

## Summary

For a profinite-cartesian square
```
Y ──→ T
│     │
↓     ↓
X ──→ π₀(X)
```
with `X` w-local and `T` profinite, the following are now sorry-free:

* `ConnectedComponents.preimage_closedPoints_eq_closedPoints_of_isPullback`: `f ⁻¹' closedPoints X = closedPoints Y`.
* `ConnectedComponents.wlocalSpace_of_isPullback`: `Y` is a w-local space.
* `ConnectedComponents.isWLocalMap_of_isPullback`: `Y → X` is a w-local map.

The proof realises `Y ≃ₜ {p : T × X // i p.1 = mk p.2}` via the categorical pullback iso and `pullbackIsoProdSubtype`, so that `f` factors as the proper projection `T × X → X` precomposed with a closed embedding, and so that `(f, g)` is injective.

## Test plan
- [x] `lake build Proetale.Topology.SpectralSpace.WLocal.Pullback` (no warnings).
- [x] `lake build --wfail` on the full project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)