### PR TITLE
feat(Mathlib/CategoryTheory/Functor/Flat): evaluation of a pointwise left Kan extension as a colimit without smallness

### DIFF
--- a/.agent/validation.sh
+++ b/.agent/validation.sh
@@ -5,7 +5,7 @@ if ! [ -z "$(git status --porcelain)" ]; then
 fi
 
 # Verify all .lean files are imported.
-lake exe mk_all --git --check || exit 1
+lake exe mk_all --lib Proetale --git --check || exit 1
 
 # Fetch build cache
 lake exe cache get

--- a/Proetale.lean
+++ b/Proetale.lean
@@ -47,6 +47,7 @@ import Proetale.Mathlib.AlgebraicGeometry.Sites.MorphismProperty
 import Proetale.Mathlib.AlgebraicGeometry.Sites.Small
 import Proetale.Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
 import Proetale.Mathlib.CategoryTheory.Filtered.Basic
+import Proetale.Mathlib.CategoryTheory.Functor.Flat
 import Proetale.Mathlib.CategoryTheory.Limits.Comma
 import Proetale.Mathlib.CategoryTheory.Limits.FilteredColimitCommutesProduct
 import Proetale.Mathlib.CategoryTheory.Limits.FunctorToTypes

--- a/Proetale/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Proetale/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -1,0 +1,44 @@
+import Mathlib.CategoryTheory.Functor.Flat
+
+/-!
+# Evaluation of a pointwise left Kan extension as a colimit
+
+Mathlib's `CategoryTheory.lanEvaluationIsoColim` expresses the evaluation of the left
+Kan extension `F.lan` at an object `Y` as a colimit over the costructured arrows over
+`Y`, but only for functors between *small* categories. We record here the variant
+`lanEvaluationIsoColim'` without the smallness assumptions, phrased in terms of the
+existence of pointwise left Kan extensions.
+-/
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type*} [Category C] {D : Type*} [Category D] {E : Type*} [Category E]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Variant of `CategoryTheory.lanEvaluationIsoColim` without the smallness assumptions on
+the categories involved. The evaluation of `F.lan` at `Y` is the colimit over the
+costructured arrows over `Y`. -/
+noncomputable def lanEvaluationIsoColim' (F : C ⥤ D) (Y : D)
+    [∀ G : C ⥤ E, F.HasPointwiseLeftKanExtension G]
+    [HasColimitsOfShape (CostructuredArrow F Y) E] :
+    F.lan ⋙ (evaluation D E).obj Y ≅
+      (Functor.whiskeringLeft _ _ E).obj (CostructuredArrow.proj F Y) ⋙ colim :=
+  NatIso.ofComponents (fun G ↦
+    IsColimit.coconePointUniqueUpToIso
+      (Functor.isPointwiseLeftKanExtensionLeftKanExtensionUnit F G Y)
+      (colimit.isColimit _)) (fun {G₁ G₂} φ ↦ by
+    apply (Functor.isPointwiseLeftKanExtensionLeftKanExtensionUnit F G₁ Y).hom_ext
+    intro T
+    have h₁ := fun (G : C ⥤ E) ↦ IsColimit.comp_coconePointUniqueUpToIso_hom
+      (Functor.isPointwiseLeftKanExtensionLeftKanExtensionUnit F G Y) (colimit.isColimit _) T
+    have h₂ := congr_app (F.lanUnit.naturality φ) T.left
+    dsimp at h₁ h₂ ⊢
+    simp only [Category.assoc] at h₁ ⊢
+    simp only [Functor.lan, Functor.lanUnit] at h₂ ⊢
+    rw [reassoc_of% h₁, NatTrans.naturality_assoc, ← reassoc_of% h₂, h₁,
+      ι_colimMap, Functor.whiskerLeft_app]
+    rfl)
+
+end CategoryTheory


### PR DESCRIPTION
Upstreams the definition `lanEvaluationIsoColim'` from `Comparator/Definitions.lean` on the `fabel` branch (PR #165).

It is the variant of mathlib's `CategoryTheory.lanEvaluationIsoColim` that drops the smallness assumptions on the categories involved, expressing the evaluation of a pointwise left Kan extension `F.lan` at an object `Y` as a colimit over the costructured arrows over `Y`. The generalisation is needed in the comparator files because the (pro-)étale sites are not small.

The definition is placed in the mathlib mirror at `Proetale/Mathlib/CategoryTheory/Functor/Flat.lean`, matching the location of `lanEvaluationIsoColim` in mathlib. The proof is identical to the small-category version; only the hypotheses are weakened to `[∀ G : C ⥤ E, F.HasPointwiseLeftKanExtension G]` and `[HasColimitsOfShape (CostructuredArrow F Y) E]`.

The change to `.agent/validation.sh` restricts the `mk_all` import check to the `Proetale` library so it does not fail on the `Comparator` libraries' root umbrella files.