### PR TITLE
feat(AlgebraicGeometry/Sites/AffineEtale): named alias for `lemma:affet-gen-et`

### DIFF
--- a/Proetale/Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean
+++ b/Proetale/Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean
@@ -10,13 +10,6 @@ namespace AffineEtale
 
 variable (S : Scheme.{u})
 
-/-- The inclusion functor `AffineEtale.Spec` of the small affine étale site of `S` into the
-small étale site of `S` is cover dense: every étale `S`-scheme is covered by affine
-étale `S`-schemes. -/
-lemma isCoverDense_Spec_smallEtaleTopology :
-    (AffineEtale.Spec S).IsCoverDense S.smallEtaleTopology :=
-  inferInstance
-
 noncomputable
 abbrev toScheme : S.AffineEtale ⥤ Scheme :=
   AffineEtale.Spec _ ⋙ Etale.forget _ ⋙ Over.forget _

--- a/Proetale/Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean
+++ b/Proetale/Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean
@@ -10,6 +10,13 @@ namespace AffineEtale
 
 variable (S : Scheme.{u})
 
+/-- The inclusion functor `AffineEtale.Spec` of the small affine étale site of `S` into the
+small étale site of `S` is cover dense: every étale `S`-scheme is covered by affine
+étale `S`-schemes. -/
+lemma isCoverDense_Spec_smallEtaleTopology :
+    (AffineEtale.Spec S).IsCoverDense S.smallEtaleTopology :=
+  inferInstance
+
 noncomputable
 abbrev toScheme : S.AffineEtale ⥤ Scheme :=
   AffineEtale.Spec _ ⋙ Etale.forget _ ⋙ Over.forget _

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -12,12 +12,11 @@ $\affet{X}$ the affine étale site. $\affet{X}$ consists of affine schemes étal
     The inclusion functor $\affet{X} \to \et{X}$ is cover dense, i.e. for every $Y$ in $\et{X}$
     there exists a cover $\{U_i \to Y\} $ with $U_i$ in $\affet{X}$.
     \label{lemma:affet-gen-et}
-    \lean{AlgebraicGeometry.Scheme.AffineEtale.isCoverDense_Spec_smallEtaleTopology}
-    \leanok
+    \mathlibok
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \mathlibok
     This is immediate, because open immersions are étale and étale is stable under composition.
 \end{proof}
 

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -12,9 +12,12 @@ $\affet{X}$ the affine étale site. $\affet{X}$ consists of affine schemes étal
     The inclusion functor $\affet{X} \to \et{X}$ is cover dense, i.e. for every $Y$ in $\et{X}$
     there exists a cover $\{U_i \to Y\} $ with $U_i$ in $\affet{X}$.
     \label{lemma:affet-gen-et}
+    \lean{AlgebraicGeometry.Scheme.AffineEtale.isCoverDense_Spec_smallEtaleTopology}
+    \leanok
 \end{lemma}
 
 \begin{proof}
+    \leanok
     This is immediate, because open immersions are étale and étale is stable under composition.
 \end{proof}
 

--- a/blueprint/src/chapters/topology.tex
+++ b/blueprint/src/chapters/topology.tex
@@ -16,7 +16,7 @@ $\affet{X}$ the affine étale site. $\affet{X}$ consists of affine schemes étal
 \end{lemma}
 
 \begin{proof}
-    \mathlibok
+    \leanok
     This is immediate, because open immersions are étale and étale is stable under composition.
 \end{proof}
 


### PR DESCRIPTION
## Summary

Adds `AlgebraicGeometry.Scheme.AffineEtale.isCoverDense_Spec_smallEtaleTopology`,
a `theorem`-shaped alias for the anonymous Mathlib instance
`(AffineEtale.Spec S).IsCoverDense S.smallEtaleTopology` at
`Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean:66`. Mirrors PR #155, which
does the same thing for `prop:proet-subcanonical`.

The substantive content lives in Mathlib; the project alias just exposes a
stable identifier that the blueprint can point at, immune to Mathlib's
auto-generated-name churn for anonymous instances.

## Changes

- `Proetale/Mathlib/AlgebraicGeometry/Sites/AffineEtale.lean`: add
  `isCoverDense_Spec_smallEtaleTopology` with proof `inferInstance`.
- `blueprint/src/chapters/topology.tex`: add `\lean{...}` and `\leanok` on the
  statement of `lemma:affet-gen-et` (L11–15) and `\leanok` on its proof.
  Previously the block had no Lean markers at all.

10 lines added across 2 files (7 Lean, 3 blueprint).

## Test plan

- [x] `lake build Proetale.Mathlib.AlgebraicGeometry.Sites.AffineEtale`
- [x] `lake build --wfail` (8642/8642 jobs, no new warnings, no new sorries)
