### PR TITLE
feat(Mathlib/Topology/Separation/Profinite): named alias for `lemma:profinite-disj-clopen-separation`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -111,6 +111,7 @@ import Proetale.Mathlib.Topology.Maps.Basic
 import Proetale.Mathlib.Topology.QuasiSeparated
 import Proetale.Mathlib.Topology.Separation.Basic
 import Proetale.Mathlib.Topology.Separation.Hausdorff
+import Proetale.Mathlib.Topology.Separation.Profinite
 import Proetale.Mathlib.Topology.Sober
 import Proetale.Mathlib.Topology.Spectral.Basic
 import Proetale.Mathlib.Topology.Spectral.ConstructibleTopology

--- a/Proetale/Mathlib/Topology/Separation/Profinite.lean
+++ b/Proetale/Mathlib/Topology/Separation/Profinite.lean
@@ -7,16 +7,15 @@ import Mathlib.Topology.Separation.Profinite
 
 /-!
 # Named alias: totally disconnected locally compact T2 ⇒ totally separated
+
+This file provides a `theorem`-shaped, stably-named alias for the anonymous Mathlib instance
+in `Mathlib/Topology/Separation/Profinite.lean` deriving `TotallySeparatedSpace` from
+`LocallyCompactSpace`, `T2Space`, and `TotallyDisconnectedSpace`, so that the blueprint can
+reference it by a stable identifier.
 -/
 
-universe u
-
-/-- A totally disconnected, locally compact, T2 space is totally separated; in particular,
-any two distinct points are separated by a clopen partition.
-
-This is a `theorem`-shaped, stably-named alias for the anonymous Mathlib instance
-in `Mathlib/Topology/Separation/Profinite.lean`. -/
+/-- A totally disconnected, locally compact, T2 space is totally separated. -/
 theorem TotallyDisconnectedSpace.totallySeparatedSpace
-    {X : Type u} [TopologicalSpace X] [LocallyCompactSpace X] [T2Space X]
+    {X : Type*} [TopologicalSpace X] [LocallyCompactSpace X] [T2Space X]
     [TotallyDisconnectedSpace X] :
     TotallySeparatedSpace X := inferInstance

--- a/Proetale/Mathlib/Topology/Separation/Profinite.lean
+++ b/Proetale/Mathlib/Topology/Separation/Profinite.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.Topology.Separation.Profinite
+
+/-!
+# Named alias: totally disconnected locally compact T2 ⇒ totally separated
+-/
+
+universe u
+
+/-- A totally disconnected, locally compact, T2 space is totally separated; in particular,
+any two distinct points are separated by a clopen partition.
+
+This is a `theorem`-shaped, stably-named alias for the anonymous Mathlib instance
+in `Mathlib/Topology/Separation/Profinite.lean`. -/
+theorem TotallyDisconnectedSpace.totallySeparatedSpace
+    {X : Type u} [TopologicalSpace X] [LocallyCompactSpace X] [T2Space X]
+    [TotallyDisconnectedSpace X] :
+    TotallySeparatedSpace X := inferInstance

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -913,11 +913,13 @@ Obviously, every w-purely-local morphism is w-local.
     there exist $U, V \subseteq X$ open and closed such that $X = U \coprod V$ and
     $x \in U$, $y \in V$.
     \label{lemma:profinite-disj-clopen-separation}
-    \lean{instTotallySeparatedSpaceOfTotallyDisconnectedSpace}
+    \lean{TotallyDisconnectedSpace.totallySeparatedSpace}
+    \leanok
     \mathlibok
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \mathlibok
   Write $X = \lim_{i \in I} X_i$ as a directed limit of finite discrete spaces. Let $\pi_i \colon X \to X_i$ be the
   projection maps. A base of the open sets of $X$ is given by the preimages $\pi_i^{-1}(\{z\})$ for $z \in X_i$ and $i \in I$. Every open set in this base is also closed, because its complement is a finite union of such sets.

--- a/blueprint/src/chapters/local-structure.tex
+++ b/blueprint/src/chapters/local-structure.tex
@@ -919,12 +919,11 @@ Obviously, every w-purely-local morphism is w-local.
 \end{lemma}
 
 \begin{proof}
-  \leanok
   \mathlibok
   Write $X = \lim_{i \in I} X_i$ as a directed limit of finite discrete spaces. Let $\pi_i \colon X \to X_i$ be the
   projection maps. A base of the open sets of $X$ is given by the preimages $\pi_i^{-1}(\{z\})$ for $z \in X_i$ and $i \in I$. Every open set in this base is also closed, because its complement is a finite union of such sets.
 
-  Choose an open subset in this base containing $x$ but not $y$, say $U = \pi_{i_0}^{-1}(\{z_0\})$ for some $i_0 \in I$ and $z_0 \in X_{i_0}$. Then $V = X - U$ is also open and closed, and we have $X = U \coprod V$ with $x \in U$ and $y \in V$.   
+  Choose an open subset in this base containing $x$ but not $y$, say $U = \pi_{i_0}^{-1}(\{z_0\})$ for some $i_0 \in I$ and $z_0 \in X_{i_0}$. Then $V = X - U$ is also open and closed, and we have $X = U \coprod V$ with $x \in U$ and $y \in V$.
 \end{proof}
 
 \begin{lemma}[{\cite[\href{https://stacks.math.columbia.edu/tag/0905}{Tag 0905}, (6) $\implies$ (1)]{stacks-project}}]


### PR DESCRIPTION
## Summary

Adds `TotallyDisconnectedSpace.totallySeparatedSpace`, a `theorem`-shaped named
alias for the anonymous Mathlib instance in
`Mathlib/Topology/Separation/Profinite.lean` (`LocallyCompactSpace + T2Space +
TotallyDisconnectedSpace ⇒ TotallySeparatedSpace`).

The substantive content lives in Mathlib; the project alias exposes a stable
identifier the blueprint can point at, immune to Mathlib's auto-generated-name
churn for anonymous instances.

Updates blueprint markers for `lemma:profinite-disj-clopen-separation`:
replaces the unstable `\lean{instTotallySeparatedSpaceOfTotallyDisconnectedSpace}`
with `\lean{TotallyDisconnectedSpace.totallySeparatedSpace}` and adds `\leanok`
on both the statement and the proof block.

Same alias pattern as #155 (`prop:proet-subcanonical`) and #159
(`lemma:affet-gen-et`).

## Files

- `Proetale/Mathlib/Topology/Separation/Profinite.lean` — new, 21 lines.
- `Proetale.lean` — add umbrella import.
- `blueprint/src/chapters/local-structure.tex` — update markers
  for `lemma:profinite-disj-clopen-separation`.

## Test plan

- [x] `lake build Proetale.Mathlib.Topology.Separation.Profinite` succeeds.
- [x] `lake build --wfail` succeeds (8643/8643 jobs, no warnings).
