### PR TITLE
feat(Algebra/WeaklyEtaleField): a weakly étale extension of fields is separable algebraic (Stacks 092P)

### DIFF
--- a/Proetale/Algebra/WeakDimension.lean
+++ b/Proetale/Algebra/WeakDimension.lean
@@ -239,6 +239,28 @@ lemma _root_.Module.flat_of_localization_atPrime_isField
 instance [AbsolutelyFlat R] : Module.Flat R M :=
   Module.flat_of_localization_atPrime_isField _ _ (fun _ _ ↦ isField_of_isLocalRing _)
 
+variable {R} in
+/-- In an absolutely flat ring every element `a` can be written as `a = a * a * b`,
+i.e. absolutely flat commutative rings are von Neumann regular. -/
+theorem exists_eq_mul_self_mul [AbsolutelyFlat R] (a : R) : ∃ b, a = a * a * b := by
+  have : (Ideal.span {a}).Pure := AbsolutelyFlat.flat _
+  obtain ⟨y, hy, heq⟩ := Ideal.exists_eq_mul_of_pure (Ideal.mem_span_singleton_self a)
+  obtain ⟨b, rfl⟩ := Ideal.mem_span_singleton'.mp hy
+  exact ⟨b, by linear_combination heq⟩
+
+variable {R} in
+/-- A commutative ring in which every element `a` can be written as `a = a * a * b`
+(i.e. a von Neumann regular commutative ring) is absolutely flat. This is the converse of
+`Ring.AbsolutelyFlat.exists_eq_mul_self_mul`. -/
+theorem of_forall_exists_eq_mul_self_mul (h : ∀ a : R, ∃ b, a = a * a * b) :
+    AbsolutelyFlat R := by
+  refine ⟨fun I ↦ Ideal.Pure.of_inf_eq_mul I fun J _ ↦
+    le_antisymm (fun y hy ↦ ?_) (Ideal.mul_le_inf)⟩
+  obtain ⟨hyI, hyJ⟩ := Submodule.mem_inf.mp hy
+  obtain ⟨b, hb⟩ := h y
+  have hy' : y * (b * y) = y := by linear_combination -hb
+  exact hy' ▸ Ideal.mul_mem_mul hyI (J.mul_mem_left b hyJ)
+
 theorem tfae : [AbsolutelyFlat R,
     IsReduced R ∧ ∀ P : Ideal R, P.IsPrime → P.IsMaximal,
     IsReduced R ∧ Ring.KrullDimLE 0 R,

--- a/Proetale/Algebra/WeakDimension.lean
+++ b/Proetale/Algebra/WeakDimension.lean
@@ -255,11 +255,29 @@ variable {R} in
 theorem of_forall_exists_eq_mul_self_mul (h : ∀ a : R, ∃ b, a = a * a * b) :
     AbsolutelyFlat R := by
   refine ⟨fun I ↦ Ideal.Pure.of_inf_eq_mul I fun J _ ↦
-    le_antisymm (fun y hy ↦ ?_) (Ideal.mul_le_inf)⟩
+    le_antisymm (fun y hy ↦ ?_) Ideal.mul_le_inf⟩
   obtain ⟨hyI, hyJ⟩ := Submodule.mem_inf.mp hy
   obtain ⟨b, hb⟩ := h y
   have hy' : y * (b * y) = y := by linear_combination -hb
   exact hy' ▸ Ideal.mul_mem_mul hyI (J.mul_mem_left b hyJ)
+
+/-- Von Neumann regularity descends along a ring map `f : A → B` that admits an additive,
+unital retraction `r : B → A` satisfying `r (f a * z) = a * r z`: if every element `x` of `B`
+can be written as `x = x * x * u`, then every element `a` of `A` can be written as
+`a = a * a * v`. -/
+theorem exists_eq_mul_self_mul_of_retract {A B : Type*} [CommRing A] [CommRing B]
+    (f : A →+* B) (r : B →+ A) (hr : ∀ (a : A) (z : B), r (f a * z) = a * r z) (hr1 : r 1 = 1)
+    (hB : ∀ x : B, ∃ u, x = x * x * u) (a : A) : ∃ v, a = a * a * v := by
+  have hrf : ∀ a, r (f a) = a := fun a ↦ by
+    have := hr a 1
+    rwa [mul_one, hr1, mul_one] at this
+  obtain ⟨u, hu⟩ := hB (f a)
+  refine ⟨r u, ?_⟩
+  calc a = r (f a) := (hrf a).symm
+    _ = r (f a * (f a * u)) := by rw [← mul_assoc, ← hu]
+    _ = a * r (f a * u) := hr _ _
+    _ = a * (a * r u) := by rw [hr]
+    _ = a * a * r u := (mul_assoc _ _ _).symm
 
 theorem tfae : [AbsolutelyFlat R,
     IsReduced R ∧ ∀ P : Ideal R, P.IsPrime → P.IsMaximal,

--- a/Proetale/Algebra/WeaklyEtaleField.lean
+++ b/Proetale/Algebra/WeaklyEtaleField.lean
@@ -35,13 +35,77 @@ universe u
 
 open scoped TensorProduct
 
+open IntermediateField
+
 variable {k : Type u} [Field k] {R : Type u} [CommRing R] [Algebra k R]
 
 namespace Algebra.WeaklyEtale
 
+/-- If every element `a` of `L ⊗[k] L` can be written as `a = a * a * u`, then the same holds
+in `E ⊗[k] E` for any intermediate field `E` of `L/k`. Indeed, any `E`-linear retraction
+`L → E` of the inclusion induces a retraction `L ⊗[k] L → E ⊗[k] E` which is semilinear over
+`E ⊗[k] E`. -/
+private lemma exists_eq_mul_self_mul_tensor_of_intermediateField {L : Type*} [Field L]
+    [Algebra k L] (E : IntermediateField k L)
+    (h : ∀ a : L ⊗[k] L, ∃ u, a = a * a * u) (b : E ⊗[k] E) :
+    ∃ v, b = b * b * v := by
+  obtain ⟨π, hπ⟩ := LinearMap.exists_leftInverse_of_injective (Algebra.linearMap E L)
+    (LinearMap.ker_eq_bot.mpr (algebraMap E L).injective)
+  have hπ' : ∀ c : E, π c = c := fun c ↦ by
+    simpa using LinearMap.congr_fun hπ c
+  let ι : E ⊗[k] E →ₐ[k] L ⊗[k] L := Algebra.TensorProduct.map E.val E.val
+  let r : L ⊗[k] L →ₗ[k] E ⊗[k] E :=
+    _root_.TensorProduct.map (π.restrictScalars k) (π.restrictScalars k)
+  have hπmul : ∀ (c : E) (z : L), π (c * z) = c * π z := fun c z ↦ by
+    rw [show (c : L) * z = c • z by rw [Algebra.smul_def, IntermediateField.algebraMap_apply],
+      map_smul, smul_eq_mul]
+  have hr : ∀ (c : E ⊗[k] E) (z : L ⊗[k] L), r (ι c * z) = c * r z := by
+    intro c z
+    induction c using TensorProduct.induction_on with
+    | zero => simp
+    | add c c' hc hc' => simp only [map_add, add_mul, hc, hc']
+    | tmul c₁ c₂ =>
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z z' hz hz' => simp only [map_add, mul_add, hz, hz']
+      | tmul z₁ z₂ =>
+        simp only [ι, r, Algebra.TensorProduct.map_tmul, IntermediateField.coe_val,
+          Algebra.TensorProduct.tmul_mul_tmul, _root_.TensorProduct.map_tmul,
+          LinearMap.coe_restrictScalars, hπmul]
+  have h1 : r 1 = 1 := by
+    simp only [r, Algebra.TensorProduct.one_def, _root_.TensorProduct.map_tmul,
+      LinearMap.coe_restrictScalars]
+    rw [show (1 : L) = ((1 : E) : L) by simp, hπ' 1]
+  have hrι : ∀ b : E ⊗[k] E, r (ι b) = b := fun b ↦ by
+    have := hr b 1
+    rwa [mul_one, h1, mul_one] at this
+  obtain ⟨u, hu⟩ := h (ι b)
+  refine ⟨r u, ?_⟩
+  calc b = r (ι b) := (hrι b).symm
+    _ = r (ι (b * b) * u) := by rw [map_mul ι b b, ← hu]
+    _ = b * b * r u := hr _ _
+
 /-- Any weakly étale extension of fields is algebraic separable -/
-lemma isAlgebraic {L : Type*} [Field L] [Algebra k L] [WeaklyEtale k L] : Algebra.IsSeparable k L :=
-  sorry
+lemma isAlgebraic {L : Type*} [Field L] [Algebra k L] [WeaklyEtale k L] :
+    Algebra.IsSeparable k L := by
+  have habs : Ring.AbsolutelyFlat (L ⊗[k] L) :=
+    .of_flat_lmul' L (L ⊗[k] L) (flat_lmul' L (L ⊗[k] L))
+  refine ⟨fun x ↦ ?_⟩
+  -- The von Neumann regularity of `L ⊗[k] L` descends to `k⟮x⟯ ⊗[k] k⟮x⟯`, hence `k⟮x⟯` is
+  -- weakly étale over `k`.
+  have : Ring.AbsolutelyFlat (k⟮x⟯ ⊗[k] k⟮x⟯) :=
+    .of_forall_exists_eq_mul_self_mul <|
+      exists_eq_mul_self_mul_tensor_of_intermediateField k⟮x⟯
+        fun a ↦ Ring.AbsolutelyFlat.exists_eq_mul_self_mul a
+  have : WeaklyEtale k k⟮x⟯ :=
+    ⟨inferInstance, RingHom.Flat.of_pure_ker_of_surjective
+      (fun y ↦ ⟨1 ⊗ₜ y, by simp⟩) (Ring.AbsolutelyFlat.flat _)⟩
+  -- `k⟮x⟯` is essentially of finite type and formally unramified over `k`, hence separable.
+  have : Algebra.EssFiniteType k k⟮x⟯ :=
+    IntermediateField.essFiniteType_iff.mpr (IntermediateField.fg_adjoin_of_finite (Set.toFinite _))
+  have : Algebra.IsSeparable k k⟮x⟯ := Algebra.FormallyUnramified.isSeparable k k⟮x⟯
+  exact IntermediateField.isSeparable_of_mem_isSeparable k L
+    (IntermediateField.mem_adjoin_simple_self k x)
 
 /-- Any finitely-generated subalgebra of a weakly étale algebra is étale. -/
 lemma etale_of_fg [WeaklyEtale k R] (A : Subalgebra k R) (hA : A.FG) : Etale k A :=

--- a/Proetale/Algebra/WeaklyEtaleField.lean
+++ b/Proetale/Algebra/WeaklyEtaleField.lean
@@ -41,24 +41,36 @@ variable {k : Type u} [Field k] {R : Type u} [CommRing R] [Algebra k R]
 
 namespace Algebra.WeaklyEtale
 
-/-- If every element `a` of `L ⊗[k] L` can be written as `a = a * a * u`, then the same holds
-in `E ⊗[k] E` for any intermediate field `E` of `L/k`. Indeed, any `E`-linear retraction
-`L → E` of the inclusion induces a retraction `L ⊗[k] L → E ⊗[k] E` which is semilinear over
+/-- If `K → L` is weakly étale and `L` is absolutely flat (e.g. a field), then `L ⊗[K] L`
+is absolutely flat.
+
+Special case of Stacks [092I] (weakly étale algebras over absolutely flat rings are absolutely
+flat) applied to the base change `L → L ⊗[K] L`. -/
+instance absolutelyFlat_tensor_self (K L : Type*) [CommRing K] [CommRing L] [Algebra K L]
+    [Ring.AbsolutelyFlat L] [Algebra.WeaklyEtale K L] :
+    Ring.AbsolutelyFlat (L ⊗[K] L) :=
+  Ring.AbsolutelyFlat.of_flat_lmul' L (L ⊗[K] L)
+    (Algebra.WeaklyEtale.flat_lmul' L (L ⊗[K] L))
+
+/-- For any intermediate field `E` of `L/k`, absolute flatness of `L ⊗[k] L` descends to
 `E ⊗[k] E`. -/
-private lemma exists_eq_mul_self_mul_tensor_of_intermediateField {L : Type*} [Field L]
-    [Algebra k L] (E : IntermediateField k L)
-    (h : ∀ a : L ⊗[k] L, ∃ u, a = a * a * u) (b : E ⊗[k] E) :
-    ∃ v, b = b * b * v := by
+private lemma absolutelyFlat_tensor_of_intermediateField {L : Type*} [Field L]
+    [Algebra k L] (E : IntermediateField k L) [Ring.AbsolutelyFlat (L ⊗[k] L)] :
+    Ring.AbsolutelyFlat (E ⊗[k] E) := by
+  -- An `E`-linear retraction `π : L → E` of the inclusion induces an additive, unital
+  -- retraction `r : L ⊗[k] L → E ⊗[k] E` of `ι : E ⊗[k] E → L ⊗[k] L`, along which von
+  -- Neumann regularity of `L ⊗[k] L` descends to `E ⊗[k] E`.
   obtain ⟨π, hπ⟩ := LinearMap.exists_leftInverse_of_injective (Algebra.linearMap E L)
     (LinearMap.ker_eq_bot.mpr (algebraMap E L).injective)
   have hπ' : ∀ c : E, π c = c := fun c ↦ by
     simpa using LinearMap.congr_fun hπ c
+  have hπmul : ∀ (c : E) (z : L), π (c * z) = c * π z := by
+    intro c z
+    have hcz : (c : L) * z = c • z := by rw [Algebra.smul_def, IntermediateField.algebraMap_apply]
+    rw [hcz, map_smul, smul_eq_mul]
   let ι : E ⊗[k] E →ₐ[k] L ⊗[k] L := Algebra.TensorProduct.map E.val E.val
   let r : L ⊗[k] L →ₗ[k] E ⊗[k] E :=
     _root_.TensorProduct.map (π.restrictScalars k) (π.restrictScalars k)
-  have hπmul : ∀ (c : E) (z : L), π (c * z) = c * π z := fun c z ↦ by
-    rw [show (c : L) * z = c • z by rw [Algebra.smul_def, IntermediateField.algebraMap_apply],
-      map_smul, smul_eq_mul]
   have hr : ∀ (c : E ⊗[k] E) (z : L ⊗[k] L), r (ι c * z) = c * r z := by
     intro c z
     induction c using TensorProduct.induction_on with
@@ -69,43 +81,34 @@ private lemma exists_eq_mul_self_mul_tensor_of_intermediateField {L : Type*} [Fi
       | zero => simp
       | add z z' hz hz' => simp only [map_add, mul_add, hz, hz']
       | tmul z₁ z₂ =>
-        simp only [ι, r, Algebra.TensorProduct.map_tmul, IntermediateField.coe_val,
+        simp only [ι, r, Algebra.TensorProduct.map_tmul, coe_val,
           Algebra.TensorProduct.tmul_mul_tmul, _root_.TensorProduct.map_tmul,
           LinearMap.coe_restrictScalars, hπmul]
   have h1 : r 1 = 1 := by
+    have h1L : (1 : L) = ((1 : E) : L) := by simp
     simp only [r, Algebra.TensorProduct.one_def, _root_.TensorProduct.map_tmul,
       LinearMap.coe_restrictScalars]
-    rw [show (1 : L) = ((1 : E) : L) by simp, hπ' 1]
-  have hrι : ∀ b : E ⊗[k] E, r (ι b) = b := fun b ↦ by
-    have := hr b 1
-    rwa [mul_one, h1, mul_one] at this
-  obtain ⟨u, hu⟩ := h (ι b)
-  refine ⟨r u, ?_⟩
-  calc b = r (ι b) := (hrι b).symm
-    _ = r (ι (b * b) * u) := by rw [map_mul ι b b, ← hu]
-    _ = b * b * r u := hr _ _
+    rw [h1L, hπ' 1]
+  exact .of_forall_exists_eq_mul_self_mul fun b ↦
+    Ring.AbsolutelyFlat.exists_eq_mul_self_mul_of_retract ι.toRingHom r.toAddMonoidHom hr h1
+      Ring.AbsolutelyFlat.exists_eq_mul_self_mul b
 
-/-- Any weakly étale extension of fields is algebraic separable -/
-lemma isAlgebraic {L : Type*} [Field L] [Algebra k L] [WeaklyEtale k L] :
+/-- Any weakly étale extension of fields is separable (hence algebraic). -/
+lemma isSeparable {L : Type*} [Field L] [Algebra k L] [WeaklyEtale k L] :
     Algebra.IsSeparable k L := by
-  have habs : Ring.AbsolutelyFlat (L ⊗[k] L) :=
-    .of_flat_lmul' L (L ⊗[k] L) (flat_lmul' L (L ⊗[k] L))
   refine ⟨fun x ↦ ?_⟩
-  -- The von Neumann regularity of `L ⊗[k] L` descends to `k⟮x⟯ ⊗[k] k⟮x⟯`, hence `k⟮x⟯` is
-  -- weakly étale over `k`.
-  have : Ring.AbsolutelyFlat (k⟮x⟯ ⊗[k] k⟮x⟯) :=
-    .of_forall_exists_eq_mul_self_mul <|
-      exists_eq_mul_self_mul_tensor_of_intermediateField k⟮x⟯
-        fun a ↦ Ring.AbsolutelyFlat.exists_eq_mul_self_mul a
-  have : WeaklyEtale k k⟮x⟯ :=
+  -- Absolute flatness of `L ⊗[k] L` descends to `k⟮x⟯ ⊗[k] k⟮x⟯`, hence `k⟮x⟯` is weakly étale
+  -- over `k`.
+  have hflat : Ring.AbsolutelyFlat (k⟮x⟯ ⊗[k] k⟮x⟯) :=
+    absolutelyFlat_tensor_of_intermediateField k⟮x⟯
+  have hwe : WeaklyEtale k k⟮x⟯ :=
     ⟨inferInstance, RingHom.Flat.of_pure_ker_of_surjective
       (fun y ↦ ⟨1 ⊗ₜ y, by simp⟩) (Ring.AbsolutelyFlat.flat _)⟩
   -- `k⟮x⟯` is essentially of finite type and formally unramified over `k`, hence separable.
-  have : Algebra.EssFiniteType k k⟮x⟯ :=
-    IntermediateField.essFiniteType_iff.mpr (IntermediateField.fg_adjoin_of_finite (Set.toFinite _))
-  have : Algebra.IsSeparable k k⟮x⟯ := Algebra.FormallyUnramified.isSeparable k k⟮x⟯
-  exact IntermediateField.isSeparable_of_mem_isSeparable k L
-    (IntermediateField.mem_adjoin_simple_self k x)
+  have hft : Algebra.EssFiniteType k k⟮x⟯ :=
+    IntermediateField.essFiniteType_iff.mpr (fg_adjoin_of_finite (Set.toFinite _))
+  have hsep : Algebra.IsSeparable k k⟮x⟯ := Algebra.FormallyUnramified.isSeparable k k⟮x⟯
+  exact isSeparable_of_mem_isSeparable k L (mem_adjoin_simple_self k x)
 
 /-- Any finitely-generated subalgebra of a weakly étale algebra is étale. -/
 lemma etale_of_fg [WeaklyEtale k R] (A : Subalgebra k R) (hA : A.FG) : Etale k A :=
@@ -115,17 +118,6 @@ variable (k R) in
 /-- Any weakly étale algebra over a field is ind-étale. -/
 theorem indEtale_field [WeaklyEtale k R] : IndEtale k R :=
   sorry
-
-/-- If `K → L` is weakly étale and `L` is absolutely flat (e.g. a field), then `L ⊗[K] L`
-is absolutely flat.
-
-Special case of Stacks [092I] (weakly étale algebras over absolutely flat rings are absolutely
-flat) applied to the base change `L → L ⊗[K] L`. -/
-instance absolutelyFlat_tensor_self (K L : Type u) [CommRing K] [CommRing L] [Algebra K L]
-    [Ring.AbsolutelyFlat L] [Algebra.WeaklyEtale K L] :
-    Ring.AbsolutelyFlat (L ⊗[K] L) :=
-  Ring.AbsolutelyFlat.of_flat_lmul' L (L ⊗[K] L)
-    (Algebra.WeaklyEtale.flat_lmul' L (L ⊗[K] L))
 
 variable (K L : Type u) [CommRing K] [CommRing L] [Algebra K L]
 

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -590,6 +590,7 @@ suffices for our purposes.
 \end{lemma}
 
 \begin{proof}
+    \leanok
     TBA.
 \end{proof}
 

--- a/blueprint/src/chapters/more-on-local-structure.tex
+++ b/blueprint/src/chapters/more-on-local-structure.tex
@@ -585,13 +585,28 @@ suffices for our purposes.
     \label{lem:flat-tensor-over-field-imples-algebraic}
     Let $L/K$ be an extension of fields. If $L \otimes_K L \to L$ is flat, then $L$ is an algebraic
     separable extension of $K$.
-    \lean{Algebra.WeaklyEtale.isAlgebraic}
+    \lean{Algebra.WeaklyEtale.isSeparable}
     \leanok
 \end{lemma}
 
 \begin{proof}
     \leanok
-    TBA.
+    Flatness of $L \otimes_K L \to L$ means $K \to L$ is weakly étale, and since $L$ is a field
+    (hence absolutely flat) the base change $L \to L \otimes_K L$ is again weakly étale, so
+    $L \otimes_K L$ is absolutely flat, i.e.\ von Neumann regular: every $a \in L \otimes_K L$
+    can be written as $a = a^2 u$.
+
+    It suffices to show that every $x \in L$ is separable algebraic over $K$, so we may replace
+    $L$ by the simple subextension $E := K(x)$. The inclusion $E \to L$ is split by an
+    $E$-linear retraction $\pi : L \to E$, which induces an additive, unital retraction
+    $r : L \otimes_K L \to E \otimes_K E$ of $\iota : E \otimes_K E \to L \otimes_K L$
+    satisfying $r(\iota(c) \cdot z) = c \cdot r(z)$. Along such a retraction von Neumann
+    regularity descends, so $E \otimes_K E$ is again absolutely flat, hence $K \to E$ is
+    weakly étale.
+
+    Finally $E = K(x)$ is essentially of finite type and formally unramified over $K$ (the
+    latter from weak étaleness), and an essentially-of-finite-type formally unramified extension
+    of fields is separable. Thus $x$ is separable over $K$, as required.
 \end{proof}
 
 \begin{theorem}[\stacksproject{092Q}, (2) => (3) and last part]


### PR DESCRIPTION
Close the `Algebra.WeaklyEtale.isAlgebraic` sorry, proving that a weakly étale extension of fields `K → L` is separable algebraic (blueprint `lem:flat-tensor-over-field-imples-algebraic`, [Stacks 092P](https://stacks.math.columbia.edu/tag/092P)).

The proof reduces to the simple subextensions `k⟮x⟯`: the von Neumann regularity of `L ⊗[k] L` descends to `k⟮x⟯ ⊗[k] k⟮x⟯` via an `E`-linear retraction, so `k⟮x⟯` is weakly étale, essentially of finite type and formally unramified over `k`, hence separable.

Supporting this, two von Neumann regularity lemmas are added to `Algebra/WeakDimension.lean`: `Ring.AbsolutelyFlat.exists_eq_mul_self_mul` (every element of an absolutely flat ring is `a = a * a * b`) and its converse `Ring.AbsolutelyFlat.of_forall_exists_eq_mul_self_mul`. The blueprint proof is marked `\leanok`.