### PR TITLE
ci: remove dead docgen build/deploy from Lean Action CI

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -7,10 +7,8 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-# via the gh-pages branch
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -27,31 +25,3 @@ jobs:
         uses: leanprover/lean-action@v1
         with:
           build-args: "--wfail"
-
-      - name: Build project documentation
-        id: build-docgen
-        uses: leanprover-community/docgen-action@main
-        with:
-          api-docs: false
-          # The blueprint is built and deployed separately by blueprint.yml (the
-          # Verso blueprint), so docgen-action does not build one here.
-          blueprint: false
-          # The site is deployed to the gh-pages branch below instead of
-          # docgen-action's artifact-based Pages deployment, so that the
-          # blueprint (deployed by blueprint.yml to /blueprint and
-          # /preview/<pr>/blueprint) can live on the same Pages site.
-          deploy: false
-
-      - name: Deploy website to GitHub Pages
-        if: github.event_name == 'push'
-        # `force: false` makes the deploy action rebase and retry if another
-        # workflow pushed to gh-pages concurrently.
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: docs
-          branch: gh-pages
-          force: false
-          clean-exclude: |
-            blueprint
-            preview
-          commit-message: 'deploy docs for ${{ github.sha }}'


### PR DESCRIPTION
## Problem

After #191 (remove LaTeX blueprint, keep Verso), `Lean Action CI` fails on `master`:

> The directory you're trying to deploy named `.../docs` doesn't exist.

`docgen-action` only ever creates the `docs/` folder as part of its **blueprint** step (`mkdir -p docs; cp blueprint/web docs/blueprint`). With `api-docs: false` and `blueprint: false` it produces nothing, so `DOCS_EXISTS: false` and the subsequent `JamesIves/github-pages-deploy-action` (`folder: docs`) fails.

The repo's `home_page/` was never actually deployed by this workflow (docgen's `homepage` input defaults to `docs`, which never existed here), so there is no landing page to preserve.

## Fix

The blueprint is now built and deployed independently by `blueprint.yml` (the Verso blueprint) to `/blueprint`. This workflow only needs to build and lint the Lean project, so the `Build project documentation` and `Deploy website to GitHub Pages` steps are removed, along with the now-unused `contents: write` permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)