### PR TITLE
feat(Mathlib/AlgebraicGeometry/Limits): named alias for `lemma:scheme-finitaryextensive`

### DIFF
--- a/Proetale.lean
+++ b/Proetale.lean
@@ -37,6 +37,7 @@ import Proetale.Mathlib.AlgebraicGeometry.AffineTransitionLimit
 import Proetale.Mathlib.AlgebraicGeometry.Cover.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Cover.QuasiCompact
 import Proetale.Mathlib.AlgebraicGeometry.Extensive
+import Proetale.Mathlib.AlgebraicGeometry.Limits
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.FinitePresentation
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
 import Proetale.Mathlib.AlgebraicGeometry.Morphisms.UnderlyingMap

--- a/Proetale/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Proetale/Mathlib/AlgebraicGeometry/Limits.lean
@@ -6,19 +6,14 @@ Authors: Christian Merten
 import Mathlib.AlgebraicGeometry.Limits
 
 /-!
-# Named alias: the category of schemes is finitary extensive
-
-This file provides a `theorem`-shaped, stably-named alias for the anonymous Mathlib
-instance `FinitaryExtensive Scheme` in `Mathlib/AlgebraicGeometry/Limits.lean`.
+# `FinitaryExtensive` for the category of schemes
 -/
 
 universe u
 
-open CategoryTheory
-
-namespace AlgebraicGeometry.Scheme
+namespace AlgebraicGeometry
 
 /-- The category of schemes is finitary extensive. -/
-theorem finitaryExtensive : FinitaryExtensive Scheme.{u} := inferInstance
+lemma finitaryExtensive_scheme : CategoryTheory.FinitaryExtensive Scheme.{u} := inferInstance
 
-end AlgebraicGeometry.Scheme
+end AlgebraicGeometry

--- a/Proetale/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Proetale/Mathlib/AlgebraicGeometry/Limits.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.AlgebraicGeometry.Limits
+
+/-!
+# Named alias: the category of schemes is finitary extensive
+
+This file provides a `theorem`-shaped, stably-named alias for the anonymous Mathlib
+instance `FinitaryExtensive Scheme` in `Mathlib/AlgebraicGeometry/Limits.lean`.
+-/
+
+universe u
+
+open CategoryTheory
+
+namespace AlgebraicGeometry.Scheme
+
+/-- The category of schemes is finitary extensive. -/
+theorem finitaryExtensive : FinitaryExtensive Scheme.{u} := inferInstance
+
+end AlgebraicGeometry.Scheme

--- a/blueprint/src/chapters/pro-categories.tex
+++ b/blueprint/src/chapters/pro-categories.tex
@@ -114,7 +114,7 @@ Recall the following definition:
     The category of schemes is finitary extensive.
     \mathlibok
     \label{lemma:scheme-finitaryextensive}
-    \lean{AlgebraicGeometry.Scheme.finitaryExtensive}
+    \lean{AlgebraicGeometry.finitaryExtensive_scheme}
     \leanok
 \end{lemma}
 

--- a/blueprint/src/chapters/pro-categories.tex
+++ b/blueprint/src/chapters/pro-categories.tex
@@ -114,6 +114,8 @@ Recall the following definition:
     The category of schemes is finitary extensive.
     \mathlibok
     \label{lemma:scheme-finitaryextensive}
+    \lean{AlgebraicGeometry.Scheme.finitaryExtensive}
+    \leanok
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

Adds `AlgebraicGeometry.Scheme.finitaryExtensive`, a `theorem`-shaped, stably-named
alias for the anonymous Mathlib instance `FinitaryExtensive Scheme` at
`Mathlib/AlgebraicGeometry/Limits.lean:452`. Updates blueprint markers for
`lemma:scheme-finitaryextensive` (`pro-categories.tex` L113–117) accordingly.

Same alias pattern as #155, #159, #161. The substantive content lives in Mathlib;
the project alias just exposes a stable identifier that the blueprint can point
at, immune to Mathlib's auto-generated-name churn for anonymous instances.

## Changes

- `Proetale/Mathlib/AlgebraicGeometry/Limits.lean`: new file (23 lines) defining
  `AlgebraicGeometry.Scheme.finitaryExtensive` via `inferInstance`.
- `Proetale.lean`: add the new file to the root umbrella import list.
- `blueprint/src/chapters/pro-categories.tex`: add `\lean{...}` and `\leanok` on
  the statement of `lemma:scheme-finitaryextensive`. (Previously only `\mathlibok`;
  the proof block already had `\leanok`.)

27 lines added across 3 files (24 Lean + import, 2 blueprint, 1 root umbrella).

## Test plan

- [x] `lake build Proetale.Mathlib.AlgebraicGeometry.Limits` succeeds.
- [x] `lake build --wfail` succeeds (8643/8643 jobs, no new warnings, no new sorries).
