### PR TITLE
feat(Topology/Flat/Sheaf): named alias for `thm:fpqc-subcanonical`

### DIFF
--- a/Proetale/Topology/Flat/Sheaf.lean
+++ b/Proetale/Topology/Flat/Sheaf.lean
@@ -25,15 +25,15 @@ variable {P : MorphismProperty Scheme.{u}}
 
 open Scheme
 
+/-- The fpqc topology on the category of schemes is subcanonical, i.e., every representable
+presheaf is a sheaf. -/
+theorem Scheme.fpqcTopology_subcanonical : fpqcTopology.Subcanonical := inferInstance
+
 variable (P : MorphismProperty Scheme.{u}) [P.IsMultiplicative] [P.IsStableUnderBaseChange]
 
 open Opposite
 
 variable {P}
-
-/-- The fpqc topology on the category of schemes is subcanonical, i.e. every representable
-presheaf is a sheaf. -/
-theorem Scheme.fpqcTopology_subcanonical : fpqcTopology.Subcanonical := inferInstance
 
 @[simp]
 lemma Scheme.Hom.generate_singleton_mem_fpqcTopology_of_locallyOfFinitePresentation

--- a/Proetale/Topology/Flat/Sheaf.lean
+++ b/Proetale/Topology/Flat/Sheaf.lean
@@ -31,6 +31,10 @@ open Opposite
 
 variable {P}
 
+/-- The fpqc topology on the category of schemes is subcanonical, i.e. every representable
+presheaf is a sheaf. -/
+theorem Scheme.fpqcTopology_subcanonical : fpqcTopology.Subcanonical := inferInstance
+
 @[simp]
 lemma Scheme.Hom.generate_singleton_mem_fpqcTopology_of_locallyOfFinitePresentation
     {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] [LocallyOfFinitePresentation f] :

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -126,6 +126,8 @@ For us, the main relevant property of the fqpc site is that it is subcanonical:
     The fpqc site is subcanonical, i.e., every representable presheaf is a sheaf.
     \uses{def:fpqc-site}
     \label{thm:fpqc-subcanonical}
+    \lean{AlgebraicGeometry.Scheme.fpqcTopology_subcanonical}
+    \leanok
     \mathlibok
 \end{theorem}
 


### PR DESCRIPTION
## Summary

Adds `AlgebraicGeometry.Scheme.fpqcTopology_subcanonical`, a theorem-shaped
alias for the anonymous instance `fpqcTopology.Subcanonical` in
`Mathlib/AlgebraicGeometry/Sites/Fpqc.lean:83`. Mirrors PR #155 which did the
same for `prop:proet-subcanonical`.

The substantive content lives in Mathlib; the project alias just exposes a
stable identifier that the blueprint can point at, immune to Mathlib's
auto-generated-name churn for anonymous instances.

## Changes

- `Proetale/Topology/Flat/Sheaf.lean`: add `Scheme.fpqcTopology_subcanonical`
  with proof `inferInstance`.
- `blueprint/src/chapters/topology.tex`: add `\lean{...}` and `\leanok` on the
  statement of `thm:fpqc-subcanonical` (L125–130). Previously only had
  `\mathlibok`.

6 lines added across 2 files (4 Lean, 2 blueprint).

## Test plan

- [x] `lake build Proetale.Topology.Flat.Sheaf`
- [x] `lake build --wfail` (8638/8638 jobs, no new warnings)
